### PR TITLE
TOOLS-2102 Check for errors reading oplog file

### DIFF
--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -104,6 +104,9 @@ func (restore *MongoRestore) RestoreOplog() error {
 	}
 
 	log.Logvf(log.Info, "applied %v ops", totalOps)
+	if err := bsonSource.Err(); err != nil {
+		return fmt.Errorf("error reading oplog bson input: %v", err)
+	}
 	return nil
 
 }


### PR DESCRIPTION
To test this I think we can copy `testdata/oplogdump` and corrupt one of the documents in oplog.bson. Then the `DecodedBSONSource` would error when decoding the corrupt document. 