### PR TITLE
TOOLS-1120 Add option targetDb to mongorestore when use option archive

### DIFF
--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -234,6 +234,9 @@ func (restore *MongoRestore) CreateAllIntents(dir archive.DirLike, filterDB stri
 	if err != nil {
 		return fmt.Errorf("error reading root dump folder: %v", err)
 	}
+	if filterDB == "" && restore.OutputOptions != nil && restore.OutputOptions.TargetDB != "" && len(entries) > 1 {
+		return fmt.Errorf("You can use --targetDb without --db only when there is one database in archive. Please use --db option.")
+	}
 	for _, entry := range entries {
 		if entry.IsDir() {
 			if err = util.ValidateDBName(entry.Name()); err != nil {

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -126,7 +126,9 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 			return fmt.Errorf("cannot use --oplogFile with --archive specified")
 		}
 	}
-
+	if restore.InputOptions.Archive == "" && restore.OutputOptions.TargetDB != "" {
+		return fmt.Errorf("cannot use --targetDb with --archive unspecified")
+	}
 	// check if we are using a replica set and fall back to w=1 if we aren't (for <= 2.4)
 	nodeType, err := restore.SessionProvider.GetNodeType()
 	if err != nil {
@@ -150,7 +152,7 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 	} else {
 		restore.tempRolesCol = *restore.ToolOptions.HiddenOptions.TempRolesColl
 	}
-	
+
 	if len(restore.OutputOptions.ExcludedCollections) > 0 && restore.ToolOptions.Namespace.Collection != "" {
 		return fmt.Errorf("--collection is not allowed when --excludeCollection is specified")
 	}
@@ -263,7 +265,7 @@ func (restore *MongoRestore) Restore() error {
 			In: restore.archive.In,
 		}
 	}
-
+	log.Logf(log.Always, "Target database set: %v", restore.OutputOptions.TargetDB)
 	switch {
 	case restore.InputOptions.Archive != "":
 		log.Logf(log.Always,

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -41,6 +41,7 @@ type OutputOptions struct {
 	ExcludedCollections        []string `long:"excludeCollection" value-name:"<collection-name>" description:"collection to skip over during restore (may be specified multiple times to exclude additional collections)"`
 	ExcludedCollectionPrefixes []string `long:"excludeCollectionsWithPrefix" value-name:"<collection-prefix>" description:"collections to skip over during restore that have the given prefix (may be specified multiple times to exclude additional prefixes)"`
 	BypassDocumentValidation   bool     `long:"bypassDocumentValidation" description:"bypass document validation"`
+	TargetDB                   string   `long:"targetDb" value-name:"<database-name>" optional:"true" optional-value:"" description:"Set in which db it will be restored when use --archive.  --db is not needed if you have only one db in arhive file"`
 }
 
 // Name returns a human-readable group name for output options.

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -78,8 +78,11 @@ func (restore *MongoRestore) RestoreIntents() error {
 
 // RestoreIntent attempts to restore a given intent into MongoDB.
 func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
-
-	collectionExists, err := restore.CollectionExists(intent)
+	targetDb := intent.DB
+	if restore.OutputOptions.TargetDB != "" {
+		targetDb = restore.OutputOptions.TargetDB
+	}
+	collectionExists, err := restore.CollectionExistsFromDbName(targetDb, intent)
 	if err != nil {
 		return fmt.Errorf("error reading database: %v", err)
 	}
@@ -95,7 +98,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 				log.Logf(log.Always, "cannot drop system collection %v, skipping", intent.Namespace())
 			} else {
 				log.Logf(log.Info, "dropping collection %v before restoring", intent.Namespace())
-				err = restore.DropCollection(intent)
+				err = restore.DropCollectionFromDbName(targetDb, intent)
 				if err != nil {
 					return err // no context needed
 				}
@@ -147,7 +150,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 	if !collectionExists {
 		log.Logf(log.Info, "creating collection %v %s", intent.Namespace(), logMessageSuffix)
 		log.Logf(log.DebugHigh, "using collection options: %#v", options)
-		err = restore.CreateCollection(intent, options)
+		err = restore.CreateCollectionFromDbName(targetDb, intent, options)
 		if err != nil {
 			return fmt.Errorf("error creating collection %v: %v", intent.Namespace(), err)
 		}
@@ -167,8 +170,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 
 		bsonSource := db.NewDecodedBSONSource(db.NewBSONSource(intent.BSONFile))
 		defer bsonSource.Close()
-
-		documentCount, err = restore.RestoreCollectionToDB(intent.DB, intent.C, bsonSource, intent.BSONFile, intent.Size)
+		documentCount, err = restore.RestoreCollectionToDB(targetDb, intent.C, bsonSource, intent.BSONFile, intent.Size)
 		if err != nil {
 			return fmt.Errorf("error restoring from %v: %v", intent.Location, err)
 		}


### PR DESCRIPTION
When we use the option archive it could be nice to de-archive just one database inside another database which have a different name.

The actual use case is this one:
1. I have a mongo database created by a SaaS, this service give one database
2. I dump this database as an archive (Archive is used because of the necessity to dump it as a stream using stdout)
3. I want to restore my database to a new created database created from SaaS wich have a different database name than the original one
4. I'm blocked cause it's not possible with `--archive` option when restoring, it wants to create a database with the name from the original database which is not possible to use

Behavior of the option `--targetDb` in mongorestore:
- this can only be used when using `--archive` option
- This option make mongorestore to restore just one database at once
- If you have more than one database in archive and user use `--targetDb` it will fail, in this case it will ask to set also the option `--db`
- else mongorestore will take the only database set in archive and restore it in the database set in `--targetDb`

For the test, i didn't any test cause I don't see ad to add them, it seems to have no canvas to make this test. It should be in `mongorestore_test.go` but there is no relevant place for this because `--archive` option doesn't seem to be tested