### PR TITLE
Fix for the build error

### DIFF
--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -201,7 +201,7 @@ func addClientCertFromFile(cfg *tls.Config, clientFile, keyPasswd string) (strin
 		return "", err
 	}
 
-	return crt.Subject.CommonName, nil
+	return crt.ToRDNSequence().String(), nil
 }
 
 // addCACertFromFile adds a root CA certificate to the configuration given a path

--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -201,7 +201,7 @@ func addClientCertFromFile(cfg *tls.Config, clientFile, keyPasswd string) (strin
 		return "", err
 	}
 
-	return crt.Subject.String(), nil
+	return crt.Subject.CommonName, nil
 }
 
 // addCACertFromFile adds a root CA certificate to the configuration given a path

--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -201,7 +201,7 @@ func addClientCertFromFile(cfg *tls.Config, clientFile, keyPasswd string) (strin
 		return "", err
 	}
 
-	return crt.ToRDNSequence().String(), nil
+	return crt.Subject.CommonName, nil
 }
 
 // addCACertFromFile adds a root CA certificate to the configuration given a path


### PR DESCRIPTION
Sorry I didn't see a bug fix branch - so fixed in main. 

Error: 

Building bsondump...
# github.com/mongodb/mongo-tools/vendor/github.com/mongodb/mongo-tools-common/db
vendor/github.com/mongodb/mongo-tools-common/db/db.go:204:20: crt.Subject.String undefined (type pkix.Name has no field or method String)
Error building bsondump

I'm getting a build error - this fixes it because crt.Subject is an enum pkix.Name, so just returning CommonName