### PR TITLE
TOOLS-834: Return a context-specific error for invalid escape sequences.

### DIFF
--- a/common/json/regexp.go
+++ b/common/json/regexp.go
@@ -27,7 +27,7 @@ func stateInRegexpPattern(s *scanner, c int) int {
 		return scanRegexpOptions
 	}
 	if c == '\\' {
-		s.step = stateInRegexpPattern
+		s.step = stateInRegexpPatternEsc
 		return scanRegexpPattern
 	}
 	if c < 0x20 {

--- a/common/json/regexp_test.go
+++ b/common/json/regexp_test.go
@@ -228,5 +228,16 @@ func TestRegexpLiteral(t *testing.T) {
 			err := Unmarshal([]byte(data), &jsonMap)
 			So(err, ShouldNotBeNil)
 		})
+
+		Convey("cannot contain invalid escape sequences", func() {
+			var jsonMap map[string]interface{}
+
+			key := "key"
+			value := `/f\o\o/`
+			data := fmt.Sprintf(`{"%v":%v}`, key, value)
+
+			err := Unmarshal([]byte(data), &jsonMap)
+			So(err, ShouldNotBeNil)
+		})
 	})
 }


### PR DESCRIPTION
Makes it so that the error "invalid character 'o' in string escape code" is returned instead of "invalid escape character" when given the regular expression `/f\o\o/`.

https://jira.mongodb.org/browse/TOOLS-834