### PR TITLE
Enable Windows Developers

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,16 @@
+@echo off
+
+REM This is not handling tags
+
+
+if exist "%cd%\vendor\pkg" rd /s /q "%cd%\vendor\pkg"
+
+call set_gopath.bat
+
+if not exist "%cd%\bin" mkdir "%cd%\bin"
+
+for %%i in (bsondump, mongostat, mongofiles, mongoexport, mongoimport, mongorestore, mongodump, mongotop, mongooplog) do (
+	echo Building %%i
+
+	go build -o "%cd%\bin\%%i.exe" "%cd%\%%i\main\%%i.go"
+)

--- a/set_gopath.bat
+++ b/set_gopath.bat
@@ -1,6 +1,6 @@
 @echo off
-set TOOLSPKG=%cd%\.gopath\src\github.com\mongodb\mongo-tools
-for %%t in (bsondump, common, mongostat, mongofiles, mongoexport, mongoimport, mongorestore, mongodump, mongotop, mongooplog) do echo d | xcopy %cd%\%%t %TOOLSPKG%\%%t /Y /E /S
-REM copy vendored libraries to GOPATH
-for /f %%v in ('dir /b /a:d "%cd%\vendor\src\*"') do echo d | xcopy %cd%\vendor\src\%%v %cd%\.gopath\src\%%v /Y /E /S
+
+if exist "%cd%\.gopath\" rd /s /q "%cd%\.gopath\"
+md "%cd%\.gopath\src\github.com\mongodb\"
+mklink /J "%cd%\.gopath\src\github.com\mongodb\mongo-tools" "%cd%" >nul 2>&1
 set GOPATH=%cd%\.gopath;%cd%\vendor

--- a/set_gopath.ps1
+++ b/set_gopath.ps1
@@ -1,0 +1,9 @@
+$goPath = "${pwd}\.gopath"
+$vendorPath = "${pwd}\vendor"
+
+# Using cmd invocation to recursively delete directories because Remove-Item -Recurse -Force 
+# has a bug causing the script to fail.
+Invoke-Expression "cmd /c rd /s /q $goPath"
+New-Item $goPath\src\github.com\mongodb -ItemType Container | Out-Null
+Invoke-Expression "cmd /c mklink /J $goPath\src\github.com\mongodb\mongo-tools ${pwd}" | Out-Null
+$env:GOPATH = "$goPath;$vendorPath"

--- a/vendor.bat
+++ b/vendor.bat
@@ -1,0 +1,31 @@
+@echo off
+
+setlocal EnableDelayedExpansion
+
+set GOPATH=%cd%\vendor
+
+for /F "eol=; tokens=1,2,3" %%i in (Godeps) do (
+	set package=%%i
+	set version=%%j
+	set dest=%%k
+	echo Getting package !package!
+
+	if not "!dest!"=="" (
+		set dest=!package!
+		set package=%%k
+	)
+
+	go get -u -d "!package!" >nul 2>&1
+	echo Setting package to version !version!
+	cd "%GOPATH%\src\!package!"
+	git checkout !version! >nul 2>&1
+
+	if not "!dest!"=="" (
+		cd "%GOPATH%"
+		if exist "%GOPATH%\src\!dest!" rd /s /q "%GOPATH%\src\!dest!"
+		xcopy "%GOPATH%\src\!package!" "%GOPATH%\src\!dest!" /Y /S /I >nul 2>&1
+		rd /s /q "%GOPATH%\src\!package!"
+	)
+)
+
+endlocal


### PR DESCRIPTION
Fixed set_gopath.bat to use symlinks just like set_gopath.sh does. This enables developers to run set_gopath.bat and not have to copy files before building. I've also included a set_gopath.ps1 for devs using a powershell prompt.  Finally, I've implemented vendor.sh and built.sh as batch files.

With these changes, I can clone the repo, run vendor.bat, run set_gopath.bat (or .ps1), run build.bat and get working versions of all the tools. In addition, when changing into each tools directory, I can run "go test" successfully.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/mongo-tools/46)
<!-- Reviewable:end -->
