### PR TITLE
[TOOLS-1576] Move defer statements to after err checks.

### DIFF
--- a/mongoexport/main/mongoexport.go
+++ b/mongoexport/main/mongoexport.go
@@ -62,6 +62,10 @@ func main() {
 	opts.ReplicaSetName = setName
 
 	provider, err := db.NewSessionProvider(*opts)
+	if err != nil {
+		log.Logvf(log.Always, "%v", err)
+		os.Exit(util.ExitError)
+	}
 	defer provider.Close()
 
 	// temporarily allow secondary reads for the isMongos check

--- a/mongofiles/main/mongofiles.go
+++ b/mongofiles/main/mongofiles.go
@@ -50,11 +50,11 @@ func main() {
 
 	// create a session provider to connect to the db
 	provider, err := db.NewSessionProvider(*opts)
-	defer provider.Close()
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to host: %v", err)
 		os.Exit(util.ExitError)
 	}
+	defer provider.Close()
 	mf := mongofiles.MongoFiles{
 		ToolOptions:     opts,
 		StorageOptions:  storageOpts,

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -50,11 +50,11 @@ func main() {
 
 	// create a session provider to connect to the db
 	sessionProvider, err := db.NewSessionProvider(*opts)
-	defer sessionProvider.Close()
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to host: %v", err)
 		os.Exit(util.ExitError)
 	}
+	defer sessionProvider.Close()
 	sessionProvider.SetBypassDocumentValidation(ingestOpts.BypassDocumentValidation)
 
 	m := mongoimport.MongoImport{

--- a/mongooplog/main/mongooplog.go
+++ b/mongooplog/main/mongooplog.go
@@ -63,21 +63,21 @@ func main() {
 
 	// create a session provider for the destination server
 	sessionProviderTo, err := db.NewSessionProvider(*opts)
-	defer sessionProviderTo.Close()
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to destination host: %v", err)
 		os.Exit(util.ExitError)
 	}
+	defer sessionProviderTo.Close()
 
 	// create a session provider for the source server
 	opts.Connection.Host = sourceOpts.From
 	opts.Connection.Port = ""
 	sessionProviderFrom, err := db.NewSessionProvider(*opts)
-	defer sessionProviderFrom.Close()
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to source host: %v", err)
 		os.Exit(util.ExitError)
 	}
+	defer sessionProviderFrom.Close()
 
 	// initialize mongooplog
 	oplog := mongooplog.MongoOplog{

--- a/mongoreplay/execute.go
+++ b/mongoreplay/execute.go
@@ -150,10 +150,10 @@ func (context *ExecutionContext) newExecutionSession(url string, start time.Time
 		var connected bool
 		time.Sleep(start.Add(-5 * time.Second).Sub(now)) // Sleep until five seconds before the start time
 		session, err := mgo.Dial(url)
-		defer session.Close()
 		if err == nil {
 			userInfoLogger.Logvf(Info, "(Connection %v) New connection CREATED.", connectionNum)
 			connected = true
+			defer session.Close()
 		} else {
 			userInfoLogger.Logvf(Info, "(Connection %v) New Connection FAILED: %v", connectionNum, err)
 		}

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -67,11 +67,11 @@ func main() {
 	opts.ReplicaSetName = setName
 
 	provider, err := db.NewSessionProvider(*opts)
-	defer provider.Close()
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to host: %v", err)
 		os.Exit(util.ExitError)
 	}
+	defer provider.Close()
 	provider.SetBypassDocumentValidation(outputOpts.BypassDocumentValidation)
 
 	// disable TCP timeouts for restore jobs


### PR DESCRIPTION
Arguments to defer are evaluated eagerly, hence should occur after any
error response is checked.

Fixes https://jira.mongodb.org/browse/TOOLS-1576