### PR TITLE
TOOLS-750: add the final count of dumped documents with mongodump

### DIFF
--- a/common/progress/progress_bar.go
+++ b/common/progress/progress_bar.go
@@ -42,6 +42,12 @@ func (c *countProgressor) Set(amount int64) {
 	c.current = amount
 }
 
+func (c *countProgressor) Get() (int64) {
+	c.Lock()
+	defer c.Unlock()
+	return c.current
+}
+
 func NewCounter(max int64) *countProgressor {
 	return &countProgressor{max, 0, &sync.Mutex{}}
 }
@@ -55,6 +61,9 @@ type Progressor interface {
 
 	// Inc increments the current progress counter by the given amount.
 	Inc(amount int64)
+
+	// Get the amount completed
+	Get() (int64)
 
 	// Set resets the progress counter to the given amount.
 	Set(amount int64)

--- a/common/progress/progress_bar.go
+++ b/common/progress/progress_bar.go
@@ -52,11 +52,7 @@ type Progressor interface {
 	// the amount completed. This method is called by progress.Bar to
 	// determine what percentage to display.
 	Progress() (int64, int64)
-}
 
-// Updateable is an interface which exposes the ability for a progressing value to be
-// incremented, or reset.
-type Updateable interface {
 	// Inc increments the current progress counter by the given amount.
 	Inc(amount int64)
 

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -48,6 +48,7 @@ type MongoDump struct {
 	authVersion     int
 	archive         *archive.Writer
 	progressManager *progress.Manager
+	count		int
 }
 
 // ValidateOptions checks for any incompatible sets of options.
@@ -417,6 +418,7 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent) error {
 
 	}
 
+	dump.count = 0
 	if dump.useStdout {
 		log.Logf(log.Always, "writing %v to stdout", intent.Namespace())
 		return dump.dumpQueryToWriter(findQuery, intent)
@@ -444,7 +446,8 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent) error {
 		return nil
 	}
 
-	log.Logf(log.Always, "done dumping %v", intent.Namespace())
+	log.Logf(log.Always, "done dumping %v (%v documents dumped)",
+		intent.Namespace(), dump.count)
 	return nil
 }
 
@@ -513,6 +516,7 @@ func (dump *MongoDump) dumpIterToWriter(
 			return fmt.Errorf("error writing to file: %v", err)
 		}
 		progressCount.Inc(1)
+		dump.count += 1
 	}
 
 	return nil


### PR DESCRIPTION
This does not resolve the issue since it doesn't explain why the first count is different than the final number of dumped documents, but at least it shows the difference and avoid user to run a `bsondump --objcheck` to know how many documents where dumped.