### PR TITLE
TOOLS-2336: Fix deprecation message for --nsInclude when restoring from stdin

### DIFF
--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -221,7 +221,7 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 			return err
 		}
 
-		if fileType != BSONFileType {
+		if fileType != BSONFileType && restore.InputOptions.Archive != "" {
 			log.Logvf(log.Always, "the --db and --collection args should only be used when "+
 				"restoring from a BSON file. Other uses are deprecated and will not exist "+
 				"in the future; use --nsInclude instead")

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -215,13 +215,19 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 
 	// deprecations with --nsInclude --nsExclude
 	if restore.NSOptions.DB != "" || restore.NSOptions.Collection != "" {
-		// these are only okay if restoring from a bson file
+		// log a deprecation message if restoring from a directory, or
+		// from a non-bson file with the --archive option
 		_, fileType, err := restore.getInfoFromFilename(restore.TargetDirectory)
 		if err != nil {
 			return err
 		}
 
-		if fileType != BSONFileType && restore.InputOptions.Archive != "" {
+		isDir := false
+		if target, err := newActualPath(restore.TargetDirectory); err == nil {
+			isDir = target.IsDir()
+		}
+		
+		if isDir || (fileType != BSONFileType && restore.InputOptions.Archive != "") {
 			log.Logvf(log.Always, "the --db and --collection args should only be used when "+
 				"restoring from a BSON file. Other uses are deprecated and will not exist "+
 				"in the future; use --nsInclude instead")


### PR DESCRIPTION
Before, doing `cat ~/empty.bson | mongorestore --db test --collection cafes -` unnecessarily printed the following deprecation message on the first line:
```
2020-01-30T14:26:46.894-0500	the --db and --collection args should only be used when restoring from a BSON file. Other uses are deprecated and will not exist in the future; use --nsInclude instead
2020-01-30T14:26:46.895-0500	setting up a collection to be read from standard input
2020-01-30T14:26:46.895-0500	restoring to existing collection test.cafes without dropping
2020-01-30T14:26:46.895-0500	restoring test.cafes from -
2020-01-30T14:26:46.962-0500	no indexes to restore
2020-01-30T14:26:46.962-0500	finished restoring test.cafes (0 documents, 0 failures)
2020-01-30T14:26:46.962-0500	0 document(s) restored successfully. 0 document(s) failed to restore.
```

Now, that same command will omit the deprecation message on the first line since there's no `--archive` option:
```
2020-01-30T14:30:06.731-0500	setting up a collection to be read from standard input
2020-01-30T14:30:06.732-0500	restoring to existing collection test.cafes without dropping
2020-01-30T14:30:06.732-0500	restoring test.cafes from -
2020-01-30T14:30:06.802-0500	no indexes to restore
2020-01-30T14:30:06.802-0500	finished restoring test.cafes (0 documents, 0 failures)
2020-01-30T14:30:06.802-0500	0 document(s) restored successfully. 0 document(s) failed to restore.
```

Doing `cat ~/empty.archive | mongorestore --db test --collection cafes --archive` still correctly prints the message:
```
2020-01-30T14:24:59.443-0500	the --db and --collection args should only be used when restoring from a BSON file. Other uses are deprecated and will not exist in the future; use --nsInclude instead
2020-01-30T14:24:59.443-0500	Failed: I/O failure reading beginning of archive: EOF
2020-01-30T14:24:59.443-0500	0 document(s) restored successfully. 0 document(s) failed to restore.
```
