### PR TITLE
TOOLS-2222 Mongodump should ignore config.transactions and config.transaction_coordinators

### DIFF
--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -149,7 +149,7 @@ func shouldSkipSystemNamespace(dbName, collName string) bool {
 			return true
 		}
 	case "config":
-		if collName == "transactions" || collName == "system.sessions" {
+		if collName == "transactions" || collName == "system.sessions" || collName == "transaction_coordinators"{
 			return true
 		}
 	default:

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -149,7 +149,7 @@ func shouldSkipSystemNamespace(dbName, collName string) bool {
 			return true
 		}
 	case "config":
-		if collName == "transactions" || collName == "system.sessions" || collName == "transaction_coordinators"{
+		if collName == "transactions" || collName == "system.sessions" || collName == "transaction_coordinators" {
 			return true
 		}
 	default:


### PR DESCRIPTION
[TOOLS-2222](https://jira.mongodb.com/browse/TOOLS-2222)