### PR TITLE
TOOLS-2162 Fix logging formatting directives

### DIFF
--- a/mongoreplay/packet_handler.go
+++ b/mongoreplay/packet_handler.go
@@ -63,7 +63,7 @@ func (p *PacketHandler) Handle(streamHandler StreamHandler, numToHandle int) err
 	count := int64(0)
 	start := time.Now()
 	if p.Verbose && numToHandle > 0 {
-		userInfoLogger.Logvf(Always, "Processing", numToHandle, "packets")
+		userInfoLogger.Logvf(Always, "Processing %v %v", numToHandle, "packets")
 	}
 	source := gopacket.NewPacketSource(p.pcap, p.pcap.LinkType())
 	streamPool := NewStreamPool(streamHandler)

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -360,7 +360,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				// Server versions >= 3.0.3 disallow user inserts to system.profile so
 				// it would likely fail anyway.
 				if collection == "system.profile" {
-					log.Logvf(log.DebugLow, "skipping restore of system.profile collection", db)
+					log.Logvf(log.DebugLow, "skipping restore of system.profile collection in %v", db)
 					skip = true
 				}
 				// skip restoring the indexes collection if we are using metadata


### PR DESCRIPTION
Fix logging formatting directives in `mongoreplay/packet_handler.go` and `mongorestore/filepath.go`.

What to do to get this merged?