### PR TITLE
TOOLS-2253 Eliminate distinct exit codes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,7 +104,7 @@
 
 [[projects]]
   branch = "mongofiles_errors"
-  digest = "1:b6bce36ca633c991debae37e21bb10a8ff73156cd03dce5b244d8d68b8c5fde2"
+  digest = "1:22830fa374196551d2f8f44737d94206e564e5715a0282dd5005b392adcd9f25"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "906660f293ead9d4e6c3972aa03d1cb518475556"
+  revision = "0375a3a0803316191cc7ad6eed7bf5d8093afb5e"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,8 +103,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "mongofiles_errors"
-  digest = "1:22830fa374196551d2f8f44737d94206e564e5715a0282dd5005b392adcd9f25"
+  branch = "master"
+  digest = "1:bd7cacb910136519ed62250f396649eea056610fe7eb4c8c7844ac6c43908cf7"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "0375a3a0803316191cc7ad6eed7bf5d8093afb5e"
+  revision = "a9ff4e9b1db25d1b01d2014c3e9945c763349a59"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,7 +104,7 @@
 
 [[projects]]
   branch = "mongofiles_errors"
-  digest = "1:22830fa374196551d2f8f44737d94206e564e5715a0282dd5005b392adcd9f25"
+  digest = "1:b6bce36ca633c991debae37e21bb10a8ff73156cd03dce5b244d8d68b8c5fde2"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "0375a3a0803316191cc7ad6eed7bf5d8093afb5e"
+  revision = "906660f293ead9d4e6c3972aa03d1cb518475556"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,8 +103,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:64629229e2ed5c7af1cb1629b8b85ef8d1b3b7c949e6d96dfd19afa383e9030f"
+  branch = "mongofiles_errors"
+  digest = "1:22830fa374196551d2f8f44737d94206e564e5715a0282dd5005b392adcd9f25"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "f450824d00a780709a0175633d91b50ffb766c8c"
+  revision = "0375a3a0803316191cc7ad6eed7bf5d8093afb5e"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  branch = "master"
+  branch = "mongofiles_errors"
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  branch = "mongofiles_errors"
+  branch = "master"
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"

