### PR TITLE
TOOLS-2179 Fix testBsondump not running on Windows

### DIFF
--- a/bsondump/bsondump_test.go
+++ b/bsondump/bsondump_test.go
@@ -19,12 +19,13 @@ import (
 
 func TestBsondump(t *testing.T) {
 	// TOOLS-2179 filed to figure out why this is neccessary
+	executable := "../bin/bsondump"
 	if runtime.GOOS == "windows" {
-		t.SkipNow()
+		executable = "../bin/bsondump.exe"
 	}
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	Convey("Test bsondump reading from stdin and writing to stdout", t, func() {
-		cmd := exec.Command("../bin/bsondump")
+		cmd := exec.Command(executable)
 
 		// Attach a file to stdin of the command.
 		inFile, err := os.Open("testdata/sample.bson")
@@ -50,7 +51,7 @@ func TestBsondump(t *testing.T) {
 	})
 
 	Convey("Test bsondump reading from stdin and writing to a file", t, func() {
-		cmd := exec.Command("../bin/bsondump", "--outFile", "out.json")
+		cmd := exec.Command(executable, "--outFile", "out.json")
 
 		// Attach a file to stdin of the command.
 		inFile, err := os.Open("testdata/sample.bson")
@@ -82,7 +83,7 @@ func TestBsondump(t *testing.T) {
 	})
 
 	Convey("Test bsondump reading from a file with --bsonFile and writing to stdout", t, func() {
-		cmd := exec.Command("../bin/bsondump", "--bsonFile", "testdata/sample.bson")
+		cmd := exec.Command(executable, "--bsonFile", "testdata/sample.bson")
 
 		// Attach a buffer to stdout of the command.
 		cmdOutput := &bytes.Buffer{}
@@ -103,7 +104,7 @@ func TestBsondump(t *testing.T) {
 	})
 
 	Convey("Test bsondump reading from a file with a positional arg and writing to stdout", t, func() {
-		cmd := exec.Command("../bin/bsondump", "testdata/sample.bson")
+		cmd := exec.Command(executable, "testdata/sample.bson")
 
 		// Attach a buffer to stdout of command.
 		cmdOutput := &bytes.Buffer{}
@@ -124,7 +125,7 @@ func TestBsondump(t *testing.T) {
 	})
 
 	Convey("Test bsondump reading from a file with --bsonFile and writing to a file", t, func() {
-		cmd := exec.Command("../bin/bsondump", "--outFile", "out.json",
+		cmd := exec.Command(executable, "--outFile", "out.json",
 			"--bsonFile", "testdata/sample.bson")
 
 		err := cmd.Run()
@@ -152,7 +153,7 @@ func TestBsondump(t *testing.T) {
 	})
 
 	Convey("Test bsondump reading from a file with a positional arg and writing to a file", t, func() {
-		cmd := exec.Command("../bin/bsondump", "--outFile", "out.json", "testdata/sample.bson")
+		cmd := exec.Command(executable, "--outFile", "out.json", "testdata/sample.bson")
 
 		err := cmd.Run()
 		So(err, ShouldBeNil)

--- a/bsondump/bsondump_test.go
+++ b/bsondump/bsondump_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestBsondump(t *testing.T) {
-	// TOOLS-2179 filed to figure out why this is neccessary
 	executable := "../bin/bsondump"
 	if runtime.GOOS == "windows" {
 		executable = "../bin/bsondump.exe"

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ set_goenv || exit
 BINARY_EXT=""
 UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
     case ${UNAME_S} in
-        'CYGWIN*')
+        CYGWIN*)
             BINARY_EXT=".exe"
         ;;
     esac

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,14 @@ cd $SCRIPT_DIR
 . ./set_goenv.sh
 set_goenv || exit
 
+BINARY_EXT=""
+UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
+    case ${UNAME_S} in
+        'CYGWIN*')
+            BINARY_EXT=".exe"
+        ;;
+    esac
+
 # remove stale packages
 rm -rf vendor/pkg
 
@@ -21,8 +29,8 @@ mkdir -p bin
 ec=0
 for i in bsondump mongostat mongofiles mongoexport mongoimport mongorestore mongodump mongotop mongoreplay; do
         echo "Building ${i}..."
-        go build -o "bin/$i" $(buildflags) -ldflags "$(print_ldflags)" -tags "$(print_tags $tags)" "$i/main/$i.go" || { echo "Error building $i"; ec=1; break; }
-        ./bin/$i --version | head -1
+        go build -o "bin/$i$BINARY_EXT" $(buildflags) -ldflags "$(print_ldflags)" -tags "$(print_tags $tags)" "$i/main/$i.go" || { echo "Error building $i"; ec=1; break; }
+        ./bin/${i}${BINARY_EXT} --version | head -1
 done
 
 if [ -t /dev/stdin ]; then

--- a/set_goenv.sh
+++ b/set_goenv.sh
@@ -23,10 +23,10 @@ set_goenv() {
 
     # Set OS-level compilation flags
     case $UNAME_S in
-        'CYGWIN*')
+        CYGWIN*)
             export CGO_CFLAGS="-D_WIN32_WINNT=0x0601 -DNTDDI_VERSION=0x06010000"
             ;;
-        'Darwin')
+        Darwin)
             export CGO_CFLAGS="-mmacosx-version-min=10.11"
             export CGO_LDFLAGS="-mmacosx-version-min=10.11"
             ;;


### PR DESCRIPTION
[TOOLS-2179](https://jira.mongodb.com/browse/TOOLS-2179)

This PR allows the testBsondump to run on windows. The problem was that the binaries were being output without a Windows executable file extension, so they could never be run from a command-line like environment. The changes here ensure build.sh outputs the binaries with a .exe file extension if it detects it's being run in a Cygwin environment.

[evergreen patch](https://evergreen.mongodb.com/version/5c6c74557742ae4f5bebfd79)