### PR TITLE
TOOLS-1956 Add Bulk Upsert and Remove Modes and increase batch size limit

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -221,11 +221,14 @@ func getUpsertValue(field string, document bson.D) interface{} {
 	if subDoc == nil {
 		return nil
 	}
-	subDocD, ok := subDoc.(bson.D)
-	if !ok {
+	switch subDoc.(type) {
+	case bson.D:
+		return getUpsertValue(field[index+1:], subDoc.(bson.D))
+	case *bson.D:
+		return getUpsertValue(field[index+1:], *subDoc.(*bson.D))
+	default:
 		return nil
 	}
-	return getUpsertValue(field[index+1:], subDocD)
 }
 
 // filterIngestError accepts a boolean indicating if a non-nil error should be,

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -80,9 +80,9 @@ func main() {
 		if err != nil {
 			log.Logvf(log.Always, "Failed: %v", err)
 		}
-		message := fmt.Sprintf("imported 1 document")
+		message := fmt.Sprintf("processed 1 document")
 		if numDocs != 1 {
-			message = fmt.Sprintf("imported %v documents", numDocs)
+			message = fmt.Sprintf("processed %v documents", numDocs)
 		}
 		log.Logvf(log.Always, message)
 	}

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -64,10 +64,11 @@ type IngestOptions struct {
 	// Modify the import process.
 	// Always insert the documents if they are new (do NOT match --upsertFields).
 	// For existing documents (match --upsertFields) in the database:
-	// "insert": Insert only, skip exisiting documents.
+	// "insert": Insert only, skip existing documents.
 	// "upsert": Insert new documents or replace existing ones.
 	// "merge": Insert new documents or modify existing ones; Preserve values in the database that are not overwritten.
-	Mode string `long:"mode" choice:"insert" choice:"upsert" choice:"merge" description:"insert: insert only. upsert: insert or replace existing documents. merge: insert or modify existing documents. defaults to insert"`
+	// "remove": Remove existing documents based on upsertFields
+	Mode string `long:"mode" choice:"insert" choice:"upsert" choice:"merge" choice:"remove" description:"insert: insert only. upsert: insert or replace existing documents. merge: insert or modify existing documents. remove: remove existing documents based on upsertFields. defaults to insert"`
 
 	Upsert bool `long:"upsert" hidden:"true" description:"(deprecated; same as --mode=upsert) insert or update objects that already exist"`
 
@@ -86,6 +87,8 @@ type IngestOptions struct {
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
 	BulkBufferSize int `long:"batchSize" default:"1000" hidden:"true"`
+
+	BulkUpdate bool `long:"bulkUpdate" hidden:"true" description:"Bypass one at a time safeties for upsert"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/vendor/src/gopkg.in/mgo.v2/bulk.go
+++ b/vendor/src/gopkg.in/mgo.v2/bulk.go
@@ -125,7 +125,7 @@ func (c *Collection) Bulk() *Bulk {
 
 // Unordered puts the bulk operation in unordered mode.
 //
-// In unordered mode the indvidual operations may be sent
+// In unordered mode the individual operations may be sent
 // out of order, which means latter operations may proceed
 // even if prior ones have failed.
 func (b *Bulk) Unordered() {


### PR DESCRIPTION
The below changes were implemented after consulting with our Mongo rep Anant Srivastava to meet internal implementation needs. I will be opening a pull request shortly with our changes for review in case some/all of these changes want to be rolled into the product.

Bulk upserts
Enable bulk upsert operations. In the live version of mongoimport, running in upsert mode limits to 1 insertion worker process and an effective batch size of 1. This results in performance that unfortunately rendered mongoimport not viable for our volumes. With the addition of bulk, multi-worker upserts, we are seeing a 400-700X performance boost. With this performance tweak, mongoimport became a viable tool for our update process.

--bulkUpdate command line option added. When toggled on, upserts can be executed in bulk and in multiple worker processes. This option was added to limit the impact to existing processes using mongoimport. There is some debate on whether this flag is necessary or if 'bulkUpdate' mode should be 'on' by default and toggled 'off' via the --maintainInsertionOrder option

The change for 'bulkUpdate' upsert mode was implemented through disabling maintainInsertionOrder, removing the restriction for 1 insertion worker and adding new method to BufferedBulkInserter to support bulk Upsert operations.

Remove mode
--mode remove option added. Will construct bson selectors using records from input file and --upsertFields to remove matching documents. Each selector will remove only a single matching document. Implemented through adding new method to BufferedBulkInserter to support bulk Remove operations.

--upsertFields are required when specifying this option.

batchSize limit increased from 1k to 100k
With the MongoDB 3.6 batch size limit changes, the --batchSize option's maximum was raised to 100k documents. Mongoimport and mongo driver code (gopkg.in/mgo.v2) were patched to support this. Specifying a batch size larger than 1000 and targeting MongoDB <3.6 results in operations being batched driver side in chunks of 1000. The driver was also patched to split write operations >16MB into separate writeOpCommand calls for *insertOp, bulkUpdateOp, and bulkDeleteOp operation types.

https://docs.mongodb.com/manual/reference/limits/#Write-Command-Batch-Limit-Size

See https://jira.mongodb.org/browse/TOOLS-1956 for more details. 