### PR TITLE
TOOLS-2229 Fix mongofiles deletes chunks of existing file when failing to put_id with existing _id

### DIFF
--- a/test/qa-tests/jstests/files/mongofiles_put.js
+++ b/test/qa-tests/jstests/files/mongofiles_put.js
@@ -96,6 +96,25 @@ load('jstests/files/util/mongofiles_common.js');
 
     assert.eq(actual, expected, 'mismatched md5 sum - expected ' + expected + ' got ' + actual);
 
+    // test put_id with duplicate _id
+    const dupId = '1';
+
+    assert.eq(runMongoProgram.apply(this, ['mongofiles',
+          '--port', conn.port,
+          'put_id', filesToInsert[0], dupId]
+            .concat(passthrough.args)),
+        0, 'put_id failed when it should have succeeded');
+
+    const numChunks = db.fs.chunks.count();
+
+    assert.neq(runMongoProgram.apply(this, ['mongofiles',
+          '--port', conn.port,
+          'put_id', filesToInsert[1], dupId]
+            .concat(passthrough.args)),
+        0, 'put_id succeeded when it should have failed');
+
+    assert.eq(numChunks, db.fs.chunks.count(), 'existing chunks were modified when they should not have been');
+
     t.stop();
   };
 


### PR DESCRIPTION
[TOOLS-2229](https://jira.mongodb.org/browse/TOOLS-2229)

The bug here is likely within mgo itself attempting to clean up orphan chunks when something goes wrong inserting into GridFS, but changing that behavior may break all other kinds of things within mgo and projects that depend on it. It's much easier just to perform a query here in mongofiles instead, which is what I've done.

[evg patch](https://evergreen.mongodb.com/version/5c786bb4850e614e333352bd)