### PR TITLE
TOOLS-2246 Rework maintainInsertionOrder and stopOnError

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,7 +104,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0f7fe0d90dc37cabf4b4d659a3d073d0cf6f3f592552fc0bc4496d6e58a02387"
+  digest = "1:882213a313a027a54622cfb7ed320cb93fbbfd5e4d4a1588e3a1397882d107cd"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "10f1f7c6ab8b0a992aa7cc32c70b21a1a91e2bab"
+  revision = "08e3232eed777bffd5672413a144e51d1d65daad"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 
 	"github.com/mongodb/mongo-tools-common/bsonutil"
-	"github.com/mongodb/mongo-tools-common/db"
 	"github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/util"
 	"go.mongodb.org/mongo-driver/bson"
@@ -233,30 +232,6 @@ func getUpsertValue(field string, document bson.D) interface{} {
 		log.Logvf(log.DebugHigh, "subdoc found for '%v', but couldn't coerce to bson.D", left)
 		return nil
 	}
-}
-
-// filterIngestError accepts a boolean indicating if a non-nil error should be,
-// returned as an actual error.
-//
-// If the error indicates an unreachable server, it returns that immediately.
-//
-// If the error indicates an invalid write concern was passed, it returns nil
-//
-// If the error is not nil, it logs the error. If the error is an io.EOF error -
-// indicating a lost connection to the server, it sets the error as such.
-//
-func filterIngestError(stopOnError bool, err error) error {
-	if err == nil {
-		return nil
-	}
-	if err.Error() == io.EOF.Error() {
-		return fmt.Errorf(db.ErrLostConnection)
-	}
-	if stopOnError || db.IsConnectionError(err) {
-		return err
-	}
-	log.Logvf(log.Always, "error inserting documents: %v", err)
-	return nil
 }
 
 // removeBlankFields takes document and returns a new copy in which

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -7,11 +7,9 @@
 package mongoimport
 
 import (
-	"fmt"
 	"io"
 	"testing"
 
-	"github.com/mongodb/mongo-tools-common/db"
 	"github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools-common/testtype"
@@ -585,33 +583,6 @@ func TestChannelQuorumError(t *testing.T) {
 			ch <- nil
 			ch <- io.EOF
 			So(channelQuorumError(ch, 2), ShouldBeNil)
-		})
-	})
-}
-
-func TestFilterIngestError(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
-
-	Convey("Given a boolean 'stopOnError' and an error...", t, func() {
-
-		Convey("an error should be returned if stopOnError is true the err is not nil", func() {
-			So(filterIngestError(true, fmt.Errorf("")), ShouldNotBeNil)
-		})
-
-		Convey("errLostConnection should be returned if stopOnError is true the err is io.EOF", func() {
-			So(filterIngestError(true, io.EOF).Error(), ShouldEqual, db.ErrLostConnection)
-		})
-
-		Convey("no error should be returned if stopOnError is false the err is not nil", func() {
-			So(filterIngestError(false, fmt.Errorf("")), ShouldBeNil)
-		})
-
-		Convey("no error should be returned if stopOnError is false the err is nil", func() {
-			So(filterIngestError(false, nil), ShouldBeNil)
-		})
-
-		Convey("no error should be returned if stopOnError is true the err is nil", func() {
-			So(filterIngestError(true, nil), ShouldBeNil)
 		})
 	})
 }

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/mongodb/mongo-tools-common/log"
@@ -49,16 +48,16 @@ func main() {
 	}
 	defer m.Close()
 
