### PR TITLE
Add bsonutil.FindStringValueByKey

### DIFF
--- a/common/bsonutil/bsonutil.go
+++ b/common/bsonutil/bsonutil.go
@@ -21,6 +21,7 @@ import (
 )
 
 var ErrNoSuchField = errors.New("no such field")
+var ErrNoSuchString = errors.New("field present, but is not a string")
 
 // ConvertJSONDocumentToBSON iterates through the document map and converts JSON
 // values to their corresponding BSON values. It also replaces any extended JSON
@@ -78,6 +79,21 @@ func FindValueByKey(keyName string, document *bson.D) (interface{}, error) {
 		}
 	}
 	return nil, ErrNoSuchField
+}
+
+// FindStringValueByKey returns the value of keyName in document as a String.
+// If keyName is not found in the top-level of the document, returns ErrNoSuchField.
+// If keyName is found but the value is not a string, returns ErrNoSuchString.
+func FindStringValueByKey(keyName string, document *bson.D) (string, error) {
+	value, err := FindValueByKey(keyName, document)
+	if err != nil {
+		return "", err
+	}
+	str, ok := value.(string)
+	if !ok {
+		return "", ErrNoSuchString
+	}
+	return str, nil
 }
 
 // ParseSpecialKeys takes a JSON document and inspects it for any extended JSON

--- a/common/bsonutil/marshal_d_test.go
+++ b/common/bsonutil/marshal_d_test.go
@@ -112,6 +112,35 @@ func TestFindValueByKey(t *testing.T) {
 	})
 }
 
+func TestFindStringValueByKey(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	Convey("Given a bson.D document and a specific key", t, func() {
+		subDocument := &bson.D{
+			bson.DocElem{Name: "field4", Value: "c"},
+		}
+		document := &bson.D{
+			bson.DocElem{Name: "field1", Value: "a"},
+			bson.DocElem{Name: "field2", Value: "b"},
+			bson.DocElem{Name: "field3", Value: subDocument},
+		}
+		Convey("the corresponding value top-level keys should be returned", func() {
+			value, err := FindStringValueByKey("field1", document)
+			So(value, ShouldEqual, "a")
+			So(err, ShouldBeNil)
+		})
+		Convey("for non-existent keys empty string and an error should be returned", func() {
+			value, err := FindStringValueByKey("field4", document)
+			So(value, ShouldEqual, "")
+			So(err, ShouldNotBeNil)
+		})
+		Convey("for existing keys with non-string values empty string and an error should be returned", func() {
+			value, err := FindStringValueByKey("field3", document)
+			So(value, ShouldEqual, "")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
 func TestEscapedKey(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	Convey("Given a bson.D document with a key that requires escaping", t, func() {


### PR DESCRIPTION
@xdg [pointed out](https://github.com/10gen/mongomirror/pull/133/files#r260497575) a couple of places in a mongomirror PR where we had duplicated logic to call `bsonutil.FindValueByKey` and then cast the return value to a string. 
searching through the codebase I found several more places we do this, so I've added a helper to do both at once. 

[evg patch](https://evergreen.mongodb.com/version/5c76ae160305b922178f28ee)