### PR TITLE
TOOLS-2290 Fix mongorestore unable to restore collections with percents in names from archive

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,7 +104,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:882213a313a027a54622cfb7ed320cb93fbbfd5e4d4a1588e3a1397882d107cd"
+  digest = "1:c1e7c7400eab4665796e35dd486992d480942ef46d8bfd4d2ffcc4c4352e8b3b"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -125,7 +125,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "08e3232eed777bffd5672413a144e51d1d65daad"
+  revision = "1ca4ef7aeca6bbf734acd4122f3cfa36bda74b6e"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/test/qa-tests/jstests/restore/archive_stdout.js
+++ b/test/qa-tests/jstests/restore/archive_stdout.js
@@ -35,9 +35,9 @@
     barData.push({i: i*5});
   }
 
-  // test that slashes in collection names works for archives
+  // test that slashes and percents in collection names works for archives
   const collFoo = "coll/foo";
-  const collBar = "coll/bar";
+  const collBar = "coll%bar";
 
   testDb[collFoo].insertMany(fooData);
   testDb[collBar].insertMany(barData);

--- a/vendor/github.com/mongodb/mongo-tools-common/archive/prelude.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/archive/prelude.go
@@ -195,11 +195,6 @@ func (hpc *preludeParserConsumer) BodyBSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	cm.Collection, err = util.UnescapeCollectionName(cm.Collection)
-	if err != nil {
-		return err
-	}
-
 	hpc.prelude.AddMetadata(cm)
 	return nil
 }


### PR DESCRIPTION
[TOOLS-2290](https://jira.mongodb.org/browse/TOOLS-2290)

This PR fixes a bug where collections that had '%' in their names could not be restored using `--archive`. 

The bug was caused by an extraneous unescape attempt when reading the archive prelude. When dealing with archives, escaping and unescaping of collection names should only be performed in the filesystem abstraction layer `PreludeExplorer`, but I had included one below that in the actual prelude parser.