### PR TITLE
TOOLS-976: Added support to exclude collections for mongorestore

### DIFF
--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -272,6 +272,13 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, filterCollection stri
 							"has .metadata.json files", db)
 					skip = true
 				}
+
+				// TOOLS-976: skip restoring the collections should be excluded 
+				if filterCollection == "" && restore.shouldSkipCollection(collection) {
+					log.Logf(log.DebugLow, "skipping restoring %v.%v, it is excluded", db, collection)
+					skip = true
+				}
+
 				if filterCollection != "" && filterCollection != collection {
 					skip = true
 				}
@@ -309,12 +316,19 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, filterCollection stri
 				log.Logf(log.Info, "found collection %v bson to restore", intent.Namespace())
 				restore.manager.Put(intent)
 			case MetadataFileType:
+				// TOOLS-976: skip restoring the collections should be excluded 
+				if filterCollection == "" && restore.shouldSkipCollection(collection) {
+					log.Logf(log.DebugLow, "skipping restoring %v.%v metadata, it is excluded", db, collection)
+					continue	
+				}
+
 				usesMetadataFiles = true
 				intent := &intents.Intent{
 					DB:           db,
 					C:            collection,
 					MetadataPath: entry.Path(),
 				}
+				
 				if restore.InputOptions.Archive != "" {
 					if restore.InputOptions.Archive == "-" {
 						intent.Location = "archive on stdin"
@@ -411,6 +425,24 @@ func (restore *MongoRestore) CreateIntentForCollection(db string, collection str
 	restore.manager.Put(intent)
 
 	return nil
+}
+
+func (restore *MongoRestore) shouldSkipCollection(colName string) bool {
+	if restore.OutputOptions != nil && len(restore.OutputOptions.ExcludedCollections) > 0 {
+		for _, excludedCollection := range restore.OutputOptions.ExcludedCollections {
+			if colName == excludedCollection {
+				return true
+			}
+		}
+	}
+	if restore.OutputOptions != nil && len(restore.OutputOptions.ExcludedCollectionPrefixes) > 0 {
+		for _, excludedCollectionPrefix := range restore.OutputOptions.ExcludedCollectionPrefixes {
+			if strings.HasPrefix(colName, excludedCollectionPrefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // helper for searching a list of FileInfo for metadata files

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -142,6 +142,13 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 	} else {
 		restore.tempRolesCol = *restore.ToolOptions.HiddenOptions.TempRolesColl
 	}
+	
+	if len(restore.OutputOptions.ExcludedCollections) > 0 && restore.ToolOptions.Namespace.Collection != "" {
+		return fmt.Errorf("--collection is not allowed when --excludeCollection is specified")
+	}
+	if len(restore.OutputOptions.ExcludedCollectionPrefixes) > 0 && restore.ToolOptions.Namespace.Collection != "" {
+		return fmt.Errorf("--collection is not allowed when --excludeCollectionsWithPrefix is specified")
+	}
 
 	if restore.OutputOptions.NumInsertionWorkers < 0 {
 		return fmt.Errorf(

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -37,6 +37,8 @@ type OutputOptions struct {
 	NumParallelCollections int    `long:"numParallelCollections" short:"j" description:"number of collections to restore in parallel (4 by default)" default:"4" default-mask:"-"`
 	NumInsertionWorkers    int    `long:"numInsertionWorkersPerCollection" description:"number of insert operations to run concurrently per collection (1 by default)" default:"1" default-mask:"-"`
 	StopOnError            bool   `long:"stopOnError" description:"stop restoring if an error is encountered on insert (off by default)"`
+	ExcludedCollections        []string `long:"excludeCollection" value-name:"<collection-name>" description:"collection to exclude from the dump (may be specified multiple times to exclude additional collections)"`
+	ExcludedCollectionPrefixes []string `long:"excludeCollectionsWithPrefix" value-name:"<collection-prefix>" description:"exclude all collections from the dump that have the given prefix (may be specified multiple times to exclude additional prefixes)"`
 }
 
 // Name returns a human-readable group name for output options.

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -37,8 +37,8 @@ type OutputOptions struct {
 	NumParallelCollections int    `long:"numParallelCollections" short:"j" description:"number of collections to restore in parallel (4 by default)" default:"4" default-mask:"-"`
 	NumInsertionWorkers    int    `long:"numInsertionWorkersPerCollection" description:"number of insert operations to run concurrently per collection (1 by default)" default:"1" default-mask:"-"`
 	StopOnError            bool   `long:"stopOnError" description:"stop restoring if an error is encountered on insert (off by default)"`
-	ExcludedCollections        []string `long:"excludeCollection" value-name:"<collection-name>" description:"collection to exclude from the dump (may be specified multiple times to exclude additional collections)"`
-	ExcludedCollectionPrefixes []string `long:"excludeCollectionsWithPrefix" value-name:"<collection-prefix>" description:"exclude all collections from the dump that have the given prefix (may be specified multiple times to exclude additional prefixes)"`
+	ExcludedCollections        []string `long:"excludeCollection" value-name:"<collection-name>" description:"collection to skip over during restore (may be specified multiple times to exclude additional collections)"`
+	ExcludedCollectionPrefixes []string `long:"excludeCollectionsWithPrefix" value-name:"<collection-prefix>" description:"collections to skip over during restore that have the given prefix (may be specified multiple times to exclude additional prefixes)"`
 }
 
 // Name returns a human-readable group name for output options.

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -135,6 +135,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 		if err != nil {
 			return fmt.Errorf("error parsing metadata from %v: %v", intent.Location, err)
 		}
+
 		if !restore.OutputOptions.NoOptionsRestore {
 			if options != nil {
 				if !collectionExists {
@@ -153,7 +154,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 			log.Log(log.Info, "skipping options restoration")
 		}
 	}
-
+	
 	var documentCount int64
 	if intent.BSONPath != "" {
 		err = intent.BSONFile.Open()
@@ -189,11 +190,13 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 	return nil
 }
 
+
 // RestoreCollectionToDB pipes the given BSON data into the database.
 // Returns the number of documents restored and any errors that occured.
 func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 	bsonSource *db.DecodedBSONSource, fileSize int64) (int64, error) {
 
+	
 	var termErr error
 	session, err := restore.SessionProvider.GetSession()
 	if err != nil {


### PR DESCRIPTION
Added support for exclude collections and exclude colletions with prefix

a sample restore could be 
```
mongorestore  --excludeCollection collectionA --excludeCollection collectionB --excludeCollectionsWithPrefix prefix_  --db dev --drop  --maintainInsertionOrder path/of/your/dump
```
Ref #41 and https://jira.mongodb.org/browse/TOOLS-976

@mpobrien could you take a look at this?

The feature is tested with 
```
go run vendor/src/github.com/3rf/mongo-lint/golint/golint.go mongo* bson* common/*
cd mongorestore 
go test -v -test.types=unit,integration
```
The test would fail because of other issues with the master branch I branched on, but the PR feature doesn't cause any failture in Unit Tests and Interagtion Tests.