-	numDocs, err := m.ImportDocuments()
+	numDocs, numFailure, err := m.ImportDocuments()
 	if !opts.Quiet {
 		if err != nil {
 			log.Logvf(log.Always, "Failed: %v", err)
 		}
-		message := fmt.Sprintf("imported 1 document")
-		if numDocs != 1 {
-			message = fmt.Sprintf("imported %v documents", numDocs)
+		if m.ToolOptions.WriteConcern.Acknowledged() {
+			log.Logvf(log.Always, "%v document(s) imported successfully. %v document(s) failed to import.", numDocs, numFailure)
+		} else {
+			log.Logvf(log.Always, "done")
 		}
-		log.Logvf(log.Always, message)
 	}
 	if err != nil {
 		os.Exit(util.ExitFailure)

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -475,7 +475,8 @@ readLoop:
 			if !alive {
 				break readLoop
 			}
-			if err := db.FilterError(imp.IngestOptions.StopOnError, imp.importDocument(inserter, document)); err != nil {
+			err := imp.importDocument(inserter, document)
+			if db.FilterError(imp.IngestOptions.StopOnError, err) != nil {
 				return err
 			}
 		case <-imp.Dying():

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -64,13 +64,13 @@ type IngestOptions struct {
 	IgnoreBlanks bool `long:"ignoreBlanks" description:"ignore fields with empty values in CSV and TSV"`
 
 	// Indicates that documents will be inserted in the order of their appearance in the input source.
-	MaintainInsertionOrder bool `long:"maintainInsertionOrder" description:"insert documents in the order of their appearance in the input source"`
+	MaintainInsertionOrder bool `long:"maintainInsertionOrder" description:"insert the documents in the order of their appearance in the input source. By default the insertions will be performed in an arbitrary order. Setting this flag also enables the behavior of --stopOnError and restricts NumInsertionWorkers to 1."`
 
 	// Sets the number of insertion routines to use
 	NumInsertionWorkers int `short:"j" value-name:"<number>" long:"numInsertionWorkers" description:"number of insert operations to run concurrently (defaults to 1)" default:"1" default-mask:"-"`
 
 	// Forces mongoimport to halt the import operation at the first insert or upsert error.
-	StopOnError bool `long:"stopOnError" description:"stop importing at first insert/upsert error"`
+	StopOnError bool `long:"stopOnError" description:"halt after encountering any error during importing. By default, mongoimport will attempt to continue through document validation and DuplicateKey errors, but with this option enabled, the tool will stop instead. A small number of documents may be inserted after encountering an error even with this option enabled; use --maintainInsertionOrder to halt immediately after an error"`
 
 	// Modify the import process.
 	// Always insert the documents if they are new (do NOT match --upsertFields).

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -49,8 +49,19 @@ func main() {
 	finishedChan := signals.HandleWithInterrupt(restore.HandleInterrupt)
 	defer close(finishedChan)
 
-	if err = restore.Restore(); err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+	result := restore.Restore()
+	if result.Err != nil {
+		log.Logvf(log.Always, "Failed: %v", result.Err)
+	}
+
+	if restore.ToolOptions.WriteConcern.Acknowledged() {
+		log.Logvf(log.Always, "%v document(s) restored successfully. %v document(s) failed to restore.", result.Successes, result.Failures)
+	} else {
+		log.Logvf(log.Always, "done")
+	}
+
+	if result.Err != nil {
 		os.Exit(util.ExitFailure)
 	}
+	os.Exit(util.ExitSuccess)
 }

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -378,8 +378,8 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 
 		log.Logvf(log.DebugLow, "restoring %v to temporary collection", arg.intentType)
 		result := restore.RestoreCollectionToDB("admin", arg.tempCollectionName, bsonSource, arg.intent.BSONFile, 0)
-		if result.err != nil {
-			return fmt.Errorf("error restoring %v: %v", arg.intentType, result.err)
+		if result.Err != nil {
+			return fmt.Errorf("error restoring %v: %v", arg.intentType, result.Err)
 		}
 
 		// make sure we always drop the temporary collection

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -377,8 +377,9 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 		}
 
 		log.Logvf(log.DebugLow, "restoring %v to temporary collection", arg.intentType)
-		if _, err = restore.RestoreCollectionToDB("admin", arg.tempCollectionName, bsonSource, arg.intent.BSONFile, 0); err != nil {
-			return fmt.Errorf("error restoring %v: %v", arg.intentType, err)
+		result := restore.RestoreCollectionToDB("admin", arg.tempCollectionName, bsonSource, arg.intent.BSONFile, 0)
+		if result.err != nil {
+			return fmt.Errorf("error restoring %v: %v", arg.intentType, result.err)
 		}
 
 		// make sure we always drop the temporary collection

--- a/mongorestore/mongorestore_archive_test.go
+++ b/mongorestore/mongorestore_archive_test.go
@@ -71,11 +71,11 @@ func TestMongorestoreShortArchive(t *testing.T) {
 				In:      ioutil.NopCloser(io.LimitReader(file, i)),
 			}
 
-			err = restore.Restore()
+			result := restore.Restore()
 			if i == fileSize {
-				So(err, ShouldBeNil)
+				So(result.Err, ShouldBeNil)
 			} else {
-				So(err, ShouldNotBeNil)
+				So(result.Err, ShouldNotBeNil)
 			}
 			restore.Close()
 		}
@@ -98,7 +98,9 @@ func TestMongorestoreArchiveWithOplog(t *testing.T) {
 		restore, err := getRestoreWithArgs(args...)
 		So(err, ShouldBeNil)
 
-		err = restore.Restore()
-		So(err, ShouldBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldBeNil)
+		So(result.Failures, ShouldEqual, 0)
+		So(result.Successes, ShouldNotEqual, 0)
 	})
 }

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -74,8 +74,10 @@ func TestMongorestore(t *testing.T) {
 		c1.Drop(nil)
 		Convey("and an explicit target restores from that dump directory", func() {
 			restore.TargetDirectory = "testdata/testdirs"
-			err = restore.Restore()
-			So(err, ShouldBeNil)
+			result := restore.Restore()
+			So(result.Err, ShouldBeNil)
+			So(result.Successes, ShouldEqual, 100)
+			So(result.Failures, ShouldEqual, 0)
 			count, err := c1.CountDocuments(nil, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 100)
@@ -88,8 +90,8 @@ func TestMongorestore(t *testing.T) {
 			So(err, ShouldBeNil)
 			restore.InputReader = bsonFile
 			restore.TargetDirectory = "-"
-			err = restore.Restore()
-			So(err, ShouldBeNil)
+			result := restore.Restore()
+			So(result.Err, ShouldBeNil)
 			count, err := c1.CountDocuments(nil, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 100)
@@ -119,8 +121,8 @@ func TestMongorestoreCantPreserveUUID(t *testing.T) {
 		restore, err := getRestoreWithArgs(args...)
 		So(err, ShouldBeNil)
 
-		err = restore.Restore()
-		So(err, ShouldNotBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "target host does not support --preserveUUID")
 	})
 }
@@ -152,8 +154,8 @@ func TestMongorestorePreserveUUID(t *testing.T) {
 			restore, err := getRestoreWithArgs(args...)
 			So(err, ShouldBeNil)
 
-			err = restore.Restore()
-			So(err, ShouldBeNil)
+			result := restore.Restore()
+			So(result.Err, ShouldBeNil)
 			count, err := c1.CountDocuments(nil, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 5)
@@ -172,9 +174,9 @@ func TestMongorestorePreserveUUID(t *testing.T) {
 			restore, err := getRestoreWithArgs(args...)
 			So(err, ShouldBeNil)
 
-			err = restore.Restore()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "cannot specify --preserveUUID without --drop")
+			result := restore.Restore()
+			So(result.Err, ShouldNotBeNil)
+			So(result.Err.Error(), ShouldContainSubstring, "cannot specify --preserveUUID without --drop")
 		})
 
 		Convey("PreserveUUID with drop preserves UUID", func() {
@@ -188,8 +190,8 @@ func TestMongorestorePreserveUUID(t *testing.T) {
 			restore, err := getRestoreWithArgs(args...)
 			So(err, ShouldBeNil)
 
-			err = restore.Restore()
-			So(err, ShouldBeNil)
+			result := restore.Restore()
+			So(result.Err, ShouldBeNil)
 			count, err := c1.CountDocuments(nil, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 5)
@@ -209,9 +211,9 @@ func TestMongorestorePreserveUUID(t *testing.T) {
 			restore, err := getRestoreWithArgs(args...)
 			So(err, ShouldBeNil)
 
-			err = restore.Restore()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "--preserveUUID used but no UUID found")
+			result := restore.Restore()
+			So(result.Err, ShouldNotBeNil)
+			So(result.Err.Error(), ShouldContainSubstring, "--preserveUUID used but no UUID found")
 		})
 
 	})
@@ -293,8 +295,10 @@ func TestMongorestoreMIOSOE(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(restore.OutputOptions.MaintainInsertionOrder, ShouldBeFalse)
 
-		err = restore.Restore()
-		So(err, ShouldBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldBeNil)
+		So(result.Successes, ShouldEqual, 20000)
+		So(result.Failures, ShouldEqual, 1)
 
 		count, err := coll.CountDocuments(nil, bson.M{})
 		So(err, ShouldBeNil)
@@ -311,8 +315,10 @@ func TestMongorestoreMIOSOE(t *testing.T) {
 		So(restore.OutputOptions.MaintainInsertionOrder, ShouldBeTrue)
 		So(restore.OutputOptions.NumInsertionWorkers, ShouldEqual, 1)
 
-		err = restore.Restore()
-		So(err, ShouldNotBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldNotBeNil)
+		So(result.Successes, ShouldEqual, 10000)
+		So(result.Failures, ShouldEqual, 1)
 
 		count, err := coll.CountDocuments(nil, bson.M{})
 		So(err, ShouldBeNil)
@@ -329,8 +335,10 @@ func TestMongorestoreMIOSOE(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(restore.OutputOptions.StopOnError, ShouldBeTrue)
 
-		err = restore.Restore()
-		So(err, ShouldNotBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldNotBeNil)
+		So(result.Successes, ShouldAlmostEqual, 10000, restore.OutputOptions.BulkBufferSize)
+		So(result.Failures, ShouldEqual, 1)
 
 		count, err := coll.CountDocuments(nil, bson.M{})
 		So(err, ShouldBeNil)

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -105,7 +105,7 @@ func (restore *MongoRestore) RestoreOplog() error {
 		fileNeedsIOBuffer.ReleaseIOBuffer()
 	}
 
-	log.Logvf(log.Info, "applied %v ops", totalOps)
+	log.Logvf(log.Always, "applied %v oplog entries", totalOps)
 	if err := bsonSource.Err(); err != nil {
 		return fmt.Errorf("error reading oplog bson input: %v", err)
 	}

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -155,8 +155,9 @@ func TestOplogRestore(t *testing.T) {
 		c1.Drop(nil)
 
 		// Run mongorestore
-		err = restore.Restore()
-		So(err, ShouldBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldBeNil)
+		So(result.Failures, ShouldEqual, 0)
 
 		// Verify restoration
 		count, err := c1.CountDocuments(nil, bson.M{})
@@ -185,7 +186,8 @@ func TestOplogRestoreTools2002(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Run mongorestore
-		err = restore.Restore()
-		So(err, ShouldBeNil)
+		result := restore.Restore()
+		So(result.Err, ShouldBeNil)
+		So(result.Failures, ShouldEqual, 0)
 	})
 }

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -92,10 +92,10 @@ type OutputOptions struct {
 	NoIndexRestore           bool   `long:"noIndexRestore" description:"don't restore indexes"`
 	NoOptionsRestore         bool   `long:"noOptionsRestore" description:"don't restore collection options"`
 	KeepIndexVersion         bool   `long:"keepIndexVersion" description:"don't update index version"`
-	MaintainInsertionOrder   bool   `long:"maintainInsertionOrder" description:"preserve order of documents during restoration"`
+	MaintainInsertionOrder   bool   `long:"maintainInsertionOrder" description:"restore the documents in the order of their appearance in the input source. By default the insertions will be performed in an arbitrary order. Setting this flag also enables the behavior of --stopOnError and restricts NumInsertionWorkersPerCollection to 1."`
 	NumParallelCollections   int    `long:"numParallelCollections" short:"j" description:"number of collections to restore in parallel (4 by default)" default:"4" default-mask:"-"`
 	NumInsertionWorkers      int    `long:"numInsertionWorkersPerCollection" description:"number of insert operations to run concurrently per collection (1 by default)" default:"1" default-mask:"-"`
-	StopOnError              bool   `long:"stopOnError" description:"stop restoring if an error is encountered on insert (off by default)"`
+	StopOnError              bool   `long:"stopOnError" description:"halt after encountering any error during insertion. By default, mongorestore will attempt to continue through document validation and DuplicateKey errors, but with this option enabled, the tool will stop instead. A small number of documents may be inserted after encountering an error even with this option enabled; use --maintainInsertionOrder to halt immediately after an error"`
 	BypassDocumentValidation bool   `long:"bypassDocumentValidation" description:"bypass document validation"`
 	PreserveUUID             bool   `long:"preserveUUID" description:"preserve original collection UUIDs (off by default, requires drop)"`
 	TempUsersColl            string `long:"tempUsersColl" default:"tempusers" hidden:"true"`

--- a/test/qa-tests/jstests/restore/restore_document_validation.js
+++ b/test/qa-tests/jstests/restore/restore_document_validation.js
@@ -177,4 +177,46 @@
   assert.eq(0, ret, 'restoring documents should work with bypass document validation set');
   assert.eq(1000, testDB.bar.count(),
     'all documents should be restored with bypass document validation set');
+  testDB.dropDatabase();
+
+  /**
+   * Part 5: Test that restore will stop inserting when getting validation errors if --stopOnError is enabled.
+   */
+  // turn on validation
+  r = testDB.createCollection('bar', {validator: {baz: {$exists: true}}});
+  assert.eq(r, {ok: 1}, 'create collection with validation should work');
+
+  // test that we cannot insert an 'invalid' document
+  r = testDB.bar.insert({num: 10000});
+  assert.eq(r.nInserted, 0, 'invalid documents should not be inserted');
+
+  // restore the 1000 records again with bypassDocumentValidation turned on
+  ret = toolTest.runTool.apply(toolTest, ['restore',
+    '--file', toolTest.extFile,
+    '--db', testDB.toString(),
+    '-c', 'bar',
+    '--stopOnError']
+    .concat(commonToolArgs));
+  assert.neq(0, ret,
+    'restoring documents should report documentation validation errors when using --stopOnError');
+  testDB.dropDatabase();
+
+  /**
+   * Part 6: Test that restore will stop inserting when getting validation errors if --maintainInsertionOrder is enabled.
+   */
+  r = testDB.createCollection('bar', {validator: {baz: {$exists: true}}});
+  assert.eq(r, {ok: 1}, 'create collection with validation should work');
+
+  // test that we cannot insert an 'invalid' document
+  r = testDB.bar.insert({num: 10000});
+  assert.eq(r.nInserted, 0, 'invalid documents should not be inserted');
+
+  // import the 1000 records again with bypassDocumentValidation turned on
+  ret = toolTest.runTool.apply(toolTest, ['restore',
+    '--file', toolTest.extFile,
+    '--db', 'test',
+    '-c', 'bar',
+    '--maintainInsertionOrder']
+    .concat(commonToolArgs));
+  assert.neq(0, ret, 'restoring documents should report documentation validation errors when using --maintainInsertionOrder');
 }());

--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -285,7 +285,12 @@ func CanIgnoreError(err error) bool {
 				return false
 			}
 		}
-		return mongoErr.WriteConcernError == nil
+
+		if mongoErr.WriteConcernError != nil {
+			log.Logvf(log.Always, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
+			return false
+		}
+		return true
 	case mongo.CommandError:
 		_, ok := ignorableWriteErrorCodes[int(mongoErr.Code)]
 		return ok

--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -11,10 +11,11 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
-	"go.mongodb.org/mongo-driver/x/network/connection"
-
+	"github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools-common/password"
 	"go.mongodb.org/mongo-driver/bson"
@@ -22,11 +23,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	mopt "go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-
-	"fmt"
-	"io"
-	"strings"
-	"sync"
+	"go.mongodb.org/mongo-driver/x/network/connection"
 )
 
 type (
@@ -66,6 +63,17 @@ const (
 	ErrUnableToTargetPrefix         = "unable to target"
 	ErrNotMaster                    = "not master"
 	ErrConnectionRefusedSuffix      = "Connection refused"
+
+	// ignorable errors
+	ErrDuplicateKeyCode         = 11000
+	ErrFailedDocumentValidation = 121
+	ErrUnacknowledgedWrite      = "unacknowledged write"
+)
+
+var ignorableWriteErrorCodes = map[int]bool{ErrDuplicateKeyCode: true, ErrFailedDocumentValidation: true}
+
+const (
+	continueThroughErrorFormat = "continuing through error: %v"
 )
 
 // Used to manage database sessions
@@ -237,32 +245,51 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 	return mongo.NewClient(uriOpts, clientopt)
 }
 
-// IsConnectionError returns a boolean indicating if a given error is due to
-// an error in an underlying DB connection (as opposed to some other write
-// failure such as a duplicate key error)
-func IsConnectionError(err error) bool {
+// FilterError determines whether an error needs to be propagated back to the user or can be continued through. If an
+// error cannot be ignored, a non-nil error is returned. If an error can be continued through, it is logged and nil is
+// returned.
+func FilterError(stopOnError bool, err error) error {
+	if err == nil || err.Error() == ErrUnacknowledgedWrite {
+		return nil
+	}
+
+	if !stopOnError && CanIgnoreError(err) {
+		// Just log the error but don't propagate it.
+		if bwe, ok := err.(mongo.BulkWriteException); ok {
+			for _, be := range bwe.WriteErrors {
+				log.Logvf(log.Always, continueThroughErrorFormat, be.Message)
+			}
+		} else {
+			log.Logvf(log.Always, continueThroughErrorFormat, err)
+		}
+		return nil
+	}
+	// Propagate this error, since it's either a fatal error or the user has turned on --stopOnError
+	return err
+}
+
+// Returns whether the tools can continue when encountering the given error.
+// Currently, only DuplicateKeyErrors are ignorable.
+func CanIgnoreError(err error) bool {
 	if err == nil {
-		return false
-	}
-
-	// The new driver stringifies command errors as "(Name) Message" rather than just "message". Cast to the
-	// CommandError type if possible to extract the correct error message.
-	errMsg := err.Error()
-	if cmdErr, ok := err.(mongo.CommandError); ok {
-		errMsg = cmdErr.Message
-	}
-
-	lowerCaseError := strings.ToLower(errMsg)
-	if lowerCaseError == ErrNoReachableServers ||
-		err == io.EOF ||
-		strings.Contains(lowerCaseError, ErrReplTimeoutPrefix) ||
-		strings.Contains(lowerCaseError, ErrCouldNotContactPrimaryPrefix) ||
-		strings.Contains(lowerCaseError, ErrWriteResultsUnavailable) ||
-		strings.Contains(lowerCaseError, ErrCouldNotFindPrimaryPrefix) ||
-		strings.Contains(lowerCaseError, ErrUnableToTargetPrefix) ||
-		strings.Contains(lowerCaseError, ErrNotMaster) ||
-		strings.HasSuffix(lowerCaseError, ErrConnectionRefusedSuffix) {
 		return true
 	}
+
+	switch mongoErr := err.(type) {
+	case mongo.WriteError:
+		_, ok := ignorableWriteErrorCodes[mongoErr.Code]
+		return ok
+	case mongo.BulkWriteException:
+		for _, writeErr := range mongoErr.WriteErrors {
+			if _, ok := ignorableWriteErrorCodes[writeErr.Code]; !ok {
+				return false
+			}
+		}
+		return mongoErr.WriteConcernError == nil
+	case mongo.CommandError:
+		_, ok := ignorableWriteErrorCodes[int(mongoErr.Code)]
+		return ok
+	}
+
 	return false
 }


### PR DESCRIPTION
Based on this [design](https://docs.google.com/document/d/1U-ifRuBKV3QGTJsWVDRt4tJTdQ891jD1RJnjePifHuw/edit#).

Deviations from the design:
- input parsing errors, even for TSV and CSV, are considered failing errors. They are already implemented this way and it would entail more work to change them to be skippable errors than I imagined. If users request the feature it can be added in the future.
- Document validation errors were added to the list of skippable errors
- numDecodingWorkers does not need to be set to 1 in import, since there is already logic for ensuring multiple decoding workers maintain the order

As part of these changes, I also updated the logging to more accurately reflect the number of documents inserted and the number that failed. A "failure" means failed to write to the server. Unprocessed documents, network errors, and input parsing errors won't show up in the counts as failures.

mongoimport:
```
 $ ./bin/mongoimport file.json --port=33333 --drop
2019-05-02T17:51:42.771-0400	no collection specified
2019-05-02T17:51:42.771-0400	using filename 'file' as collection
2019-05-02T17:51:42.774-0400	connected to: mongodb://localhost:33333/
2019-05-02T17:51:42.775-0400	dropping: test.file
2019-05-02T17:51:42.846-0400	continuing through error: E11000 duplicate key error collection: test.file index: _id_ dup key: { : 3 }
2019-05-02T17:51:42.847-0400	4 document(s) imported successfully. 1 document(s) failed to import.
```
mongorestore:
```
 $ ./bin/mongorestore file.bson --port=33333 --drop
2019-05-02T17:52:39.137-0400	checking for collection data in file.bson
2019-05-02T17:52:39.198-0400	restoring test.file from file.bson
2019-05-02T17:52:39.204-0400	continuing through error: E11000 duplicate key error collection: test.file index: _id_ dup key: { : 3 }
2019-05-02T17:52:39.268-0400	no indexes to restore
2019-05-02T17:52:39.268-0400	finished restoring test.file (4 documents, 1 failure)
2019-05-02T17:52:39.268-0400	done
```
and a longer one with multiple collections:
```
 $ ./bin/mongorestore --drop --port=33333
2019-05-02T17:56:58.002-0400	using default 'dump' directory
2019-05-02T17:56:58.002-0400	preparing collections to restore from
2019-05-02T17:56:58.031-0400	reading metadata for mydb.mio from dump/mydb/mio.metadata.json
2019-05-02T17:56:58.066-0400	reading metadata for mydb.mycoll from dump/mydb/mycoll.metadata.json
2019-05-02T17:56:58.094-0400	reading metadata for mydb.mycoll1 from dump/mydb/mycoll1.metadata.json
2019-05-02T17:56:58.101-0400	restoring test.file from dump/test/file.bson
2019-05-02T17:56:58.116-0400	continuing through error: E11000 duplicate key error collection: test.file index: _id_ dup key: { : 3 }
2019-05-02T17:56:58.116-0400	no indexes to restore
2019-05-02T17:56:58.116-0400	finished restoring test.file (4 documents, 1 failure)
2019-05-02T17:56:58.149-0400	restoring mydb.mio from dump/mydb/mio.bson
2019-05-02T17:56:58.190-0400	restoring mydb.mycoll from dump/mydb/mycoll.bson
2019-05-02T17:56:58.234-0400	restoring mydb.mycoll1 from dump/mydb/mycoll1.bson
2019-05-02T17:56:58.250-0400	reading metadata for mydb.helloworld from dump/mydb/helloworld.metadata.json
2019-05-02T17:56:58.250-0400	no indexes to restore
2019-05-02T17:56:58.250-0400	finished restoring mydb.mycoll (8 documents, 0 failures)
2019-05-02T17:56:58.250-0400	no indexes to restore
2019-05-02T17:56:58.250-0400	finished restoring mydb.mycoll1 (2 documents, 0 failures)
2019-05-02T17:56:58.294-0400	restoring mydb.helloworld from dump/mydb/helloworld.bson
2019-05-02T17:56:58.311-0400	reading metadata for mydb.badcsv from dump/mydb/badcsv.metadata.json
2019-05-02T17:56:58.325-0400	reading metadata for mydb.mycoll2 from dump/mydb/mycoll2.metadata.json
2019-05-02T17:56:58.327-0400	no indexes to restore
2019-05-02T17:56:58.327-0400	finished restoring mydb.helloworld (9 documents, 0 failures)
2019-05-02T17:56:58.368-0400	restoring mydb.badcsv from dump/mydb/badcsv.bson
2019-05-02T17:56:58.410-0400	restoring mydb.mycoll2 from dump/mydb/mycoll2.bson
2019-05-02T17:56:58.421-0400	no indexes to restore
2019-05-02T17:56:58.421-0400	finished restoring mydb.badcsv (2 documents, 0 failures)
2019-05-02T17:56:58.425-0400	no indexes to restore
2019-05-02T17:56:58.425-0400	finished restoring mydb.mycoll2 (1 document, 0 failures)
2019-05-02T17:56:58.515-0400	no indexes to restore
2019-05-02T17:56:58.515-0400	finished restoring mydb.mio (11029 documents, 0 failures)
2019-05-02T17:56:58.515-0400	done
```