### PR TITLE
Tools-896: Add --noHeaderLine option for export csv

### DIFF
--- a/mongoexport/csv.go
+++ b/mongoexport/csv.go
@@ -25,23 +25,30 @@ type CSVExportOutput struct {
 	// NumExported maintains a running total of the number of documents written.
 	NumExported int64
 
+	// NoHeaderLine if set will export CSV data without a list of field names at the first line
+	NoHeaderLine bool
+
 	csvWriter *csv.Writer
 }
 
 // NewCSVExportOutput returns a CSVExportOutput configured to write output to the
 // given io.Writer, extracting the specified fields only.
-func NewCSVExportOutput(fields []string, out io.Writer) *CSVExportOutput {
+func NewCSVExportOutput(fields []string, noHeaderLine bool, out io.Writer) *CSVExportOutput {
 	return &CSVExportOutput{
 		fields,
 		0,
+		noHeaderLine,
 		csv.NewWriter(out),
 	}
 }
 
 // WriteHeader writes a comma-delimited list of fields as the output header row.
 func (csvExporter *CSVExportOutput) WriteHeader() error {
-	csvExporter.csvWriter.Write(csvExporter.Fields)
-	return csvExporter.csvWriter.Error()
+	if !csvExporter.NoHeaderLine {
+		csvExporter.csvWriter.Write(csvExporter.Fields)
+		return csvExporter.csvWriter.Error()
+	}
+	return nil
 }
 
 // WriteFooter is a no-op for CSV export formats.

--- a/mongoexport/csv_test.go
+++ b/mongoexport/csv_test.go
@@ -19,14 +19,29 @@ func TestWriteCSV(t *testing.T) {
 		out := &bytes.Buffer{}
 
 		Convey("Headers should be written correctly", func() {
-			csvExporter := NewCSVExportOutput(fields, out)
+			csvExporter := NewCSVExportOutput(fields, false, out)
 			err := csvExporter.WriteHeader()
-			So(err, ShouldBeNil)
+			csvExporter.ExportDocument(bson.D{{"_id", "12345"}})
 			csvExporter.WriteFooter()
+			csvExporter.Flush()
+			rec, err := csv.NewReader(strings.NewReader(out.String())).Read()
+			So(err, ShouldBeNil)
+			So(rec, ShouldResemble, []string{"_id", "x", " y", "z.1.a"})
+		})
+
+		Convey("Headers should not be written", func() {
+			csvExporter := NewCSVExportOutput(fields, true, out)
+			err := csvExporter.WriteHeader()
+			csvExporter.ExportDocument(bson.D{{"_id", "12345"}})
+			csvExporter.WriteFooter()
+			csvExporter.Flush()
+			rec, err := csv.NewReader(strings.NewReader(out.String())).Read()
+			So(err, ShouldBeNil)
+			So(rec, ShouldResemble, []string{"12345", "", "", ""})
 		})
 
 		Convey("Exported document with missing fields should print as blank", func() {
-			csvExporter := NewCSVExportOutput(fields, out)
+			csvExporter := NewCSVExportOutput(fields, true, out)
 			csvExporter.ExportDocument(bson.D{{"_id", "12345"}})
 			csvExporter.WriteFooter()
 			csvExporter.Flush()
@@ -36,7 +51,7 @@ func TestWriteCSV(t *testing.T) {
 		})
 
 		Convey("Exported document with index into nested objects should print correctly", func() {
-			csvExporter := NewCSVExportOutput(fields, out)
+			csvExporter := NewCSVExportOutput(fields, true, out)
 			csvExporter.ExportDocument(bson.D{{"z", []interface{}{"x", bson.D{{"a", "T"}, {"B", 1}}}}})
 			csvExporter.WriteFooter()
 			csvExporter.Flush()

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -378,7 +378,13 @@ func (exp *MongoExport) getExportOutput(out io.Writer) (ExportOutput, error) {
 				exportFields = append(exportFields, field)
 			}
 		}
-		return NewCSVExportOutput(exportFields, out), nil
+
+		var noHeaderLine bool = false
+		if exp.OutputOpts.NoHeaderLine {
+			noHeaderLine = true
+		}
+
+		return NewCSVExportOutput(exportFields, noHeaderLine, out), nil
 	}
 	return NewJSONExportOutput(exp.OutputOpts.JSONArray, exp.OutputOpts.Pretty, out), nil
 }

--- a/mongoexport/options.go
+++ b/mongoexport/options.go
@@ -30,6 +30,9 @@ type OutputFormatOptions struct {
 
 	// Pretty displays JSON data in a human-readable form.
 	Pretty bool `long:"pretty" description:"output JSON formatted to be human-readable"`
+
+	// NoHeaderLine if set will export CSV data without a list of field names at the first line.
+	NoHeaderLine bool `long:"noHeaderLine" description:"export CSV data without a list of field names at the first line"`
 }
 
 // Name returns a human-readable group name for output format options.


### PR DESCRIPTION
Add --noHeaderLine option for mongoexport. Give user an option to choose whether or not output a list of field names at the first line. 