### PR TITLE
TOOLS-2440: Sign MSI installer

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -617,6 +617,27 @@ functions:
         extract_to: src/github.com/mongodb/mongo-tools/
         bucket: mciuploads
 
+  "sign msi installer":
+    - command: shell.exec
+      type: system
+      params:
+        silent: true
+        script: |
+          echo "${signing_auth_token}" > ${PROJECT_DIR}/signing_auth_token
+    - command: shell.exec
+      # If the notary service is failing, it should be a system failure to alert the evg team.
+      type: system
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools/
+        script: |
+          /usr/local/bin/notary-client.py \
+              --key-name "server-Tools" \
+              --auth-token-file ${PROJECT_DIR}/signing_auth_token \
+              --comment "Evergreen Automatic Signing (mongo-tools) - ${version_id} - ${build_variant}" \
+              --notary-url http://notary-service.build.10gen.cc:5000 \
+              --skip-missing \
+              release.msi
+
   "upload signed release artifacts":
     - command: s3.put
       params:
@@ -869,6 +890,7 @@ tasks:
     - name: dist
   commands:
     - func: "fetch dist release artifacts"
+    - func: "sign msi installer"
     - func: "upload signed release artifacts"
 
 - name: integration-3.6

--- a/common.yml
+++ b/common.yml
@@ -632,7 +632,7 @@ functions:
         working_dir: src/github.com/mongodb/mongo-tools/
         script: |
           /usr/local/bin/notary-client.py \
-              --key-name "server-Tools" \
+              --key-name "server-Tools.pub" \
               --auth-token-file ./signing_auth_token \
               --comment "Evergreen Automatic Signing (mongo-tools)" \
               --notary-url http://notary-service.build.10gen.cc:5000 \

--- a/common.yml
+++ b/common.yml
@@ -627,16 +627,18 @@ functions:
           echo "${signing_auth_token}" > ./signing_auth_token
     - command: shell.exec
       # If the notary service is failing, it should be a system failure to alert the evg team.
+      # We overwrite the existing release.msi with a signed version via --package-file-suffix ""
       type: system
       params:
         working_dir: src/github.com/mongodb/mongo-tools/
         script: |
           /usr/local/bin/notary-client.py \
-              --key-name "server-Tools.pub" \
+              --key-name "server-Tools" \
               --auth-token-file ./signing_auth_token \
               --comment "Evergreen Automatic Signing (mongo-tools)" \
               --notary-url http://notary-service.build.10gen.cc:5000 \
               --skip-missing \
+              --package-file-suffix "" \
               release.msi
 
   "upload signed release artifacts":

--- a/common.yml
+++ b/common.yml
@@ -621,9 +621,10 @@ functions:
     - command: shell.exec
       type: system
       params:
+        working_dir: src/github.com/mongodb/mongo-tools/
         silent: true
         script: |
-          echo "${signing_auth_token}" > ${PROJECT_DIR}/signing_auth_token
+          echo "${signing_auth_token}" > ./signing_auth_token
     - command: shell.exec
       # If the notary service is failing, it should be a system failure to alert the evg team.
       type: system
@@ -632,7 +633,7 @@ functions:
         script: |
           /usr/local/bin/notary-client.py \
               --key-name "server-Tools" \
-              --auth-token-file ${PROJECT_DIR}/signing_auth_token \
+              --auth-token-file ./signing_auth_token \
               --comment "Evergreen Automatic Signing (mongo-tools)" \
               --notary-url http://notary-service.build.10gen.cc:5000 \
               --skip-missing \

--- a/common.yml
+++ b/common.yml
@@ -633,7 +633,7 @@ functions:
           /usr/local/bin/notary-client.py \
               --key-name "server-Tools" \
               --auth-token-file ${PROJECT_DIR}/signing_auth_token \
-              --comment "Evergreen Automatic Signing (mongo-tools) - ${version_id} - ${build_variant}" \
+              --comment "Evergreen Automatic Signing (mongo-tools)" \
               --notary-url http://notary-service.build.10gen.cc:5000 \
               --skip-missing \
               release.msi


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2440

I copied over the [sqlproxy `"sign msi installer"` function](https://github.com/10gen/sqlproxy/blob/1add0bfe7e43375274a936ac427f3ffb3d083d14/.evg.yml#L411-L430) and just changed the working dir, key name and auth token. There might be something else, but I believe this was it.