### PR TITLE
TOOLS-2490: Run memory-hungry task on larger linux boxes

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -49,6 +49,7 @@ mongo_tools_variables:
       - name: qa-tests-4.2
       - name: qa-tests-unstable
       - name: qa-dump-restore-with-gzip-current
+        run_on: rhel62-large
       - name: qa-dump-restore-with-archiving-current
       - name: native-cert-ssl-current
       - name: unit
@@ -69,6 +70,7 @@ mongo_tools_variables:
       - name: qa-tests-4.2
       - name: qa-tests-unstable
       - name: qa-dump-restore-with-gzip-current
+        run_on: ubuntu1604-build
       - name: qa-dump-restore-with-archiving-current
       - name: native-cert-ssl-current
       - name: unit


### PR DESCRIPTION
Some facts about the build failure fixed here:
- The task failures appear to be the OOM killer killing mongorestore when it hits 3.1G or so of memory.
- When this task passes, peak memory usage does not look substantially lower (perhaps 2.9G instead of 3.1)
- The [first commit that failed](https://evergreen.mongodb.com/task/mongo_tools_rhel62_qa_dump_restore_with_gzip_current_0660bca4bee742d34d34c8cdbf91f4bb6ee552ba_19_10_25_19_20_11) doesn't _appear_ to contain anything that would cause memory usage to spike
- Logs for passing tests are deleted more aggressively, so I can't actually compare memory usage after the first failure to memory usage prior to that commit

For a "fix", I've modified this particular task to run on a bigger rhel62/ubuntu1604 box. It's not guaranteed to make the issue go away, but I think it will suffice.