### PR TITLE
TOOLS-1675 GetIndexes should not return an error when the database does not exist

### DIFF
--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -75,30 +75,26 @@ func TestGetIndexes(t *testing.T) {
 		}
 		provider, err := NewSessionProvider(opts)
 		So(err, ShouldBeNil)
-		defer provider.Close()
 		session, err := provider.GetSession()
 		So(err, ShouldBeNil)
-		defer session.Close()
 
 		existing := session.DB("exists").C("collection")
 		missing := session.DB("exists").C("missing")
 		missingDB := session.DB("missingDB").C("missingCollection")
-		defer existing.Database.DropDatabase()
 
-		Convey("setting up test cases", t, func() {
-			err := existing.Database.DropDatabase()
-			So(err, ShouldBeNil)
-			err = existing.Create(&mgo.CollectionInfo{})
-			So(err, ShouldBeNil)
-			err = missingDB.Database.DropDatabase()
-			So(err, ShouldBeNil)
-		})
+		err = existing.Database.DropDatabase()
+		So(err, ShouldBeNil)
+		err = existing.Create(&mgo.CollectionInfo{})
+		So(err, ShouldBeNil)
+		err = missingDB.Database.DropDatabase()
+		So(err, ShouldBeNil)
 
-		Convey("When GetIndexes is called on", t, func() {
+		Convey("When GetIndexes is called on", func() {
 			Convey("an existing collection there should be no error", func() {
 				indexesIter, err := GetIndexes(existing)
 				So(err, ShouldBeNil)
 				Convey("and indexes should be returned", func() {
+					So(indexesIter, ShouldNotBeNil)
 					var indexes []mgo.Index
 					err := indexesIter.All(&indexes)
 					So(err, ShouldBeNil)
@@ -121,6 +117,12 @@ func TestGetIndexes(t *testing.T) {
 					So(indexesIter, ShouldBeNil)
 				})
 			})
+		})
+
+		Reset(func() {
+			existing.Database.DropDatabase()
+			session.Close()
+			provider.Close()
 		})
 	})
 }

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/mgo.v2"
 	"reflect"
 	"testing"
 )
@@ -58,6 +59,70 @@ func TestNewSessionProvider(t *testing.T) {
 
 	})
 
