### PR TITLE
TOOLS-2217 Use command line and URI arguments to construct read preference

### DIFF
--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -132,15 +132,9 @@ func (dump *MongoDump) Init() error {
 		dump.OutputWriter = os.Stdout
 	}
 
-	var pref *readpref.ReadPref
-	if dump.InputOptions.ReadPreference != "" {
-		pref, err = db.ParseReadPreference(dump.InputOptions.ReadPreference)
-		if err != nil {
-			return fmt.Errorf("error parsing --readPreference : %v", err)
-		}
-	} else {
-		pref = readpref.Primary()
-		// Direct connection is configured elsewhere if replica set name is not given
+	pref, err := db.ParseReadPreference(dump.InputOptions.ReadPreference, dump.ToolOptions.URI.ParsedConnString())
+	if err != nil {
+		return fmt.Errorf("error parsing --readPreference : %v", err)
 	}
 	dump.ToolOptions.ReadPreference = pref
 

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -67,6 +67,7 @@ func simpleMongoDumpInstance() *MongoDump {
 			Connection: connection,
 			Auth:       &auth,
 			Verbosity:  &options.Verbosity{},
+			URI:        &options.URI{},
 		}
 	}
 

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mongodb/mongo-tools-common/db"
 	"github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/options"
-	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 // Usage string printed as part of --help
@@ -65,16 +64,9 @@ func ParseOptions(rawArgs []string) (Options, error) {
 	opts.WriteConcern = wc
 
 	// set ReadPreference
-	if inputOpts.ReadPreference != "" {
-		opts.ReadPreference, err = db.ParseReadPreference(inputOpts.ReadPreference)
-		if err != nil {
-			return Options{}, fmt.Errorf("error parsing --readPreference: %v", err)
-		}
-	} else {
-		opts.ReadPreference, err = readpref.New(readpref.NearestMode)
-		if err != nil {
-			return Options{}, fmt.Errorf("error setting default read preference: %v", err)
-		}
+	opts.ReadPreference, err = db.ParseReadPreference(inputOpts.ReadPreference, opts.URI.ParsedConnString())
+	if err != nil {
+		return Options{}, fmt.Errorf("error parsing --readPreference: %v", err)
 	}
 
 	return Options{opts, storageOpts, inputOpts, args}, nil

--- a/mongotop/main/mongotop.go
+++ b/mongotop/main/mongotop.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mongodb/mongo-tools-common/signals"
 	"github.com/mongodb/mongo-tools-common/util"
 	"github.com/mongodb/mongo-tools/mongotop"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 func main() {
@@ -82,7 +83,7 @@ func main() {
 	}
 
 	if opts.ReplicaSetName == "" {
-		opts.ReadPreference = db.PrimaryPreferred()
+		opts.ReadPreference = readpref.PrimaryPreferred()
 	}
 
 	// create a session provider to connect to the db

--- a/vendor/github.com/mongodb/mongo-tools-common/db/read_preferences.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/read_preferences.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mongodb/mongo-tools-common/json"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/tag"
+	"go.mongodb.org/mongo-driver/x/network/connstring"
 )
 
 type readPrefDoc struct {
@@ -24,15 +25,22 @@ const (
 		"connection to mongos may produce inconsistent duplicates or miss some documents."
 )
 
-func Primary() *readpref.ReadPref          { return readpref.Primary() }
-func PrimaryPreferred() *readpref.ReadPref { return readpref.PrimaryPreferred() }
-func Nearest() *readpref.ReadPref          { return readpref.Nearest() }
+// ParseReadPreference takes a string (command line read preference argument) and a ConnString (from the command line
+// URI argument) and returns a ReadPref. If both are provided, preference is given to the command line argument. If
+// both are empty, a default read preference of nearest will be returned.
+func ParseReadPreference(cmdReadPref string, cs *connstring.ConnString) (*readpref.ReadPref, error) {
+	var rp string
+	if cs != nil {
+		rp = cs.ReadPreference
+	}
+	if cmdReadPref != "" {
+		rp = cmdReadPref
+	}
 
-func ParseReadPreference(rp string) (*readpref.ReadPref, error) {
 	var mode string
 	var tagSet tag.Set
 	if rp == "" {
-		return readpref.Nearest(), nil
+		return readpref.Primary(), nil
 	}
 	if rp[0] != '{' {
 		mode = rp


### PR DESCRIPTION
This blocks TOOLS-1836 (porting mongoexport). I decided to do this as a separate PR because the changes to mongofiles and mongodump seemed out of scope for the mongoexport PR. Once this is approved, I'll make the changes to common and revendor without doing another code review.