### PR TITLE
TOOLS-2350 Print the correct output location

### DIFF
--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -540,15 +540,6 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 		return err
 	}
 
-	// set where the intent will be written to
-	if dump.OutputOptions.Archive != "" {
-		if dump.OutputOptions.Archive == "-" {
-			intent.Location = "archive on stdout"
-		} else {
-			intent.Location = fmt.Sprintf("archive '%v'", dump.OutputOptions.Archive)
-		}
-	}
-
 	log.Logvf(log.Always, "writing %v to %v", intent.Namespace(), intent.Location)
 	if dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer); err != nil {
 		return err

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -306,6 +306,11 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 			// if archive mode, then the output should be written using an output
 			// muxer.
 			intent.BSONFile = &archive.MuxIn{Intent: intent, Mux: dump.archive.Mux}
+			if dump.OutputOptions.Archive == "-" {
+				intent.Location = "archive on stdout"
+			} else {
+				intent.Location = fmt.Sprintf("archive '%v'", dump.OutputOptions.Archive)
+			}
 		} else if dump.OutputOptions.ViewsAsCollections || !ci.IsView() {
 			// otherwise, if it's either not a view or we're treating views as collections
 			// then create a standard filesystem path for this collection.
@@ -317,6 +322,7 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 
 			path := nameGz(dump.OutputOptions.Gzip, dump.outputPath(dbName, ci.Name)+".bson")
 			intent.BSONFile = &realBSONFile{path: path, intent: intent}
+			intent.Location = path
 		} else {
 			// otherwise, it's a view and the options specify not dumping a view
 			// so don't dump it.


### PR DESCRIPTION
Sets `intent.Location` in the default case when `--archive` isn't set. Also moves setting the `intent.Location` to `MongoDump.NewIntentFromOptions()` since it feels like it makes more sense for this to be done at initialization.