### PR TITLE
TOOLS-2225 mongorestore 4.2 transaction support

### DIFF
--- a/mongorestore/fixtures_test.go
+++ b/mongorestore/fixtures_test.go
@@ -1,0 +1,167 @@
+// Copyright (C) MongoDB, Inc. 2019-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongorestore
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/mongodb/mongo-tools-common/db"
+	"github.com/mongodb/mongo-tools/legacy/util"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type testCollData struct {
+	ns      string
+	docs    []bson.D
+	options bson.D
+}
+
+func (tcd testCollData) SplitNS() (string, string) {
+	ns := strings.SplitN(tcd.ns, ".", 2)
+	if len(ns) != 2 {
+		panic(fmt.Sprintf("invalid namespace '%s'", tcd.ns))
+	}
+	return ns[0], util.EscapeCollectionName(ns[1])
+}
+
+func (tcd testCollData) Mkdir(basePath string) error {
+	db, _ := tcd.SplitNS()
+	dbDir := path.Join(basePath, db)
+	err := os.MkdirAll(dbDir, 0755)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (tcd testCollData) WriteData(basePath string) error {
+	db, coll := tcd.SplitNS()
+	file, err := os.Create(path.Join(basePath, db, coll+".bson"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for _, doc := range tcd.docs {
+		raw, err := bson.Marshal(doc)
+		if err != nil {
+			return err
+		}
+		_, err = file.Write(raw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return file.Sync()
+}
+
+func (tcd testCollData) WriteOptions(basePath string) error {
+	if tcd.options == nil {
+		return nil
+	}
+
+	db, coll := tcd.SplitNS()
+	file, err := os.Create(path.Join(basePath, db, coll+".metadata.json"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	raw, err := bson.MarshalExtJSON(tcd.options, true, false)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(raw)
+	if err != nil {
+		return err
+	}
+
+	return file.Sync()
+}
+
+type testDumpDir struct {
+	dirName     string
+	oplog       []db.Oplog
+	collections []testCollData
+}
+
+func (tdd *testDumpDir) Create() error {
+
+	err := tdd.Cleanup()
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(tdd.Path(), 0755)
+	if err != nil {
+		return err
+	}
+
+	for _, coll := range tdd.collections {
+		err := coll.Mkdir(tdd.Path())
+		if err != nil {
+			return err
+		}
+		err = coll.WriteData(tdd.Path())
+		if err != nil {
+			return err
+		}
+		err = coll.WriteOptions(tdd.Path())
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tdd.WriteOplog()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Cleanup removes the test directory unless "NO_CLEANUP" is set in the environment.
+func (tdd *testDumpDir) Cleanup() error {
+	noCleanup := os.Getenv("NO_CLEANUP")
+	if noCleanup == "0" {
+		return nil
+	}
+	return os.RemoveAll(tdd.Path())
+}
+
+func (tdd *testDumpDir) WriteOplog() error {
+	if tdd.oplog == nil {
+		return nil
+	}
+	file, err := os.Create(path.Join(tdd.Path(), "oplog.bson"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for _, op := range tdd.oplog {
+		raw, err := bson.Marshal(op)
+		if err != nil {
+			return err
+		}
+		_, err = file.Write(raw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return file.Sync()
+}
+
+func (tdd *testDumpDir) Path() string {
+	return filepath.Join("testdata", tdd.dirName)
+}

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -1,0 +1,171 @@
+package mongorestore
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mongodb/mongo-tools-common/bsonutil"
+	"github.com/mongodb/mongo-tools-common/db"
+	"github.com/mongodb/mongo-tools-common/testtype"
+	"github.com/mongodb/mongo-tools-common/testutil"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const txnTestDataFile = "testdata/transactions.json"
+
+type txnTestDataMap map[string]*txnTestDataCase
+
+type txnTestDataCase struct {
+	Ops       []db.Oplog `bson:"ops"`
+	NS        string     `bson:"ns"`
+	PostImage []bson.D   `bson:"postimage"`
+}
+
+func TestMongorestoreTxns(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	client, err := testutil.GetBareSession()
+	if err != nil {
+		t.Fatalf("No server available")
+	}
+
+	data, err := readTxnTestData(txnTestDataFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test collections (if they don't exist) and clear documents.
+	for _, v := range data {
+		parts := strings.SplitN(v.NS, ".", 2)
+		db := client.Database(parts[0])
+		coll := db.Collection(parts[1])
+		err := coll.Drop(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := db.RunCommand(context.Background(), bson.D{{"create", parts[1]}})
+		if res.Err() != nil {
+			t.Fatal(res.Err())
+		}
+	}
+
+	// Create a dump directory from transactions.json
+	dumpPath := createTxnTestDataDir(t, data)
+
+	Convey("With a test MongoRestore", t, func() {
+		args := []string{
+			OplogReplayOption,
+			DropOption,
+			dumpPath,
+		}
+		restore, err := getRestoreWithArgs(args...)
+
+		So(err, ShouldBeNil)
+
+		result := restore.Restore()
+		So(result.Err, ShouldBeNil)
+
+		for k, v := range data {
+			Println("postImageCheck for", k)
+			So(postImageCheck(client, v), ShouldBeNil)
+		}
+	})
+}
+
+func createTxnTestDataDir(t *testing.T, data txnTestDataMap) string {
+	opStreams := make([][]db.Oplog, 0)
+	for _, v := range data {
+		if len(v.Ops) != 0 {
+			opStreams = append(opStreams, v.Ops)
+		}
+	}
+
+	dumpDir := testDumpDir{
+		dirName: "txntest",
+		oplog:   testutil.MergeOplogStreams(opStreams),
+	}
+
+	err := dumpDir.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dumpDir.Path()
+}
+
+func readTxnTestData(filename string) (txnTestDataMap, error) {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load %s: %v", filename, err)
+	}
+	var data bson.Raw
+	err = bson.UnmarshalExtJSON(b, false, &data)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't decode JSON: %v", err)
+	}
+	txnTestData := make(txnTestDataMap)
+	err = bson.Unmarshal(data, &txnTestData)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't decode test data: %v", err)
+	}
+
+	return txnTestData, nil
+}
+
+func postImageCheck(client *mongo.Client, c *txnTestDataCase) error {
+	expected := make(map[int]bson.D)
+	for _, v := range c.PostImage {
+		id, err := bsonutil.FindIntByKey("_id", &v)
+		if err != nil {
+			return err
+		}
+		expected[id] = v
+	}
+
+	parts := strings.SplitN(c.NS, ".", 2)
+	db := client.Database(parts[0])
+	coll := db.Collection(parts[1])
+
+	cursor, err := coll.Find(context.Background(), bson.D{})
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(context.Background())
+	var docs []bson.D
+	err = cursor.All(context.Background(), &docs)
+	if err != nil {
+		return err
+	}
+
+	for _, got := range docs {
+		id, err := bsonutil.FindIntByKey("_id", &got)
+		if err != nil {
+			return err
+		}
+		want, ok := expected[id]
+		if !ok {
+			return fmt.Errorf("got unexpected document with _id '%d'", id)
+		}
+		if diff := cmp.Diff(got, want); diff != "" {
+			return fmt.Errorf(diff)
+		}
+		delete(expected, id)
+	}
+
+	// Check if all documents were found
+	if len(expected) != 0 {
+		missing := make([]int, 0)
+		for i := range expected {
+			missing = append(missing, i)
+		}
+		return fmt.Errorf("missing documents: %v", missing)
+	}
+
+	return nil
+}

--- a/mongorestore/testdata/transactions.json
+++ b/mongorestore/testdata/transactions.json
@@ -1,0 +1,395 @@
+{
+    "not transaction": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"i","ns":"txntest.a","o":{"_id":0,"x":0},
+                "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}
+            }
+        ],
+        "ns": "txntest.a",
+        "postimage": [
+            {"_id":0,"x":0}
+        ]
+    },
+    "applyops not transaction": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.b","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.b","o":{"$set":{"x":1}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ]
+                }
+            }
+        ],
+        "ns": "txntest.b",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "small, unprepared": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.c","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.c","o":{"$set":{"x":1}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.c","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ]
+                },
+                "lsid":{"id":{"$binary":{"base64":"CK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            }
+        ],
+        "ns": "txntest.c",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "large, unprepared": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "count":6
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            }
+        ],
+        "ns": "txntest.d",
+        "postimage": [
+            {"_id":0,"x":0},
+            {"_id":1,"x":1},
+            {"_id":2,"x":2},
+            {"_id":3,"x":3},
+            {"_id":4,"x":4},
+            {"_id":5,"x":5}
+        ]
+    },
+    "small, prepared, committed": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.e","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.e","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.e","o":{"$set":{"x":1}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.e","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                            "commitTransaction":1,
+                            "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+                },
+                "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.e",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "small, prepared, aborted": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.f","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.f","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.f","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.f","o":{"$set":{"x":1}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.f","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{"abortTransaction":1 },
+                "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.f",
+        "postimage": []
+    },
+    "large, prepared, committed": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":6,"x":6},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":7,"x":7},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":8,"x":8},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":9,"x":9},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                            "commitTransaction":1,
+                            "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.g",
+        "postimage": [
+            {"_id":0,"x":0},
+            {"_id":1,"x":1},
+            {"_id":2,"x":2},
+            {"_id":3,"x":3},
+            {"_id":4,"x":4},
+            {"_id":5,"x":5},
+            {"_id":6,"x":6},
+            {"_id":7,"x":7},
+            {"_id":8,"x":8},
+            {"_id":9,"x":9}
+        ]
+    },
+    "large, prepared, aborted": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":6,"x":6},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":7,"x":7},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":8,"x":8},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{"abortTransaction":1 },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.h",
+        "postimage": []
+    },
+    "large, unprepared, incomplete": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.i","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"IK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.i","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"IK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            }
+        ],
+        "ns": "txntest.i",
+        "postimage": []
+    },
+    "small, prepared, incomplete": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.j","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.j","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.j","o":{"$set":{"x":1}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.j","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"JK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            }
+        ],
+        "ns": "txntest.j",
+        "postimage": []
+    }
+}


### PR DESCRIPTION
This CR is based after the revendoring of mongo-tools-common to bring in the transaction oplog buffer from TOOLS-2291