### PR TITLE
TOOLS-1835 Port mongoimport to the new driver

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -17,10 +17,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/mongodb/mongo-tools/common/bsonutil"
-	"github.com/mongodb/mongo-tools/common/db"
-	"github.com/mongodb/mongo-tools/common/log"
-	"github.com/mongodb/mongo-tools/common/util"
+	"github.com/mongodb/mongo-tools-common/bsonutil"
+	"github.com/mongodb/mongo-tools-common/db"
+	"github.com/mongodb/mongo-tools-common/log"
+	"github.com/mongodb/mongo-tools-common/util"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v2"
 )
@@ -324,7 +324,7 @@ func streamDocuments(ordered bool, numDecoders int, readDocs chan Converter, out
 		iw := &importWorker{
 			unprocessedDataChan:   inChan,
 			processedDocumentChan: outChan,
-			tomb: importTomb,
+			tomb:                  importTomb,
 		}
 		importWorkers = append(importWorkers, iw)
 		wg.Add(1)

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -11,10 +11,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/db"
-	"github.com/mongodb/mongo-tools/common/log"
-	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/db"
+	"github.com/mongodb/mongo-tools-common/log"
+	"github.com/mongodb/mongo-tools-common/options"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v2"
@@ -438,7 +438,7 @@ func TestProcessDocuments(t *testing.T) {
 			iw := &importWorker{
 				unprocessedDataChan:   inputChannel,
 				processedDocumentChan: outputChannel,
-				tomb: &tomb.Tomb{},
+				tomb:                  &tomb.Tomb{},
 			}
 			inputChannel <- csvConverters[0]
 			inputChannel <- csvConverters[1]
@@ -460,7 +460,7 @@ func TestProcessDocuments(t *testing.T) {
 			iw := &importWorker{
 				unprocessedDataChan:   inputChannel,
 				processedDocumentChan: outputChannel,
-				tomb: &tomb.Tomb{},
+				tomb:                  &tomb.Tomb{},
 			}
 			inputChannel <- csvConverters[0]
 			inputChannel <- csvConverters[1]
@@ -496,12 +496,12 @@ func TestDoSequentialStreaming(t *testing.T) {
 			&importWorker{
 				unprocessedDataChan:   workerInputChannel[0],
 				processedDocumentChan: workerOutputChannel[0],
-				tomb: &tomb.Tomb{},
+				tomb:                  &tomb.Tomb{},
 			},
 			&importWorker{
 				unprocessedDataChan:   workerInputChannel[1],
 				processedDocumentChan: workerOutputChannel[1],
-				tomb: &tomb.Tomb{},
+				tomb:                  &tomb.Tomb{},
 			},
 		}
 		Convey("documents moving through the input channel should be processed and returned in sequence", func() {

--- a/mongoimport/csv_test.go
+++ b/mongoimport/csv_test.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/log"
-	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/log"
+	"github.com/mongodb/mongo-tools-common/options"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/mongoimport/json.go
+++ b/mongoimport/json.go
@@ -12,9 +12,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/mongodb/mongo-tools/common/bsonutil"
-	"github.com/mongodb/mongo-tools/common/json"
-	"github.com/mongodb/mongo-tools/common/log"
+	"github.com/mongodb/mongo-tools-common/bsonutil"
+	"github.com/mongodb/mongo-tools-common/json"
+	"github.com/mongodb/mongo-tools-common/log"
 	"gopkg.in/mgo.v2/bson"
 )
 

--- a/mongoimport/json_test.go
+++ b/mongoimport/json_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -11,33 +11,20 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mongodb/mongo-tools/common/db"
-	"github.com/mongodb/mongo-tools/common/log"
-	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/signals"
-	"github.com/mongodb/mongo-tools/common/util"
+	"github.com/mongodb/mongo-tools-common/log"
+	"github.com/mongodb/mongo-tools-common/signals"
+	"github.com/mongodb/mongo-tools-common/util"
 	"github.com/mongodb/mongo-tools/mongoimport"
 )
 
 func main() {
-	// initialize command-line opts
-	opts := options.New("mongoimport", mongoimport.Usage,
-		options.EnabledOptions{Auth: true, Connection: true, Namespace: true, URI: true})
-
-	inputOpts := &mongoimport.InputOptions{}
-	opts.AddOptions(inputOpts)
-	ingestOpts := &mongoimport.IngestOptions{}
-	opts.AddOptions(ingestOpts)
-	opts.URI.AddKnownURIParameters(options.KnownURIOptionsWriteConcern)
-
-	args, err := opts.ParseArgs(os.Args[1:])
+	opts, err := mongoimport.ParseOptions(os.Args[1:])
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongoimport --help' for more information")
 		os.Exit(util.ExitBadOptions)
 	}
 
-	log.SetVerbosity(opts.Verbosity)
 	signals.Handle()
 
 	// print help, if specified
@@ -50,30 +37,12 @@ func main() {
 		return
 	}
 
-	// verify uri options and log them
-	opts.URI.LogUnsupportedOptions()
-
-	// create a session provider to connect to the db
-	sessionProvider, err := db.NewSessionProvider(*opts)
+	m, err := mongoimport.New(opts)
 	if err != nil {
-		log.Logvf(log.Always, "error connecting to host: %v", err)
+		log.Logvf(log.Always, err.Error())
 		os.Exit(util.ExitError)
 	}
-	defer sessionProvider.Close()
-	sessionProvider.SetBypassDocumentValidation(ingestOpts.BypassDocumentValidation)
-
-	m := mongoimport.MongoImport{
-		ToolOptions:     opts,
-		InputOptions:    inputOpts,
-		IngestOptions:   ingestOpts,
-		SessionProvider: sessionProvider,
-	}
-
-	if err = m.ValidateSettings(args); err != nil {
-		log.Logvf(log.Always, "error validating settings: %v", err)
-		log.Logvf(log.Always, "try 'mongoimport --help' for more information")
-		os.Exit(util.ExitError)
-	}
+	defer m.Close()
 
 	numDocs, err := m.ImportDocuments()
 	if !opts.Quiet {

--- a/mongoimport/options_test.go
+++ b/mongoimport/options_test.go
@@ -7,76 +7,59 @@
 package mongoimport
 
 import (
-	"fmt"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/db"
-	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+// validateParseOptions is a helper function to call ParseOptions and verify the results.
+// args: command line args
+// expectSuccess: whether or not the error from ParseOptions should be nil
+// ingestWc: the correct value for opts.IngestOptions.WriteConcern
+// toolsWc: the correct value for opts.ToolsOptions.WriteConcern
+func validateParseOptions(args []string, expectSuccess bool, ingestWc string, toolsWc *writeconcern.WriteConcern) func() {
+	return func() {
+		opts, err := ParseOptions(args)
+		if expectSuccess {
+			So(err, ShouldBeNil)
+		} else {
+			So(err, ShouldNotBeNil)
+			return
+		}
+
+		So(opts.IngestOptions.WriteConcern, ShouldEqual, ingestWc)
+		So(opts.ToolOptions.WriteConcern, ShouldResemble, toolsWc)
+	}
+}
 
 // Regression test for TOOLS-1741
 func TestWriteConcernWithURIParsing(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	Convey("With an IngestOptions and ToolsOptions", t, func() {
+		Convey("Parsing with no value should set a majority write concern",
+			validateParseOptions([]string{}, true, "", writeconcern.New(writeconcern.WMajority())))
 
-		// create an 'EnabledOptions' to determine what options should be able to be
-		// parsed and set form the input.
-		enabled := options.EnabledOptions{URI: true}
-
-		// create a new tools options to hold the parsed options
-		opts := options.New("", "", enabled)
-
-		// create an 'IngestOptions', which holds the value of the write concern
-		// for mongoimport.
-		ingestOpts := &IngestOptions{}
-		opts.AddOptions(ingestOpts)
-
-		// Specify that a write concern set on the URI is not an error and is a known
-		// possible option.
-		opts.URI.AddKnownURIParameters(options.KnownURIOptionsWriteConcern)
-
-		Convey("Parsing with no value should leave write concern empty", func() {
-			_, err := opts.ParseArgs([]string{})
-			So(err, ShouldBeNil)
-			So(ingestOpts.WriteConcern, ShouldEqual, "")
-			Convey("and building write concern object, WMode should be majority", func() {
-				sessionSafety, err := db.BuildWriteConcern(ingestOpts.WriteConcern, "",
-					opts.ParsedConnString())
-				So(err, ShouldBeNil)
-				So(sessionSafety.WMode, ShouldEqual, "majority")
-			})
-		})
-
-		Convey("Parsing with no writeconcern in URI should not error", func() {
-			args := []string{
+		Convey("Parsing with no writeconcern in URI should set a majority write concern",
+			validateParseOptions([]string{
 				"--uri", "mongodb://localhost:27017/test",
-			}
-			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
-			So(ingestOpts.WriteConcern, ShouldEqual, "")
-			Convey("and parsing write concern, WMode should be majority", func() {
-				sessionSafety, err := db.BuildWriteConcern(ingestOpts.WriteConcern, "",
-					opts.ParsedConnString())
-				So(err, ShouldBeNil)
-				So(sessionSafety, ShouldNotBeNil)
-				So(sessionSafety.WMode, ShouldEqual, "majority")
-			})
-		})
-		Convey("Parsing with both writeconcern in URI and command line should error", func() {
-			args := []string{
-				"--uri", "mongodb://localhost:27017/test",
-				"--writeConcern", "majority",
-			}
-			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
-			So(ingestOpts.WriteConcern, ShouldEqual, "majority")
-			Convey("and parsing write concern, WMode should be majority", func() {
-				_, err := db.BuildWriteConcern(ingestOpts.WriteConcern, "",
-					opts.ParsedConnString())
-				So(err, ShouldResemble, fmt.Errorf("cannot specify writeConcern string and connectionString object"))
-			})
-		})
+			}, true, "", writeconcern.New(writeconcern.WMajority())))
+
+		Convey("Parsing with writeconcern only in URI should set it correctly",
+			validateParseOptions([]string{
+				"--uri", "mongodb://localhost:27017/test?w=2",
+			}, true, "", writeconcern.New(writeconcern.W(2))))
+
+		Convey("Parsing with writeconcern only in command line should set it correctly",
+			validateParseOptions([]string{
+				"--writeConcern", "{w: 2}",
+			}, true, "{w: 2}", writeconcern.New(writeconcern.W(2))))
+
+		Convey("Parsing with writeconcern in URI and command line should set to command line",
+			validateParseOptions([]string{
+				"--uri", "mongodb://localhost:27017/test?w=2",
+				"--writeConcern", "{w: 3}",
+			}, true, "{w: 3}", writeconcern.New(writeconcern.W(3))))
 	})
 }

--- a/mongoimport/tsv_test.go
+++ b/mongoimport/tsv_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/mongoimport/typed_fields_test.go
+++ b/mongoimport/typed_fields_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mongodb/mongo-tools/common/log"
-	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/mongodb/mongo-tools-common/log"
+	"github.com/mongodb/mongo-tools-common/options"
+	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2/bson"
 )


### PR DESCRIPTION
Some sort of change is necessary in mongo-tools-common/db/db.go to recognize "not master" errors from the server correctly due to a difference in how mgo and the new driver print command errors before this patch passes on Evergreen.

For the time being, I left in the dependency on bsonutil and the mgo BSON lib. Removing those can be done at a later time if needed.