### PR TITLE
TOOLS-1954 enhanced csv array notation

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -221,11 +221,14 @@ func getUpsertValue(field string, document bson.D) interface{} {
 	if subDoc == nil {
 		return nil
 	}
-	subDocD, ok := subDoc.(bson.D)
-	if !ok {
+	switch subDoc.(type) {
+	case bson.D:
+		return getUpsertValue(field[index+1:], subDoc.(bson.D))
+	case *bson.D:
+		return getUpsertValue(field[index+1:], *subDoc.(*bson.D))
+	default:
 		return nil
 	}
-	return getUpsertValue(field[index+1:], subDocD)
 }
 
 // filterIngestError accepts a boolean indicating if a non-nil error should be,


### PR DESCRIPTION
These changes add support for the csv array notation that mongoexport uses.  A header of foo.bar.0, value of 'baz' should now become `"foo": { "bar": ["baz"] } `

The live version will create: 
` "foo": { "bar": { "0": "baz" }   }`

There was also an issue when upserting using csv files where getUpsertValue would always return nil. The addition of the type switch on line 224 should address this issue. 

Additional examples can be found here: https://jira.mongodb.org/browse/TOOLS-1954

Please feel free to reach out to me with any questions or comments. Thanks! 