### PR TITLE
TOOLS-681 Added ability to import int values

### DIFF
--- a/common/bsonutil/converter.go
+++ b/common/bsonutil/converter.go
@@ -40,7 +40,7 @@ func ConvertJSONValueToBSON(x interface{}) (interface{}, error) {
 		}
 		return v, nil
 
-	case string, float64:
+	case string, float64, int:
 		return v, nil // require no conversion
 
 	case json.ObjectId: // ObjectId

--- a/common/bsonutil/converter.go
+++ b/common/bsonutil/converter.go
@@ -97,7 +97,7 @@ func ConvertJSONValueToBSON(x interface{}) (interface{}, error) {
 		return bson.Undefined, nil
 
 	default:
-		return nil, fmt.Errorf("conversion of JSON type '%v' unsupported", v)
+		return nil, fmt.Errorf("conversion of JSON type '%v' unsupported %v", reflect.TypeOf(v), v)
 	}
 }
 

--- a/common/json/decode.go
+++ b/common/json/decode.go
@@ -775,6 +775,10 @@ func (d *decodeState) convertNumber(s string) (interface{}, error) {
 		}
 		return n, nil
 	}
+	parsedInt, err := strconv.Atoi(s)
+	if err == nil {
+		return parsedInt, nil
+	}
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return nil, &UnmarshalTypeError{"number " + s, reflect.TypeOf(0.0)}


### PR DESCRIPTION
For some reason in Mongo 3+ behavior of mongoimport was changed. It
stopped to allow importing of int values, all values that are imported
became float64. This commit backs previous behavior and allows to import
either int or float.