### PR TITLE
Support precise oplog replay

### DIFF
--- a/mongooplog/mongooplog.go
+++ b/mongooplog/mongooplog.go
@@ -134,7 +134,11 @@ func buildTailingCursor(oplog *mgo.Collection,
 	// shift it appropriately, to prepare it to be converted to an
 	// oplog timestamp
 	thresholdShifted := uint64(thresholdAsUnix) << 32
-
+	
+	if sourceOptions.StartTs != 0
+	{
+		thresholdShifted = sourceOptions.StartTs
+	}
 	// build the oplog query
 	oplogQuery := bson.M{
 		"ts": bson.M{
@@ -143,6 +147,6 @@ func buildTailingCursor(oplog *mgo.Collection,
 	}
 
 	// TODO: wait time
-	return oplog.Find(oplogQuery).Iter()
+	return oplog.Find(oplogQuery).Tail(sourceOptions.Timeout * time.Second)
 
 }

--- a/mongooplog/options.go
+++ b/mongooplog/options.go
@@ -15,6 +15,7 @@ type SourceOptions struct {
 	From    string              `long:"from" description:"specify the host for mongooplog to retrive operations from"`
 	OplogNS string              `long:"oplogns" description:"specify the namespace in the --from host where the oplog lives (default 'local.oplog.rs') " default:"local.oplog.rs" default-mask:"-"`
 	Seconds bson.MongoTimestamp `long:"seconds" short:"s" description:"specify a number of seconds for mongooplog to pull from the remote host" default:"86400"  default-mask:"-"`
+	StartTs int64 		    `long:"startTs" short:"ts" description:"specify a timestamp for mongooplog to pull from the remote host" default:"0"  default-mask:"-"`
 }
 
 // Name returns a human-readable group name for source options.

--- a/mongooplog/options.go
+++ b/mongooplog/options.go
@@ -16,6 +16,7 @@ type SourceOptions struct {
 	OplogNS string              `long:"oplogns" description:"specify the namespace in the --from host where the oplog lives (default 'local.oplog.rs') " default:"local.oplog.rs" default-mask:"-"`
 	Seconds bson.MongoTimestamp `long:"seconds" short:"s" description:"specify a number of seconds for mongooplog to pull from the remote host" default:"86400"  default-mask:"-"`
 	StartTs int64 		    `long:"startTs" short:"ts" description:"specify a timestamp for mongooplog to pull from the remote host" default:"0"  default-mask:"-"`
+	Timeout int64 		    `long:"timeout" short:"to" description:"specify a timeout for oplog tailling" default:"60"  default-mask:"-"`
 }
 
 // Name returns a human-readable group name for source options.


### PR DESCRIPTION
precise `ts` GTE tailling is needed for data migrating
