### PR TITLE
TOOLS-2489: Fix and separate static analysis tasks 

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -40,9 +40,6 @@ mongo_tools_variables:
       # Disabled due to TOOLS-2119
       # - name: kerberos
       - name: legacy30
-      - name: lint-go
-      - name: format-go
-      - name: lint-js
       - name: qa-tests-3.2
       - name: qa-tests-3.4
       - name: qa-tests-3.6
@@ -53,7 +50,6 @@ mongo_tools_variables:
       - name: qa-dump-restore-with-archiving-current
       - name: native-cert-ssl-current
       - name: unit
-      - name: vet
     ubuntu_x86_64_task_list: &ubuntu_x86_64_tasks
       - name: dist
       - name: sign
@@ -63,9 +59,6 @@ mongo_tools_variables:
       - name: integration-4.2
       - name: integration-4.2-auth
       - name: kerberos
-      - name: lint-go
-      - name: format-go
-      - name: lint-js
       - name: qa-tests-3.2
       - name: qa-tests-3.4
       - name: qa-tests-3.6
@@ -76,7 +69,6 @@ mongo_tools_variables:
       - name: qa-dump-restore-with-archiving-current
       - name: native-cert-ssl-current
       - name: unit
-      - name: vet
     ubuntu_x86_64_race_task_list: &ubuntu_x86_64_race_tasks
       - name: dist
       - name: integration-4.0
@@ -1411,6 +1403,23 @@ tasks:
           go tool vet bsondump mongo*
 
 buildvariants:
+
+#######################################
+#     Static Analysis Buildvariant    #
+#######################################
+
+- name: static
+  display_name: '! Static Analysis'
+  run_on:
+  - rhel62-small
+  expansions:
+    build_tags: "ssl sasl gssapi"
+    _platform: rhel62
+  tasks:
+  - name: format-go
+  - name: lint-go
+  - name: lint-js
+  - name: vet
 
 #######################################
 #     Amazon x86_64 Buildvariants     #

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -60,7 +60,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 		return err
 	}
 
- 	if dump.OutputOptions.ViewsAsCollections || intent.IsView() {
+	if dump.OutputOptions.ViewsAsCollections || intent.IsView() {
 		log.Logvf(log.DebugLow, "not dumping indexes metadata for '%v' because it is a view", intent.Namespace())
 	} else {
 		// get the indexes

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -266,7 +266,7 @@ func setUpDBView() error {
 	collName := "coll1"
 	dbName := testDB
 
-	pipeline := []bson.M{bson.M{"$project": bson.M{"b": "$a"}}}
+	pipeline := []bson.M{{"$project": bson.M{"b": "$a"}}}
 	createCmd := bson.D{
 		{"create", "test view"},
 		{"viewOn", collName},

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -226,7 +226,7 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 		if target, err := newActualPath(restore.TargetDirectory); err == nil {
 			isDir = target.IsDir()
 		}
-		
+
 		if isDir || (fileType != BSONFileType && restore.InputOptions.Archive != "") {
 			log.Logvf(log.Always, "the --db and --collection args should only be used when "+
 				"restoring from a BSON file. Other uses are deprecated and will not exist "+


### PR DESCRIPTION
this PR fixes a failing format-go task and moves format-go, lint-go, vet, and lint-js into their own buildvariant for easier viewing from the github PR patchbuild widget