### PR TITLE
TOOLS-2068 Skip calling Count() on the oplog in mongodump

### DIFF
--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -578,6 +578,23 @@ func (dump *MongoDump) dumpQueryToIntent(
 	return dump.dumpValidatedQueryToIntent(query, intent, buffer, nil)
 }
 
+// getCount counts the number of documents in the namespace for the given intent. It does not run the count for
+// the oplog collection to avoid the performance issue in TOOLS-2068.
+func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent) (int64, error) {
+	if len(dump.query) != 0 || intent.IsOplog() {
+		log.Logvf(log.DebugLow, "not counting query on %v", intent.Namespace())
+		return 0, nil
+	}
+
+	total, err := query.Count()
+	if err != nil {
+		return 0, fmt.Errorf("error getting count from db: %v", err)
+	}
+
+	log.Logvf(log.DebugLow, "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
+	return int64(total), nil
+}
+
 // dumpValidatedQueryToIntent takes an mgo Query, its intent, a writer, and a document validator, performs the query,
 // validates the results with the validator,
 // and writes the raw bson results to the writer. Returns a final count of documents
@@ -601,18 +618,13 @@ func (dump *MongoDump) dumpValidatedQueryToIntent(
 	if intent.IsView() && !dump.OutputOptions.ViewsAsCollections {
 		return 0, nil
 	}
-	var total int
-	if len(dump.query) == 0 {
-		total, err = query.Count()
-		if err != nil {
-			return int64(0), fmt.Errorf("error getting count from db: %v", err)
-		}
-		log.Logvf(log.DebugLow, "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
-	} else {
-		log.Logvf(log.DebugLow, "not counting query on %v", intent.Namespace())
+
+	total, err := dump.getCount(query, intent)
+	if err != nil {
+		return 0, err
 	}
 
-	dumpProgressor := progress.NewCounter(int64(total))
+	dumpProgressor := progress.NewCounter(total)
 	if dump.ProgressManager != nil {
 		dump.ProgressManager.Attach(intent.Namespace(), dumpProgressor)
 		defer dump.ProgressManager.Detach(intent.Namespace())


### PR DESCRIPTION
Verified that this does not send an aggregate command to count the documents in the oplog by enabling command monitoring in the driver.