### PR TITLE
Use `EstimatedDocumentCount` instead `CountDocuments` for progress bar render

### DIFF
--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mongodb/mongo-tools-common/intents"
 	"github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/util"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 type NilPos struct{}
@@ -353,7 +352,7 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 	if err != nil {
 		return nil, err
 	}
-	count, err := session.Database(dbName).Collection(ci.Name).CountDocuments(context.Background(), bson.D{})
+	count, err := session.Database(dbName).Collection(ci.Name).EstimatedDocumentCount(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("error counting %v: %v", intent.Namespace(), err)
 	}


### PR DESCRIPTION
I am sure that the exact number of records in the progress bar is not important enough to read the collection twice.