+}
+
+func TestGetIndexes(t *testing.T) {
+
+	testutil.VerifyTestType(t, "db")
+
+	Convey("With a valid session", t, func() {
+		opts := options.ToolOptions{
+			Connection: &options.Connection{
+				Port: DefaultTestPort,
+			},
+			SSL:  &options.SSL{},
+			Auth: &options.Auth{},
+		}
+		provider, err := NewSessionProvider(opts)
+		So(err, ShouldBeNil)
+		defer provider.Close()
+		session, err := provider.GetSession()
+		So(err, ShouldBeNil)
+		defer session.Close()
+
+		existing := session.DB("exists").C("collection")
+		missing := session.DB("exists").C("missing")
+		missingDB := session.DB("missingDB").C("missingCollection")
+		defer existing.Database.DropDatabase()
+
+		Convey("setting up test cases", t, func() {
+			err := existing.Database.DropDatabase()
+			So(err, ShouldBeNil)
+			err = existing.Create(&mgo.CollectionInfo{})
+			So(err, ShouldBeNil)
+			err = missingDB.Database.DropDatabase()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("When GetIndexes is called on", t, func() {
+			Convey("an existing collection there should be no error", func() {
+				indexesIter, err := GetIndexes(existing)
+				So(err, ShouldBeNil)
+				Convey("and indexes should be returned", func() {
+					var indexes []mgo.Index
+					err := indexesIter.All(&indexes)
+					So(err, ShouldBeNil)
+					So(len(indexes), ShouldBeGreaterThan, 0)
+				})
+			})
+
+			Convey("a missing collection there should be no error", func() {
+				indexesIter, err := GetIndexes(missing)
+				So(err, ShouldBeNil)
+				Convey("and there should be no indexes", func() {
+					So(indexesIter, ShouldBeNil)
+				})
+			})
+
+			Convey("a missing database there should be no error", func() {
+				indexesIter, err := GetIndexes(missingDB)
+				So(err, ShouldBeNil)
+				Convey("and there should be no indexes", func() {
+					So(indexesIter, ShouldBeNil)
+				})
+			})
+		})
+	})
 }
 
 type listDatabasesCommand struct {

--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -23,6 +23,13 @@ func IsNoCollection(err error) bool {
 	return ok && e.Message == "no collection"
 }
 
+// IsNoNamespace returns true if err indicates a query resulted in a
+// "NamespaceNotFound" error otherwise, returns false.
+func IsNoNamespace(err error) bool {
+	e, ok := err.(*mgo.QueryError)
+	return ok && e.Code == 26
+}
+
 // buildBsonArray takes a cursor iterator and returns an array of
 // all of its documents as bson.D objects.
 func buildBsonArray(iter *mgo.Iter) ([]bson.D, error) {
@@ -67,7 +74,7 @@ func GetIndexes(coll *mgo.Collection) (*mgo.Iter, error) {
 	case IsNoCmd(err):
 		log.Logvf(log.DebugLow, "No support for listIndexes command, falling back to querying system.indexes")
 		return getIndexesPre28(coll)
-	case IsNoCollection(err):
+	case IsNoNamespace(err):
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("error running `listIndexes`. Collection: `%v` Err: %v", coll.FullName, err)

--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -16,13 +16,6 @@ func IsNoCmd(err error) bool {
 	return ok && strings.HasPrefix(e.Message, "no such cmd:")
 }
 
-// IsNoCollection returns true if err indicates a query resulted in a "no collection" error
-// otherwise, returns false.
-func IsNoCollection(err error) bool {
-	e, ok := err.(*mgo.QueryError)
-	return ok && e.Message == "no collection"
-}
-
 // IsNoNamespace returns true if err indicates a query resulted in a
 // "NamespaceNotFound" error otherwise, returns false.
 func IsNoNamespace(err error) bool {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-1675

GetIndexes ignores when the collection does not exist, this changes makes it so it does the same when the database does not exist. I'm not sure where to add a test for this but MongoDB 3.0 and up always returns error code 26 when the database/collection does not exist:
```
$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.0.0
WARNING: shell and server versions do not match
> db.runCommand({"listIndexes": "test"})
{ "ok" : 0, "errmsg" : "no collection", "code" : 26 }
> db.createdb.insert({})
WriteResult({ "nInserted" : 1 })
> db.runCommand({"listIndexes": "test"})
{ "ok" : 0, "errmsg" : "no collection", "code" : 26 }
>
bye
$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.0.14
WARNING: shell and server versions do not match
> db.runCommand({"listIndexes": "test"})
{ "ok" : 0, "errmsg" : "no database", "code" : 26 }
> db.createdb.insert({})
WriteResult({ "nInserted" : 1 })
> db.runCommand({"listIndexes": "test"})
{ "ok" : 0, "errmsg" : "no collection", "code" : 26 }
>
bye
$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.2
Server has startup warnings:
2017-03-03T10:44:52.603-0800 I CONTROL  [initandlisten]
2017-03-03T10:44:52.603-0800 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2017-03-03T10:44:52.603-0800 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2017-03-03T10:44:52.603-0800 I CONTROL  [initandlisten]
> db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no database",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
> db.createdb.insert({})
WriteResult({ "nInserted" : 1 })
> db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no collection",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
> ^C
bye
$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.2
Server has startup warnings:
2017-03-03T10:45:31.411-0800 I CONTROL  [initandlisten]
2017-03-03T10:45:31.411-0800 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2017-03-03T10:45:31.411-0800 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2017-03-03T10:45:31.411-0800 I CONTROL  [initandlisten]
> db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no database",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
> db.createdb.insert({})
WriteResult({ "nInserted" : 1 })
> db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no collection",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
>
bye
$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.5.3-79-gb94dd91
WARNING: shell and server versions do not match
Server has startup warnings:
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten]
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten] ** NOTE: This is a development version (3.5.3-79-gb94dd91) of MongoDB.
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten] **       Not recommended for production.
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten]
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2017-03-03T10:48:32.806-0800 I CONTROL  [initandlisten]
MongoDB Enterprise > db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no database",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
MongoDB Enterprise > db.createdb.insert({})
WriteResult({ "nInserted" : 1 })
MongoDB Enterprise > db.runCommand({"listIndexes": "test"})
{
	"ok" : 0,
	"errmsg" : "no collection",
	"code" : 26,
	"codeName" : "NamespaceNotFound"
}
MongoDB Enterprise > ^C
bye
```