### PR TITLE
TOOLS-896: Add --headerline option for mongoexport

### DIFF
--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -308,9 +308,11 @@ func (exp *MongoExport) exportInternal(out io.Writer) (int64, error) {
 	log.Logf(log.Always, "connected to: %v", connURL)
 
 	// Write headers
-	err = exportOutput.WriteHeader()
-	if err != nil {
-		return 0, err
+	if exp.OutputOpts.HeaderLine {
+		err = exportOutput.WriteHeader()
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	var result bson.M

--- a/mongoexport/options.go
+++ b/mongoexport/options.go
@@ -30,6 +30,9 @@ type OutputFormatOptions struct {
 
 	// Pretty displays JSON data in a human-readable form.
 	Pretty bool `long:"pretty" description:"output JSON formatted to be human-readable"`
+	
+	// HeaderLine if set will export the documents with a field list at the first line, just for csv.
+	HeaderLine bool `long:"headerline" description:"output to a field list at the first line, just for csv"`
 }
 
 // Name returns a human-readable group name for output format options.


### PR DESCRIPTION
Add an option --headerline to control whether the csv file export with field list at the first line.