--- a/bsondump/main/bsondump.go
+++ b/bsondump/main/bsondump.go
@@ -27,7 +27,7 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "%v", err)
 		log.Logvf(log.Always, "try 'bsondump --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	// print help, if specified
@@ -45,13 +45,13 @@ func main() {
 	dumper, err := bsondump.New(opts)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	defer func() {
 		err := dumper.Close()
 		if err != nil {
 			log.Logvf(log.Always, "error cleaning up: %v", err)
-			os.Exit(util.ExitError)
+			os.Exit(util.ExitFailure)
 		}
 	}()
 
@@ -67,6 +67,6 @@ func main() {
 	log.Logvf(log.Always, "%v objects found", numFound)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/bsondump/main/bsondump.go
+++ b/bsondump/main/bsondump.go
@@ -26,7 +26,7 @@ func main() {
 	opts, err := bsondump.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
 		log.Logvf(log.Always, "%v", err)
-		log.Logvf(log.Always, "try 'bsondump --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("bsondump"))
 		os.Exit(util.ExitFailure)
 	}
 

--- a/mongodump/main/mongodump.go
+++ b/mongodump/main/mongodump.go
@@ -42,13 +42,13 @@ func main() {
 	args, err := opts.ParseArgs(os.Args[1:])
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, "try 'mongodump --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongodump"))
 		os.Exit(util.ExitFailure)
 	}
 
 	if len(args) > 0 {
 		log.Logvf(log.Always, "positional arguments not allowed: %v", args)
-		log.Logvf(log.Always, "try 'mongodump --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongodump"))
 		os.Exit(util.ExitFailure)
 	}
 

--- a/mongodump/main/mongodump.go
+++ b/mongodump/main/mongodump.go
@@ -43,13 +43,13 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongodump --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if len(args) > 0 {
 		log.Logvf(log.Always, "positional arguments not allowed: %v", args)
 		log.Logvf(log.Always, "try 'mongodump --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	// print help, if specified
@@ -85,14 +85,11 @@ func main() {
 
 	if err = dump.Init(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 
 	if err = dump.Dump(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		if err == util.ErrTerminated {
-			os.Exit(util.ExitKill)
-		}
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongoexport/main/mongoexport.go
+++ b/mongoexport/main/mongoexport.go
@@ -25,7 +25,7 @@ func main() {
 	opts, err := mongoexport.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, "try 'mongoexport --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongoexport"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -45,10 +45,8 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "%v", err)
 
-		if se, ok := err.(util.SetupError); ok {
-			if se.Message != "" {
-				log.Logv(log.Always, se.Message)
-			}
+		if se, ok := err.(util.SetupError); ok && se.Message != "" {
+			log.Logv(log.Always, se.Message)
 		}
 
 		os.Exit(util.ExitFailure)

--- a/mongoexport/main/mongoexport.go
+++ b/mongoexport/main/mongoexport.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongoexport --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	signals.Handle()
@@ -45,19 +45,20 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "%v", err)
 
-		if se, ok := err.(mongoexport.SetupError); ok {
-			os.Exit(se.Code)
+		if se, ok := err.(util.SetupError); ok {
+			if se.Message != "" {
+				log.Logv(log.Always, se.Message)
+			}
 		}
 
-		// default to ExitError if a different type of error was thrown
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	defer exporter.Close()
 
 	writer, err := exporter.GetOutputWriter()
 	if err != nil {
 		log.Logvf(log.Always, "error opening output stream: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	if writer == nil {
 		writer = os.Stdout
@@ -68,7 +69,7 @@ func main() {
 	numDocs, err := exporter.Export(writer)
 	if err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 
 	if numDocs == 1 {

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -88,17 +88,6 @@ type ExportOutput interface {
 	Flush() error
 }
 
-// SetupError is the error thrown by New to convey what error occurred and the appropriate exit code.
-type SetupError struct {
-	Err  error
-	Code int
-}
-
-// Error implements the error interface.
-func (se SetupError) Error() string {
-	return se.Err.Error()
-}
-
 // New constructs a new MongoExport instance from the provided options.
 func New(opts Options) (*MongoExport, error) {
 	exporter := &MongoExport{
@@ -109,17 +98,17 @@ func New(opts Options) (*MongoExport, error) {
 
 	err := exporter.validateSettings()
 	if err != nil {
-		return nil, SetupError{
-			Err:  err,
-			Code: util.ExitBadOptions,
+		return nil, util.SetupError{
+			Err:     err,
+			Message: "try 'mongoexport --help' for more information",
 		}
 	}
 
 	provider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		return nil, SetupError{
-			Err:  err,
-			Code: util.ExitError,
+		return nil, util.SetupError{
+			Err:     err,
+			Message: "",
 		}
 	}
 
@@ -128,9 +117,9 @@ func New(opts Options) (*MongoExport, error) {
 	isMongos, err := provider.IsMongos()
 	if err != nil {
 		provider.Close()
-		return nil, SetupError{
-			Err:  err,
-			Code: util.ExitError,
+		return nil, util.SetupError{
+			Err:     err,
+			Message: "",
 		}
 	}
 

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -100,16 +100,13 @@ func New(opts Options) (*MongoExport, error) {
 	if err != nil {
 		return nil, util.SetupError{
 			Err:     err,
-			Message: "try 'mongoexport --help' for more information",
+			Message: util.ShortUsage("mongoexport"),
 		}
 	}
 
 	provider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		return nil, util.SetupError{
-			Err:     err,
-			Message: "",
-		}
+		return nil, util.SetupError{Err: err}
 	}
 
 	log.Logvf(log.Always, "connected to: %v", opts.URI.ConnectionString)
@@ -117,10 +114,7 @@ func New(opts Options) (*MongoExport, error) {
 	isMongos, err := provider.IsMongos()
 	if err != nil {
 		provider.Close()
-		return nil, util.SetupError{
-			Err:     err,
-			Message: "",
-		}
+		return nil, util.SetupError{Err: err}
 	}
 
 	// warn if we are trying to export from a secondary in a sharded cluster

--- a/mongofiles/main/mongofiles.go
+++ b/mongofiles/main/mongofiles.go
@@ -26,7 +26,7 @@ func main() {
 	opts, err := mongofiles.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		log.Logv(log.Always, "try 'mongofiles --help' for more information")
+		log.Logv(log.Always, util.ShortUsage("mongofiles"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -45,10 +45,8 @@ func main() {
 	mf, err := mongofiles.New(opts)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		if setupErr, ok := err.(util.SetupError); ok {
-			if setupErr.Message != "" {
-				log.Logvf(log.Always, setupErr.Message)
-			}
+		if setupErr, ok := err.(util.SetupError); ok && setupErr.Message != "" {
+			log.Logvf(log.Always, setupErr.Message)
 		}
 		os.Exit(util.ExitFailure)
 	}

--- a/mongofiles/main/mongofiles.go
+++ b/mongofiles/main/mongofiles.go
@@ -26,31 +26,38 @@ func main() {
 	opts, err := mongofiles.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		os.Exit(util.ExitBadOptions)
+		log.Logv(log.Always, "try 'mongofiles --help' for more information")
+		os.Exit(util.ExitFailure)
 	}
 
 	signals.Handle()
 
 	// print help, if specified
 	if opts.PrintHelp(false) {
-		os.Exit(util.ExitClean)
+		os.Exit(util.ExitSuccess)
 	}
 
 	// print version, if specified
 	if opts.PrintVersion() {
-		os.Exit(util.ExitClean)
+		os.Exit(util.ExitSuccess)
 	}
 
 	mf, err := mongofiles.New(opts)
 	if err != nil {
 		log.Logv(log.Always, err.Error())
+		if setupErr, ok := err.(util.SetupError); ok {
+			if setupErr.Message != "" {
+				log.Logvf(log.Always, setupErr.Message)
+			}
+		}
+		os.Exit(util.ExitFailure)
 	}
 	defer mf.Close()
 
 	output, err := mf.Run(true)
 	if err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	fmt.Printf("%s", output)
 }

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -72,8 +72,7 @@ func New(opts Options) (*MongoFiles, error) {
 	// create a session provider to connect to the db
 	provider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		log.Logvf(log.Always, "error connecting to host: %v", err)
-		return nil, fmt.Errorf("error connecting to host: %v", err)
+		return nil, util.SetupError{Err: fmt.Errorf("error connecting to host: %v", err), Message: ""}
 	}
 
 	mf := &MongoFiles{
@@ -84,7 +83,7 @@ func New(opts Options) (*MongoFiles, error) {
 	}
 
 	if err := mf.ValidateCommand(opts.ParsedArgs); err != nil {
-		return nil, fmt.Errorf("%v\ntry 'mongofiles --help' for more information", err)
+		return nil, util.SetupError{Err: err, Message: "try 'mongofiles --help' for more information"}
 	}
 
 	return mf, nil

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -72,7 +72,7 @@ func New(opts Options) (*MongoFiles, error) {
 	// create a session provider to connect to the db
 	provider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		return nil, util.SetupError{Err: fmt.Errorf("error connecting to host: %v", err), Message: ""}
+		return nil, util.SetupError{Err: fmt.Errorf("error connecting to host: %v", err)}
 	}
 
 	mf := &MongoFiles{
@@ -83,7 +83,7 @@ func New(opts Options) (*MongoFiles, error) {
 	}
 
 	if err := mf.ValidateCommand(opts.ParsedArgs); err != nil {
-		return nil, util.SetupError{Err: err, Message: "try 'mongofiles --help' for more information"}
+		return nil, util.SetupError{Err: err, Message: util.ShortUsage("mongofiles")}
 	}
 
 	return mf, nil

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -46,7 +46,7 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 
 	args, err := opts.ParseArgs(rawArgs)
 	if err != nil {
-		return Options{}, fmt.Errorf("error parsing command line options: %v\ntry 'mongofiles --help' for more information", err)
+		return Options{}, fmt.Errorf("error parsing command line options: %v", err)
 	}
 
 	log.SetVerbosity(opts.Verbosity)

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -27,7 +27,7 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongoimport --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	signals.Handle()
@@ -45,7 +45,7 @@ func main() {
 	m, err := mongoimport.New(opts)
 	if err != nil {
 		log.Logvf(log.Always, err.Error())
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	defer m.Close()
 
@@ -61,6 +61,6 @@ func main() {
 		log.Logvf(log.Always, message)
 	}
 	if err != nil {
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -26,7 +26,7 @@ func main() {
 	opts, err := mongoimport.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, "try 'mongoimport --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongoimport"))
 		os.Exit(util.ExitFailure)
 	}
 

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -27,7 +27,7 @@ func main() {
 	if err != nil {
 		log.Logv(log.Always, err.Error())
 		log.Logvf(log.Always, "try 'mongorestore --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	// print help or version info, if specified
@@ -42,7 +42,7 @@ func main() {
 	restore, err := mongorestore.New(opts)
 	if err != nil {
 		log.Logvf(log.Always, err.Error())
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	defer restore.Close()
 
@@ -52,8 +52,8 @@ func main() {
 	if err = restore.Restore(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
 		if err == util.ErrTerminated {
-			os.Exit(util.ExitKill)
+			os.Exit(util.ExitFailure)
 		}
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -26,7 +26,7 @@ func main() {
 
 	if err != nil {
 		log.Logv(log.Always, err.Error())
-		log.Logvf(log.Always, "try 'mongorestore --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongorestore"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -51,9 +51,6 @@ func main() {
 
 	if err = restore.Restore(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		if err == util.ErrTerminated {
-			os.Exit(util.ExitFailure)
-		}
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -360,7 +360,7 @@ func (restore *MongoRestore) Restore() error {
 		target, err = newActualPath(restore.TargetDirectory)
 		if err != nil {
 			if usedDefaultTarget {
-				log.Logv(log.Always, "see mongorestore --help for usage information")
+				log.Logv(log.Always, util.ShortUsage("mongorestore"))
 			}
 			return fmt.Errorf("mongorestore target '%v' invalid: %v", restore.TargetDirectory, err)
 		}

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -79,7 +79,7 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongostat --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	log.SetVerbosity(opts.Verbosity)
@@ -90,16 +90,16 @@ func main() {
 		if len(args) != 1 {
 			log.Logvf(log.Always, "too many positional arguments: %v", args)
 			log.Logvf(log.Always, "try 'mongostat --help' for more information")
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 		sleepInterval, err = strconv.Atoi(args[0])
 		if err != nil {
 			log.Logvf(log.Always, "invalid sleep interval: %v", args[0])
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 		if sleepInterval < 1 {
 			log.Logvf(log.Always, "sleep interval must be at least 1 second")
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 	}
 
@@ -120,31 +120,31 @@ func main() {
 		// add logic to have different error if using uri
 		if opts.URI != nil && opts.URI.ConnectionString != "" {
 			log.Logvf(log.Always, "authSource is required when authenticating against a non $external database")
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 
 		log.Logvf(log.Always, "--authenticationDatabase is required when authenticating against a non $external database")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if statOpts.Interactive && statOpts.Json {
 		log.Logvf(log.Always, "cannot use output formats --json and --interactive together")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if statOpts.Deprecated && !statOpts.Json {
 		log.Logvf(log.Always, "--useDeprecatedJsonKeys can only be used when --json is also specified")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if statOpts.Columns != "" && statOpts.AppendColumns != "" {
 		log.Logvf(log.Always, "-O cannot be used if -o is also specified")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if statOpts.HumanReadable != "true" && statOpts.HumanReadable != "false" {
 		log.Logvf(log.Always, "--humanReadable must be set to either 'true' or 'false'")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	// we have to check this here, otherwise the user will be prompted
@@ -256,6 +256,6 @@ func main() {
 	formatter.Finish()
 	if err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -78,7 +78,7 @@ func main() {
 	args, err := opts.ParseArgs(os.Args[1:])
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, "try 'mongostat --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongostat"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -89,7 +89,7 @@ func main() {
 	if len(args) > 0 {
 		if len(args) != 1 {
 			log.Logvf(log.Always, "too many positional arguments: %v", args)
-			log.Logvf(log.Always, "try 'mongostat --help' for more information")
+			log.Logvf(log.Always, util.ShortUsage("mongostat"))
 			os.Exit(util.ExitFailure)
 		}
 		sleepInterval, err = strconv.Atoi(args[0])

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -244,7 +244,7 @@ func main() {
 	for _, v := range seedHosts {
 		if err := stat.AddNewNode(v); err != nil {
 			log.Logv(log.Always, err.Error())
-			os.Exit(util.ExitError)
+			os.Exit(util.ExitFailure)
 		}
 	}
 

--- a/mongostat/stat_consumer/stat_consumer.go
+++ b/mongostat/stat_consumer/stat_consumer.go
@@ -87,7 +87,7 @@ func (sc *StatConsumer) FormatLines(lines []*line.StatLine) bool {
 	_, err := fmt.Fprintf(sc.writer, "%s", str)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error writing formatted output: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	return sc.formatter.IsFinished()
 }

--- a/mongotop/main/mongotop.go
+++ b/mongotop/main/mongotop.go
@@ -39,7 +39,7 @@ func main() {
 	args, err := opts.ParseArgs(os.Args[1:])
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, "try 'mongotop --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongotop"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -61,7 +61,7 @@ func main() {
 
 	if len(args) > 1 {
 		log.Logvf(log.Always, "too many positional arguments")
-		log.Logvf(log.Always, "try 'mongotop --help' for more information")
+		log.Logvf(log.Always, util.ShortUsage("mongotop"))
 		os.Exit(util.ExitFailure)
 	}
 

--- a/mongotop/main/mongotop.go
+++ b/mongotop/main/mongotop.go
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		log.Logvf(log.Always, "error parsing command line options: %v", err)
 		log.Logvf(log.Always, "try 'mongotop --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	// print help, if specified
@@ -62,7 +62,7 @@ func main() {
 	if len(args) > 1 {
 		log.Logvf(log.Always, "too many positional arguments")
 		log.Logvf(log.Always, "try 'mongotop --help' for more information")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	sleeptime := 1 // default to 1 second sleep time
@@ -70,21 +70,21 @@ func main() {
 		sleeptime, err = strconv.Atoi(args[0])
 		if err != nil || sleeptime <= 0 {
 			log.Logvf(log.Always, "invalid sleep time: %v", args[0])
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 	}
 	if outputOpts.RowCount < 0 {
 		log.Logvf(log.Always, "invalid value for --rowcount: %v", outputOpts.RowCount)
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Auth.Username != "" && opts.Auth.Source == "" && !opts.Auth.RequiresExternalDB() {
 		if opts.URI != nil && opts.URI.ConnectionString != "" {
 			log.Logvf(log.Always, "authSource is required when authenticating against a non $external database")
-			os.Exit(util.ExitBadOptions)
+			os.Exit(util.ExitFailure)
 		}
 		log.Logvf(log.Always, "--authenticationDatabase is required when authenticating against a non $external database")
-		os.Exit(util.ExitBadOptions)
+		os.Exit(util.ExitFailure)
 	}
 
 	if opts.ReplicaSetName == "" {
@@ -95,18 +95,18 @@ func main() {
 	sessionProvider, err := db.NewSessionProvider(*opts)
 	if err != nil {
 		log.Logvf(log.Always, "error connecting to host: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 
 	// fail fast if connecting to a mongos
 	isMongos, err := sessionProvider.IsMongos()
 	if err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 	if isMongos {
 		log.Logvf(log.Always, "cannot run mongotop against a mongos")
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 
 	// instantiate a mongotop instance
@@ -120,6 +120,6 @@ func main() {
 	// kick it off
 	if err := top.Run(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)
-		os.Exit(util.ExitError)
+		os.Exit(util.ExitFailure)
 	}
 }

--- a/test/qa-tests/jstests/export/type_case.js
+++ b/test/qa-tests/jstests/export/type_case.js
@@ -33,7 +33,7 @@
     '--type="foobar"',
     '--fields', 'a']
     .concat(commonToolArgs));
-  assert.eq(3, ret);
+  assert.eq(1, ret);
 
   // create a dump file using a lowercase csv type
   ret = toolTest.runTool.apply(toolTest, ['export',

--- a/test/qa-tests/jstests/libs/output.js
+++ b/test/qa-tests/jstests/libs/output.js
@@ -1,14 +1,5 @@
-var exitCodeSuccess = 0;
-var exitCodeErr = 1;
-// Go reserves exit code 2 for its own use.
-var exitCodeBadOptions = 3;
-var exitCodeStopped = 4;
-
-// NOTE: On Windows, stopMongoProgramByPid doesn't terminate a process in a
-// way that it can control its exit code.
-if (_isWindows()) {
-  exitCodeStopped = exitCodeErr;
-}
+const exitCodeSuccess = 0;
+const exitCodeFailure = 1;
 
 // shellRowRegex matches all lines of shell output
 const shellRowRegex = /^sh\d+\|\s+/;

--- a/test/qa-tests/jstests/stat/stat_auth.js
+++ b/test/qa-tests/jstests/stat/stat_auth.js
@@ -26,5 +26,5 @@
   assert.eq(x, exitCodeSuccess, "mongostat should exit successfully with foobar:foobar");
 
   x = runMongoProgram.apply(null, args.concat("--password", "wrong"));
-  assert.eq(x, exitCodeErr, "mongostat should exit with an error exit code with foobar:wrong");
+  assert.eq(x, exitCodeFailure, "mongostat should exit with an error exit code with foobar:wrong");
 }());

--- a/test/qa-tests/jstests/stat/stat_custom_headers.js
+++ b/test/qa-tests/jstests/stat/stat_custom_headers.js
@@ -12,7 +12,7 @@
   var x, rows;
   x = runMongoProgram("mongostat", "--port", port,
     "-o", "host,conn,time", "-O", "metrics.record.moves");
-  assert.eq(x, exitCodeBadOptions, "mongostat should fail with both -o and -O options");
+  assert.eq(x, exitCodeFailure, "mongostat should fail with both -o and -O options");
   clearRawMongoProgramOutput();
 
   // basic -o --humanReadable=false

--- a/test/qa-tests/jstests/stat/stat_discover_shard.js
+++ b/test/qa-tests/jstests/stat/stat_discover_shard.js
@@ -16,5 +16,5 @@
 
   st.stop();
   assert.soon(hasOnlyPorts([]), "stops showing data when hosts come down");
-  assert.eq(exitCodeStopped, stopMongoProgramByPid(pid), "mongostat --discover against a sharded cluster shouldn't error when the cluster goes down");
+  assert.eq(exitCodeFailure, stopMongoProgramByPid(pid), "mongostat --discover against a sharded cluster should error when the cluster goes down");
 }());

--- a/test/qa-tests/jstests/stat/stat_rowcount.js
+++ b/test/qa-tests/jstests/stat/stat_rowcount.js
@@ -28,19 +28,19 @@
 
   pid = startMongoProgramNoConnect.apply(null, ["mongostat", "--port", toolTest.port].concat(commonToolArgs));
   assert.strContains.soon('sh'+pid+'|  ', rawMongoProgramOutput, "should produce some output");
-  assert.eq(exitCodeStopped, stopMongoProgramByPid(pid), "stopping should cause mongostat exit with a 'stopped' code");
+  assert.eq(exitCodeFailure, stopMongoProgramByPid(pid), "stopping should cause mongostat exit with a 'failure' code");
 
   x = runMongoProgram.apply(null, ["mongostat", "--port", toolTest.port - 1, "--rowcount", 1].concat(commonToolArgs));
   assert.neq(exitCodeSuccess, x, "can't connect causes an error exit code");
 
   x = runMongoProgram.apply(null, ["mongostat", "--rowcount", "-1"].concat(commonToolArgs));
-  assert.eq(exitCodeBadOptions, x, "mongostat --rowcount specified with bad input: negative value");
+  assert.eq(exitCodeFailure, x, "mongostat --rowcount specified with bad input: negative value");
 
   x = runMongoProgram.apply(null, ["mongostat", "--rowcount", "foobar"].concat(commonToolArgs));
-  assert.eq(exitCodeBadOptions, x, "mongostat --rowcount specified with bad input: non-numeric value");
+  assert.eq(exitCodeFailure, x, "mongostat --rowcount specified with bad input: non-numeric value");
 
   x = runMongoProgram.apply(null, ["mongostat", "--host", "badreplset/127.0.0.1:" + toolTest.port, "--rowcount", 1].concat(commonToolArgs));
-  assert.eq(exitCodeErr, x, "--host used with a replica set string for nodes not in a replica set");
+  assert.eq(exitCodeFailure, x, "--host used with a replica set string for nodes not in a replica set");
 
   pid = startMongoProgramNoConnect.apply(null, ["mongostat", "--host", "127.0.0.1:" + toolTest.port].concat(commonToolArgs));
   assert.strContains.soon('sh'+pid+'|  ', rawMongoProgramOutput, "should produce some output");
@@ -54,5 +54,5 @@
   const rows = allDefaultStatRows();
   assert.eq(rows.length, 0, "should stop showing new stat lines, showed " + JSON.stringify(rows) + " instead.");
 
-  assert.eq(exitCodeStopped, stopMongoProgramByPid(pid), "mongostat shouldn't error out when the server goes down");
+  assert.eq(exitCodeFailure, stopMongoProgramByPid(pid), "mongostat should return a failure code when server goes down");
 }());

--- a/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
@@ -55,7 +55,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	case sig := <-sigChan:
 		// second signal exits immediately
 		log.Logvf(log.Always, "signal '%s' received; forcefully terminating", sig)
-		os.Exit(util.ExitKill)
+		os.Exit(util.ExitFailure)
 	case <-finishedChan:
 		return
 	}

--- a/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
@@ -55,7 +55,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	case sig := <-sigChan:
 		// second signal exits immediately
 		log.Logvf(log.Always, "signal '%s' received; forcefully terminating", sig)
-		os.Exit(util.ExitFailure)
+		os.Exit(util.ExitKill)
 	case <-finishedChan:
 		return
 	}

--- a/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
@@ -11,24 +11,21 @@ import (
 )
 
 const (
-	ExitSuccess int = iota
-	ExitFailure
+	ExitError      int = 1
+	ExitClean      int = 0
+	ExitBadOptions int = 3
+	ExitKill       int = 4
+	// Go reserves exit code 2 for its own use
 )
 
 var (
 	ErrTerminated = errors.New("received termination signal")
 )
 
-func ShortUsage(tool string) string {
-	return "try '" + tool + " --help' for more information"
-}
-
 // SetupError is the error thrown by "New" functions used to convey what error occurred and the appropriate exit code.
 type SetupError struct {
-	Err error
-
-	// An optional message to be logged before exiting
-	Message string
+	Err  error
+	Code int
 }
 
 // Error implements the error interface.

--- a/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
@@ -11,13 +11,23 @@ import (
 )
 
 const (
-	ExitError      int = 1
-	ExitClean      int = 0
-	ExitBadOptions int = 3
-	ExitKill       int = 4
-	// Go reserves exit code 2 for its own use
+	ExitFailure int = 1
+	ExitSuccess int = 0
 )
 
 var (
 	ErrTerminated = errors.New("received termination signal")
 )
+
+// SetupError is the error thrown by "New" functions used to convey what error occurred and the appropriate exit code.
+type SetupError struct {
+	Err error
+
+	// An optional message to be logged before exiting
+	Message string
+}
+
+// Error implements the error interface.
+func (se SetupError) Error() string {
+	return se.Err.Error()
+}

--- a/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
@@ -11,21 +11,24 @@ import (
 )
 
 const (
-	ExitError      int = 1
-	ExitClean      int = 0
-	ExitBadOptions int = 3
-	ExitKill       int = 4
-	// Go reserves exit code 2 for its own use
+	ExitSuccess int = iota
+	ExitFailure
 )
 
 var (
 	ErrTerminated = errors.New("received termination signal")
 )
 
+func ShortUsage(tool string) string {
+	return "try '" + tool + " --help' for more information"
+}
+
 // SetupError is the error thrown by "New" functions used to convey what error occurred and the appropriate exit code.
 type SetupError struct {
-	Err  error
-	Code int
+	Err error
+
+	// An optional message to be logged before exiting
+	Message string
 }
 
 // Error implements the error interface.

--- a/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/util/exit_code.go
@@ -11,13 +11,17 @@ import (
 )
 
 const (
-	ExitFailure int = 1
-	ExitSuccess int = 0
+	ExitSuccess int = iota
+	ExitFailure
 )
 
 var (
 	ErrTerminated = errors.New("received termination signal")
 )
+
+func ShortUsage(tool string) string {
+	return "try '" + tool + " --help' for more information"
+}
 
 // SetupError is the error thrown by "New" functions used to convey what error occurred and the appropriate exit code.
 type SetupError struct {


### PR DESCRIPTION
[TOOLS-2253](https://jira.mongodb.org/TOOLS-2253)

The new exit codes are `util.ExitFailure` (1) and `util.ExitSuccess` (0)