### PR TITLE
TOOLS-1028 mongostat json has wrong mmapv1-specific fields

### DIFF
--- a/mongostat/stat_types.go
+++ b/mongostat/stat_types.go
@@ -461,15 +461,12 @@ func (jlf *JSONLineFormatter) FormatLines(lines []StatLine, index int, discover 
 		lineJson["host"] = line.Host
 		lineJson["vsize"] = text.FormatMegabyteAmount(int64(line.Virtual))
 		lineJson["res"] = text.FormatMegabyteAmount(int64(line.Resident))
-
+		lineJson["flushes"] = fmt.Sprintf("%v", line.Flushes)
+		lineJson["qr|qw"] = fmt.Sprintf("%v|%v", line.QueuedReaders, line.QueuedWriters)
+		lineJson["ar|aw"] = fmt.Sprintf("%v|%v", line.ActiveReaders, line.ActiveWriters)
+				
 		// add mmapv1-specific fields
 		if lineFlags&MMAPOnly > 0 {
-			lineJson["flushes"] = fmt.Sprintf("%v", line.Flushes)
-			lineJson["qr|qw"] = fmt.Sprintf("%v|%v", line.QueuedReaders,
-				line.QueuedWriters)
-			lineJson["ar|aw"] = fmt.Sprintf("%v|%v", line.ActiveReaders,
-				line.ActiveWriters)
-
 			mappedVal := ""      // empty for mongos
 			if line.Mapped > 0 { // not mongos, update accordingly
 				mappedVal = text.FormatMegabyteAmount(int64(line.Mapped))


### PR DESCRIPTION
The json formatter doesn't display these fields when the engine is WiredTiger:
* flushes
* ar|aw
* qr|qw

But these fields are present in grid formatter and [documentation](https://docs.mongodb.org/manual/reference/program/mongostat/) doesn't mention that these fields are mmapv1 specific.

This patch fixes that.