### PR TITLE
Make mongodump/mongorestore code easier to use outside mongo-tools project

### DIFF
--- a/common/options/options.go
+++ b/common/options/options.go
@@ -17,8 +17,8 @@ import (
 
 // Gitspec that the tool was built with. Needs to be set using -ldflags
 var (
-	VersionStr = "r3.3.11-215-g38ea273"
-	Gitspec    = "38ea2738920a79811ddd08786173e1e23b519636"
+	VersionStr = "built-without-version-string"
+	Gitspec    = "built-without-git-spec"
 )
 
 // Struct encompassing all of the options that are reused across tools: "help",

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -17,8 +17,8 @@ import (
 
 // Gitspec that the tool was built with. Needs to be set using -ldflags
 var (
-	VersionStr = "built-without-version-string"
-	Gitspec    = "built-without-git-spec"
+	VersionStr = "r3.3.11-215-g38ea273"
+	Gitspec    = "38ea2738920a79811ddd08786173e1e23b519636"
 )
 
 // Struct encompassing all of the options that are reused across tools: "help",

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -52,7 +52,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	// that list as the "indexes" field of the metadata document.
 	log.Logvf(log.DebugHigh, "\treading indexes for `%v`", intent.Namespace())
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -36,10 +36,13 @@ type MongoDump struct {
 	InputOptions  *InputOptions
 	OutputOptions *OutputOptions
 
+	// Skip dumping users and roles, regardless of namespace, when true.
+	SkipUsersAndRoles bool
+
 	ProgressManager progress.Manager
 
 	// useful internals that we don't directly expose as options
-	sessionProvider *db.SessionProvider
+	SessionProvider *db.SessionProvider
 	manager         *intents.Manager
 	query           bson.M
 	oplogCollection string
@@ -51,8 +54,9 @@ type MongoDump struct {
 	// as well as the signal handler, and allows them to notify
 	// the intent dumpers that they should shutdown
 	shutdownIntentsNotifier *notifier
-	// the value of stdout gets initizlied to os.Stdout if it's unset
-	stdout       io.Writer
+	// Writer to take care of BSON output when not writing to the local filesystem.
+	// This is initialized to os.Stdout if unset.
+	OutputWriter io.Writer
 	readPrefMode mgo.Mode
 	readPrefTags []bson.D
 }
@@ -115,17 +119,17 @@ func (dump *MongoDump) Init() error {
 	if err != nil {
 		return fmt.Errorf("bad option: %v", err)
 	}
-	if dump.stdout == nil {
-		dump.stdout = os.Stdout
+	if dump.OutputWriter == nil {
+		dump.OutputWriter = os.Stdout
 	}
-	dump.sessionProvider, err = db.NewSessionProvider(*dump.ToolOptions)
+	dump.SessionProvider, err = db.NewSessionProvider(*dump.ToolOptions)
 	if err != nil {
 		return fmt.Errorf("can't create session: %v", err)
 	}
 
 	// temporarily allow secondary reads for the isMongos check
-	dump.sessionProvider.SetReadPreference(mgo.Nearest)
-	dump.isMongos, err = dump.sessionProvider.IsMongos()
+	dump.SessionProvider.SetReadPreference(mgo.Nearest)
+	dump.isMongos, err = dump.SessionProvider.IsMongos()
 	if err != nil {
 		return err
 	}
@@ -148,7 +152,7 @@ func (dump *MongoDump) Init() error {
 			return fmt.Errorf("error parsing --readPreference : %v", err)
 		}
 		if len(tags) > 0 {
-			dump.sessionProvider.SetTags(tags)
+			dump.SessionProvider.SetTags(tags)
 		}
 	}
 
@@ -157,9 +161,9 @@ func (dump *MongoDump) Init() error {
 		log.Logvf(log.Always, db.WarningNonPrimaryMongosConnection)
 	}
 
-	dump.sessionProvider.SetReadPreference(mode)
-	dump.sessionProvider.SetTags(tags)
-	dump.sessionProvider.SetFlags(db.DisableSocketTimeout)
+	dump.SessionProvider.SetReadPreference(mode)
+	dump.SessionProvider.SetTags(tags)
+	dump.SessionProvider.SetFlags(db.DisableSocketTimeout)
 
 	// return a helpful error message for mongos --repair
 	if dump.OutputOptions.Repair && dump.isMongos {
@@ -172,7 +176,7 @@ func (dump *MongoDump) Init() error {
 
 // Dump handles some final options checking and executes MongoDump.
 func (dump *MongoDump) Dump() (err error) {
-	defer dump.sessionProvider.Close()
+	defer dump.SessionProvider.Close()
 
 	dump.shutdownIntentsNotifier = newNotifier()
 
@@ -199,11 +203,11 @@ func (dump *MongoDump) Dump() (err error) {
 		dump.query = bson.M(asMap)
 	}
 
-	if dump.OutputOptions.DumpDBUsersAndRoles {
+	if !dump.SkipUsersAndRoles && dump.OutputOptions.DumpDBUsersAndRoles {
 		// first make sure this is possible with the connected database
-		dump.authVersion, err = auth.GetAuthVersion(dump.sessionProvider)
+		dump.authVersion, err = auth.GetAuthVersion(dump.SessionProvider)
 		if err == nil {
-			err = auth.VerifySystemAuthVersion(dump.sessionProvider)
+			err = auth.VerifySystemAuthVersion(dump.SessionProvider)
 		}
 		if err != nil {
 			return fmt.Errorf("error getting auth schema version for dumpDbUsersAndRoles: %v", err)
@@ -267,7 +271,7 @@ func (dump *MongoDump) Dump() (err error) {
 		}
 	}
 
-	if dump.OutputOptions.DumpDBUsersAndRoles && dump.ToolOptions.DB != "admin" {
+	if !dump.SkipUsersAndRoles && dump.OutputOptions.DumpDBUsersAndRoles && dump.ToolOptions.DB != "admin" {
 		err = dump.CreateUsersRolesVersionIntentsForDB(dump.ToolOptions.DB)
 		if err != nil {
 			return err
@@ -282,7 +286,7 @@ func (dump *MongoDump) Dump() (err error) {
 		}
 		exampleIntent := dump.manager.Peek()
 		if exampleIntent != nil {
-			supported, err := dump.sessionProvider.SupportsRepairCursor(
+			supported, err := dump.SessionProvider.SupportsRepairCursor(
 				exampleIntent.DB, exampleIntent.C)
 			if !supported {
 				return err // no extra context needed
@@ -302,7 +306,7 @@ func (dump *MongoDump) Dump() (err error) {
 	}
 
 	if dump.OutputOptions.Archive != "" {
-		session, err := dump.sessionProvider.GetSession()
+		session, err := dump.SessionProvider.GetSession()
 		if err != nil {
 			return err
 		}
@@ -330,20 +334,22 @@ func (dump *MongoDump) Dump() (err error) {
 		return fmt.Errorf("error dumping system indexes: %v", err)
 	}
 
-	if dump.ToolOptions.DB == "admin" || dump.ToolOptions.DB == "" {
-		err = dump.DumpUsersAndRoles()
-		if err != nil {
-			return fmt.Errorf("error dumping users and roles: %v", err)
-		}
-	}
-	if dump.OutputOptions.DumpDBUsersAndRoles {
-		log.Logvf(log.Always, "dumping users and roles for %v", dump.ToolOptions.DB)
-		if dump.ToolOptions.DB == "admin" {
-			log.Logvf(log.Always, "skipping users/roles dump, already dumped admin database")
-		} else {
-			err = dump.DumpUsersAndRolesForDB(dump.ToolOptions.DB)
+	if !dump.SkipUsersAndRoles {
+		if dump.ToolOptions.DB == "admin" || dump.ToolOptions.DB == "" {
+			err = dump.DumpUsersAndRoles()
 			if err != nil {
-				return fmt.Errorf("error dumping users and roles for db: %v", err)
+				return fmt.Errorf("error dumping users and roles: %v", err)
+			}
+		}
+		if dump.OutputOptions.DumpDBUsersAndRoles {
+			log.Logvf(log.Always, "dumping users and roles for %v", dump.ToolOptions.DB)
+			if dump.ToolOptions.DB == "admin" {
+				log.Logvf(log.Always, "skipping users/roles dump, already dumped admin database")
+			} else {
+				err = dump.DumpUsersAndRolesForDB(dump.ToolOptions.DB)
+				if err != nil {
+					return fmt.Errorf("error dumping users and roles for db: %v", err)
+				}
 			}
 		}
 	}
@@ -504,7 +510,7 @@ func (dump *MongoDump) DumpIntents() error {
 
 // DumpIntent dumps the specified database's collection.
 func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutputBuffer) error {
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}
@@ -686,7 +692,7 @@ func (dump *MongoDump) dumpIterToWriter(
 // DumpUsersAndRolesForDB queries and dumps the users and roles tied to the given
 // database. Only works with an authentication schema version >= 3.
 func (dump *MongoDump) DumpUsersAndRolesForDB(db string) error {
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	buffer := dump.getResettableOutputBuffer()
 	if err != nil {
 		return err
@@ -782,7 +788,7 @@ func (*nopCloseWriter) Close() error {
 
 func (dump *MongoDump) getArchiveOut() (out io.WriteCloser, err error) {
 	if dump.OutputOptions.Archive == "-" {
-		out = &nopCloseWriter{dump.stdout}
+		out = &nopCloseWriter{dump.OutputWriter}
 	} else {
 		targetStat, err := os.Stat(dump.OutputOptions.Archive)
 		if err == nil && targetStat.IsDir() {

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -348,7 +348,7 @@ func (dump *MongoDump) Dump() (err error) {
 			} else {
 				err = dump.DumpUsersAndRolesForDB(dump.ToolOptions.DB)
 				if err != nil {
-					return fmt.Errorf("error dumping users and roles for db: %v", err)
+					return fmt.Errorf("error dumping users and roles: %v", err)
 				}
 			}
 		}

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -3,6 +3,13 @@ package mongodump
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/json"
@@ -13,12 +20,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
 )
 
 var (
@@ -434,7 +435,7 @@ func TestMongoDumpBSON(t *testing.T) {
 				Convey("it dumps to standard output", func() {
 					md.OutputOptions.Out = "-"
 					stdoutBuf := &bytes.Buffer{}
-					md.stdout = stdoutBuf
+					md.OutputWriter = stdoutBuf
 					err = md.Dump()
 					So(err, ShouldBeNil)
 					var count int

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -2,6 +2,7 @@ package mongodump
 
 import (
 	"fmt"
+
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
@@ -12,7 +13,7 @@ import (
 // the name of the oplog collection in the connected db
 func (dump *MongoDump) determineOplogCollectionName() error {
 	masterDoc := bson.M{}
-	err := dump.sessionProvider.Run("isMaster", &masterDoc, "admin")
+	err := dump.SessionProvider.Run("isMaster", &masterDoc, "admin")
 	if err != nil {
 		return fmt.Errorf("error running command: %v", err)
 	}
@@ -38,7 +39,7 @@ func (dump *MongoDump) determineOplogCollectionName() error {
 func (dump *MongoDump) getOplogStartTime() (bson.MongoTimestamp, error) {
 	mostRecentOplogEntry := db.Oplog{}
 
-	err := dump.sessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"-$natural"}, &mostRecentOplogEntry, 0)
+	err := dump.SessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"-$natural"}, &mostRecentOplogEntry, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -51,7 +52,7 @@ func (dump *MongoDump) getOplogStartTime() (bson.MongoTimestamp, error) {
 // captured at the start of the dump.
 func (dump *MongoDump) checkOplogTimestampExists(ts bson.MongoTimestamp) (bool, error) {
 	oldestOplogEntry := db.Oplog{}
-	err := dump.sessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"+$natural"}, &oldestOplogEntry, 0)
+	err := dump.SessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"+$natural"}, &oldestOplogEntry, 0)
 	if err != nil {
 		return false, fmt.Errorf("unable to read entry from oplog: %v", err)
 	}
@@ -68,7 +69,7 @@ func (dump *MongoDump) checkOplogTimestampExists(ts bson.MongoTimestamp) (bool, 
 // DumpOplogAfterTimestamp takes a timestamp and writer and dumps all oplog entries after
 // the given timestamp to the writer. Returns any errors that occur.
 func (dump *MongoDump) DumpOplogAfterTimestamp(ts bson.MongoTimestamp) error {
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -3,16 +3,17 @@ package mongodump
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/mongodb/mongo-tools/common/archive"
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/intents"
 	"github.com/mongodb/mongo-tools/common/log"
 	"gopkg.in/mgo.v2/bson"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type NilPos struct{}
@@ -186,7 +187,7 @@ func (dump *MongoDump) NewIntent(dbName, colName string) (*intents.Intent, error
 		C:  colName,
 	}
 	if dump.OutputOptions.Out == "-" {
-		intent.BSONFile = &stdoutFile{Writer: dump.stdout}
+		intent.BSONFile = &stdoutFile{Writer: dump.OutputWriter}
 	} else {
 		if dump.OutputOptions.Archive != "" {
 			intent.BSONFile = &archive.MuxIn{Intent: intent, Mux: dump.archive.Mux}
@@ -213,7 +214,7 @@ func (dump *MongoDump) NewIntent(dbName, colName string) (*intents.Intent, error
 	}
 
 	// get a document count for scheduling purposes
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +296,7 @@ func (dump *MongoDump) CreateCollectionIntent(dbName, colName string) error {
 		return err
 	}
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}
@@ -360,7 +361,7 @@ func (dump *MongoDump) createIntentFromOptions(dbName string, ci *collectionInfo
 func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 	// we must ensure folders for empty databases are still created, for legacy purposes
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}
@@ -403,7 +404,7 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 // CreateAllIntents iterates through all dbs and collections and builds
 // dump intents for each collection.
 func (dump *MongoDump) CreateAllIntents() error {
-	dbs, err := dump.sessionProvider.DatabaseNames()
+	dbs, err := dump.SessionProvider.DatabaseNames()
 	if err != nil {
 		return fmt.Errorf("error getting database names: %v", err)
 	}

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -467,7 +467,7 @@ func (restore *MongoRestore) CreateStdinIntentForCollection(db string, collectio
 		C:        collection,
 		Location: "-",
 	}
-	intent.BSONFile = &stdinFile{Reader: restore.stdin}
+	intent.BSONFile = &stdinFile{Reader: restore.InputReader}
 	restore.manager.Put(intent)
 	return nil
 }

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -499,6 +499,9 @@ func (restore *MongoRestore) ValidateAuthVersions() error {
 // ShouldRestoreUsersAndRoles returns true if mongorestore should go through
 // through the process of restoring collections pertaining to authentication.
 func (restore *MongoRestore) ShouldRestoreUsersAndRoles() bool {
+	if restore.SkipUsersAndRoles {
+		return false
+	}
 	// If the user has done anything that would indicate the restoration
 	// of users and roles (i.e. used --restoreDbUsersAndRoles, -d admin, or
 	// is doing a full restore), then we check if users or roles BSON files

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -76,7 +76,7 @@ func TestMongorestore(t *testing.T) {
 			restore.NSOptions.Collection = "c1"
 			restore.NSOptions.DB = "db1"
 			So(err, ShouldBeNil)
-			restore.stdin = bsonFile
+			restore.InputReader = bsonFile
 			restore.TargetDirectory = "-"
 			err = restore.Restore()
 			So(err, ShouldBeNil)


### PR DESCRIPTION
Export some additional fields from mongodump and mongorestore to make these tools more usable outside mongo-tools.

Add the `SkipUsersAndRoles` flag to both of these tools to allow skipping dumping/restoring users and roles, regardless of namespace.

This pull request incorporates suggestions made on a previous pull request here: https://github.com/llvtt/mongo-tools/pull/1

This patch on evergreen: https://evergreen.mongodb.com/version/5820d5d23ff1226bbd0004bf

Pinging the same people on the last review, plus @acmorrow: @gabrielrussell @deafgoat @craiggwilson @behackett @shaneharvey