### PR TITLE
TOOLS-1665 Set TCP keepalive.

### DIFF
--- a/common/db/openssl/openssl.go
+++ b/common/db/openssl/openssl.go
@@ -42,7 +42,15 @@ func (self *SSLDBConnector) Configure(opts options.ToolOptions) error {
 	dialer := func(addr *mgo.ServerAddr) (net.Conn, error) {
 		conn, err := openssl.Dial("tcp", addr.String(), self.ctx, flags)
 		self.dialError = err
-		return conn, err
+		if err != nil {
+			return nil, err
+		}
+		// enable TCP keepalive
+		err = util.EnableTCPKeepAlive(conn.UnderlyingConn(), time.Duration(opts.TCPKeepAliveSeconds)*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
 	}
 
 	timeout := time.Duration(opts.Timeout) * time.Second

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -89,7 +89,8 @@ type Connection struct {
 	Host string `short:"h" long:"host" value-name:"<hostname>" description:"mongodb host to connect to (setname/host1,host2 for replica sets)"`
 	Port string `long:"port" value-name:"<port>" description:"server port (can also use --host hostname:port)"`
 
-	Timeout int `long:"dialTimeout" default:"3" hidden:"true" description:"dial timeout in seconds"`
+	Timeout             int `long:"dialTimeout" default:"3" hidden:"true" description:"dial timeout in seconds"`
+	TCPKeepAliveSeconds int `long:"TCPKeepAliveSeconds" default:"30" hidden:"true" description:"seconds between TCP keep alives"`
 }
 
 // Struct holding ssl-related options

--- a/common/util/net.go
+++ b/common/util/net.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"net"
+	"time"
+)
+
+// EnableTCPKeepAlive enables TCP keepalive on the underlying TCP connection.
+func EnableTCPKeepAlive(conn net.Conn, keepAlivePeriod time.Duration) error {
+	if keepAlivePeriod == 0 {
+		return nil
+	}
+	if tcpconn, ok := conn.(*net.TCPConn); ok {
+		err := tcpconn.SetKeepAlive(true)
+		if err != nil {
+			return err
+		}
+		err = tcpconn.SetKeepAlivePeriod(keepAlivePeriod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-1665

This change adds a hidden `--TCPKeepAliveSeconds` parameter that controls the period between TCP keepalives. A value of 0 means do not enable TCP keepalive. The default is 30-seconds.

A 30-second keepalive period means different things depending on the platform but it roughly corresponds to 5 minutes of inactivity. Check out how the [`setKeepAlivePeriod`](https://golang.org/search?q=setKeepAlivePeriod) function is defined on various platforms:
- On Windows, after 30-seconds 10 keep-alive probes will be sent every 30 seconds. This results in 5.5 minutes of keep-alive time. See https://golang.org/src/net/tcpsockopt_windows.go?h=setKeepAlivePeriod#L14 and https://msdn.microsoft.com/en-us/library/windows/desktop/dd877220(v=vs.85).aspx.
- On Linux, after 30-seconds 8 keep-alive probes will be sent every 30 seconds. This results in 4.5 minutes of total keep alive time.

The number of keep-alive probes is configurable by the system administer so the total keep-alive time could be higher or lower depending on the machine.

The following shows that mongodump exits about 5 minutes after shutting off my wifi:
```
$ mongodump --host host.mongodb.net:27017 --authenticationDatabase admin --username user --password pass --ssl --db test
2017-05-15T15:51:49.645-0700	writing test.mongomirror to
2017-05-15T15:51:52.407-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
### Wifi shut off here
2017-05-15T15:51:55.405-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
2017-05-15T15:51:58.407-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
### Fast forward...
2017-05-15T15:56:22.406-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
2017-05-15T15:56:25.406-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
2017-05-15T15:56:25.895-0700	[#########...............]  test.mongomirror  383925/1000000  (38.4%)
2017-05-15T15:56:25.895-0700	Failed: error writing data for collection `test.mongomirror` to disk: error reading collection: read tcp 192.168.1.1:61209->192.167.1.1:27017: read: operation timed out
```