### PR TITLE
TOOLS-2464: Fix missing evergreen distros

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1653,16 +1653,6 @@ buildvariants:
 #######################################
 #     SUSE x86_64 Buildvariants       #
 #######################################
-- name: suse11
-  display_name: SUSE 11
-  run_on:
-    - suse11-test
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
 
 - name: suse12
   display_name: SUSE 12

--- a/common.yml
+++ b/common.yml
@@ -1642,7 +1642,7 @@ buildvariants:
 - name: rhel80
   display_name: RHEL 8.0
   run_on:
-    - rhel80-small
+    - rhel80-test
   expansions:
     build_tags: "sasl gssapi ssl"
   tasks:
@@ -1860,10 +1860,10 @@ buildvariants:
     run_kinit: true
   tasks: *rhel71_ppc64le_tasks
 
-- name: rhel82-ppc64le
-  display_name: ZAP PPC64LE RHEL 8.2
+- name: rhel81-ppc64le
+  display_name: ZAP PPC64LE RHEL 8.1
   run_on:
-    - rhel82-power8-test
+    - rhel81-power8-test
   stepback: false
   batchtime: 10080 # weekly
   expansions:
@@ -1951,10 +1951,10 @@ buildvariants:
   - name: sign
     run_on: amazon1-2018-test
 
-- name: rhel82-s390x
-  display_name: ZAP s390x RHEL 8.2
+- name: rhel80-s390x
+  display_name: ZAP s390x RHEL 8.0
   run_on:
-    - rhel82-zseries-test
+    - rhel80-zseries-test
   stepback: false
   batchtime: 10080 # weekly
   expansions:

--- a/common.yml
+++ b/common.yml
@@ -1731,17 +1731,6 @@ buildvariants:
   - name: sign
     run_on: amazon1-2018-test
 
-- name: ubuntu2004
-  display_name: Ubuntu 20.04
-  run_on:
-    - ubuntu2004-test
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
-
 #######################################
 #        Windows Buildvariants        #
 #######################################
@@ -1813,19 +1802,6 @@ buildvariants:
     USE_SSL: "true"
   tasks: *ubuntu1804_arm64_tasks
 
-- name: ubuntu2004-arm64
-  display_name: ZAP ARM64 Ubuntu 20.04
-  run_on:
-    - ubuntu2004-arm64-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
-
 #######################################
 #        Power Buildvariants          #
 #######################################
@@ -1849,19 +1825,6 @@ buildvariants:
     edition: enterprise
     run_kinit: true
   tasks: *rhel71_ppc64le_tasks
-
-- name: rhel81-ppc64le
-  display_name: ZAP PPC64LE RHEL 8.1
-  run_on:
-    - rhel81-power8-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: 'ssl sasl gssapi'
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
 
 # MongoDB 3.4 - 4.0
 - name: ubuntu1604-ppc64le
@@ -1890,19 +1853,6 @@ buildvariants:
   - name: dist
   - name: sign
     run_on: amazon1-2018-test
-
-- name: ubuntu2004-ppc64le
-  display_name: ZAP PPC64LE Ubuntu 20.04
-  run_on:
-    - ubuntu2004-power8-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: 'ssl sasl gssapi'
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
 
 #######################################
 #     Z (s390x) Buildvariants         #
@@ -1941,36 +1891,10 @@ buildvariants:
   - name: sign
     run_on: amazon1-2018-test
 
-- name: rhel80-s390x
-  display_name: ZAP s390x RHEL 8.0
-  run_on:
-    - rhel80-zseries-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
-
 - name: suse12-s390x
   display_name: ZAP s390x SUSE 12
   run_on:
     - suse12-zseries-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
-
-- name: suse15-s390x
-  display_name: ZAP s390x SUSE 15
-  run_on:
-    - suse15-zseries-test
   stepback: false
   batchtime: 10080 # weekly
   expansions:
@@ -2005,19 +1929,6 @@ buildvariants:
   - name: dist
   - name: sign
     run_on: amazon1-2018-test
-
-- name: ubuntu2004-s390x
-  display_name: ZAP s390x Ubuntu 20.04
-  run_on:
-    - ubuntu2004-zseries-test
-  stepback: false
-  batchtime: 10080 # weekly
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
 
 #######################################
 #     Experimental Buildvariants      #

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -232,7 +232,7 @@ var platforms = []Platform{
 		Pkg:  PkgRPM,
 	},
 	{
-		Name: "rhel82",
+		Name: "rhel81",
 		Arch: "ppc64le",
 		OS:   OSLinux,
 		Pkg:  PkgRPM,
@@ -268,7 +268,7 @@ var platforms = []Platform{
 		Pkg:  PkgRPM,
 	},
 	{
-		Name: "rhel82",
+		Name: "rhel80",
 		Arch: "s390x",
 		OS:   OSLinux,
 		Pkg:  PkgRPM,

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -197,12 +197,6 @@ var platforms = []Platform{
 		Pkg:  PkgDeb,
 	},
 	{
-		Name: "ubuntu2004",
-		Arch: "x86_64",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
-	},
-	{
 		Name: "windows",
 		Arch: "x86_64",
 		OS:   OSWindows,
@@ -220,19 +214,7 @@ var platforms = []Platform{
 		Pkg:  PkgDeb,
 	},
 	{
-		Name: "ubuntu2004",
-		Arch: "arm64",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
-	},
-	{
 		Name: "rhel71",
-		Arch: "ppc64le",
-		OS:   OSLinux,
-		Pkg:  PkgRPM,
-	},
-	{
-		Name: "rhel81",
 		Arch: "ppc64le",
 		OS:   OSLinux,
 		Pkg:  PkgRPM,
@@ -245,12 +227,6 @@ var platforms = []Platform{
 	},
 	{
 		Name: "ubuntu1804",
-		Arch: "ppc64le",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
-	},
-	{
-		Name: "ubuntu2004",
 		Arch: "ppc64le",
 		OS:   OSLinux,
 		Pkg:  PkgDeb,
@@ -280,12 +256,6 @@ var platforms = []Platform{
 		Pkg:  PkgRPM,
 	},
 	{
-		Name: "suse15",
-		Arch: "s390x",
-		OS:   OSLinux,
-		Pkg:  PkgRPM,
-	},
-	{
 		Name: "ubuntu1604",
 		Arch: "s390x",
 		OS:   OSLinux,
@@ -293,12 +263,6 @@ var platforms = []Platform{
 	},
 	{
 		Name: "ubuntu1804",
-		Arch: "s390x",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
-	},
-	{
-		Name: "ubuntu2004",
 		Arch: "s390x",
 		OS:   OSLinux,
 		Pkg:  PkgDeb,


### PR DESCRIPTION
Right now, our release task cannot run, because it requires the "sign" tasks from all distros to have run. The "sign" tasks are not running on all distros, because some distros are not yet available in evergreen.

This patch contains two commits. The first changes two distros to match seemingly equivalent distros that _do_ exist in evergreen. The second temporarily removes some distros that are not yet supported in evergreen. This second commit should be reverted in TOOLS-2505 once all the distros in question are available.