### PR TITLE
TOOLS-2285 / TOOLS-2132 Read preference parsing improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,8 +103,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ae1534940300acfbddb8a972b0b17d20fe754f26a594d8d9e0e06e31087b7eb5"
+  branch = "TOOLS-2285-readpref-fixes"
+  digest = "1:0f7fe0d90dc37cabf4b4d659a3d073d0cf6f3f592552fc0bc4496d6e58a02387"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "9c6c7b99417fccda7b763f0b7bd709ef46390fd4"
+  revision = "10f1f7c6ab8b0a992aa7cc32c70b21a1a91e2bab"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"
@@ -319,7 +319,6 @@
     "go.mongodb.org/mongo-driver/mongo/readpref",
     "go.mongodb.org/mongo-driver/mongo/writeconcern",
     "go.mongodb.org/mongo-driver/x/bsonx",
-    "go.mongodb.org/mongo-driver/x/network/connstring",
     "golang.org/x/crypto/ssh/terminal",
     "gopkg.in/mgo.v2/bson",
     "gopkg.in/tomb.v2",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,7 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "TOOLS-2285-readpref-fixes"
+  branch = "master"
   digest = "1:0f7fe0d90dc37cabf4b4d659a3d073d0cf6f3f592552fc0bc4496d6e58a02387"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  branch = "TOOLS-2285-readpref-fixes"
+  branch = "master"
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  branch = "master"
+  branch = "TOOLS-2285-readpref-fixes"
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"

--- a/mongodump/options.go
+++ b/mongodump/options.go
@@ -7,9 +7,6 @@
 package mongodump
 
 import (
-	"github.com/mongodb/mongo-tools-common/options"
-	"go.mongodb.org/mongo-driver/x/network/connstring"
-
 	"fmt"
 	"io/ioutil"
 )
@@ -26,21 +23,13 @@ See http://docs.mongodb.org/manual/reference/program/mongodump/ for more informa
 type InputOptions struct {
 	Query          string `long:"query" short:"q" description:"query filter, as a JSON string, e.g., '{x:{$gt:1}}'"`
 	QueryFile      string `long:"queryFile" description:"path to a file containing a query filter (JSON)"`
-	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference name or a preference json object"`
+	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: \"nearest\", tagSets: [{a: \"b\"}], maxStalenessSeconds: 123}')"`
 	TableScan      bool   `long:"forceTableScan" description:"force a table scan"`
 }
 
 // Name returns a human-readable group name for input options.
 func (*InputOptions) Name() string {
 	return "query"
-}
-
-func (inputOpts *InputOptions) SetOptionsFromURI(cs connstring.ConnString) error {
-	if inputOpts.ReadPreference != "" {
-		return fmt.Errorf(options.IncompatibleArgsErrorFormat, "--readPreference")
-	}
-	inputOpts.ReadPreference = cs.ReadPreference
-	return nil
 }
 
 func (inputOptions *InputOptions) HasQuery() bool {

--- a/mongoexport/options.go
+++ b/mongoexport/options.go
@@ -61,7 +61,7 @@ type InputOptions struct {
 	Query          string `long:"query" value-name:"<json>" short:"q" description:"query filter, as a JSON string, e.g., '{x:{$gt:1}}'"`
 	QueryFile      string `long:"queryFile" value-name:"<filename>" description:"path to a file containing a query filter (JSON)"`
 	SlaveOk        bool   `long:"slaveOk" short:"k" description:"allow secondary reads if available (default true)" default:"false" default-mask:"-"`
-	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference name or a preference json object"`
+	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: \"nearest\", tagSets: [{a: \"b\"}], maxStalenessSeconds: 123}')"`
 	ForceTableScan bool   `long:"forceTableScan" description:"force a table scan (do not use $snapshot)"`
 	Skip           int64  `long:"skip" value-name:"<count>" description:"number of documents to skip"`
 	Limit          int64  `long:"limit" value-name:"<count>" description:"limit the number of documents to export"`

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -111,7 +111,7 @@ func (*StorageOptions) Name() string {
 
 // InputOptions defines the set of options to use in retrieving data from the server.
 type InputOptions struct {
-	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference name or a preference json object"`
+	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: \"nearest\", tagSets: [{a: \"b\"}], maxStalenessSeconds: 123}')"`
 }
 
 // Name returns a human-readable group name for input options.

--- a/test/qa-tests/jstests/dump/read_preference_and_tags.js
+++ b/test/qa-tests/jstests/dump/read_preference_and_tags.js
@@ -37,7 +37,7 @@
 
   rs.reconfig(conf);
 
-  runMongoProgram('mongodump', '-vvvv', '--host', "replset/"+primary.host, '--readPreference={mode:"nearest", tags:{use:"secondary1"}}');
+  runMongoProgram('mongodump', '-vvvv', '--host', "replset/"+primary.host, '--readPreference={mode:"nearest", tagSets:[{use:"secondary1"}]}');
 
   var primaryCount = 0;
   var secondaryCount = 0;


### PR DESCRIPTION
This PR does the following:
- fixes the bug where a "primary" mode read preference could not be set
- fixes the bug where mongodump could not specify a read preference both in the uri and via --readPreference
- allows maxStalenessSeconds to be set via --readPreference
- allows multiple tag sets to be set via --readPreference
- updates the help output to describe how one should pass things in via --readPreference

The new help output is the following:
`      --readPreference=<string>|<json>            specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: "nearest", tagSets: [{a: "b"}], maxStalenessSeconds: 123}')`

Check the vendor files for the parsing changes. I have some unit tests written not present in this PR that will be go into mongo-tools-common once this is approved. 