### PR TITLE
TOOLS-1997 mongostat needs to handle large counters encoded as floats

### DIFF
--- a/mongostat/status/readers.go
+++ b/mongostat/status/readers.go
@@ -8,6 +8,7 @@ package status
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"time"
@@ -66,7 +67,9 @@ func numberToInt64(num interface{}) (int64, bool) {
 	case float32:
 		return int64(n), true
 	case float64:
-		return int64(n), true
+		if math.MinInt64 <= n && n <= math.MaxInt64 {
+			return int64(n), true
+		}
 	}
 	return 0, false
 }

--- a/mongostat/status/readers.go
+++ b/mongostat/status/readers.go
@@ -63,6 +63,10 @@ func numberToInt64(num interface{}) (int64, bool) {
 		return int64(n), true
 	case int:
 		return int64(n), true
+	case float32:
+		return int64(n), true
+	case float64:
+		return int64(n), true
 	}
 	return 0, false
 }


### PR DESCRIPTION
This is a minor change to display differences and rates computed from counter values larger than 1<<30, which get stored as doubles instead of signed integers.