### PR TITLE
TOOLS-2471: Automate JSON download feed generation

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -661,6 +661,15 @@ functions:
         script: |
           ${_set_shell_env}
           go run release/release.go upload-release
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/github.com/mongodb/mongo-tools/release.json
+        remote_file: mongo-tools/release/${build_id}/
+        content_type: application/json
+        bucket: mciuploads
+        permissions: public-read
 
   "fetch source" :
     - command: shell.exec

--- a/release/download/download.go
+++ b/release/download/download.go
@@ -1,0 +1,56 @@
+package download
+
+// JSONFeed represents the structure of the JSON
+// document consumed by the MongoDB downloads center.
+// An abbreviated version of the document might look like:
+// {
+//   "versions": [
+//     {
+//       "version": "4.3.2",
+//       "downloads": [
+//         {
+//           "name": "amazon",
+//           "arch": "x86_64",
+//           "archive": {
+//             "url": "fastdl.mongodb.org/tools/db/...tgz",
+//             "md5": "4ec7...",
+//             "sha1": "3269...",
+//             "sha256": "0b679..."
+//           },
+//           "package": {
+//             "url": "fastdl.mongodb.org/tools/db/...rpm",
+//             "md5": "5b35...",
+//             "sha1": "b07c...",
+//             "sha256": "f6e7..."
+//           }
+//         },
+//         ...
+//       ]
+//     }
+//   ]
+// }
+type JSONFeed struct {
+	Versions []ToolsVersion `json:"versions"`
+}
+
+type ToolsVersion struct {
+	Version   string          `json:"version"`
+	Downloads []ToolsDownload `json:"downloads"`
+}
+
+type ToolsDownload struct {
+	Name    string        `json:"name"`
+	Arch    string        `json:"arch"`
+	Archive ToolsArchive  `json:"archive"`
+	Package *ToolsPackage `json:"package,omitempty"`
+}
+
+type ToolsArchive ToolsArtifact
+type ToolsPackage ToolsArtifact
+
+type ToolsArtifact struct {
+	URL    string `json:"url"`
+	Md5    string `json:"md5"`
+	Sha1   string `json:"sha1"`
+	Sha256 string `json:"sha256"`
+}

--- a/release/release.go
+++ b/release/release.go
@@ -871,7 +871,7 @@ func uploadRelease(v version.Version) {
 				// The artifact URL indicates whether the artifact is an archive or a package.
 				// We assume there's at most one archive artifact and one package artifact
 				// for a given download entry.
-				artifactURL := path.Join("fastdl.mongodb.org/tools/db", latestStableFile)
+				artifactURL := path.Join("fastdl.mongodb.org/tools/db", stableFile)
 				md5sum := computeMD5(latestStableFile)
 				sha1sum := computeSHA1(latestStableFile)
 				sha256sum := computeSHA256(latestStableFile)
@@ -902,15 +902,15 @@ func uploadRelease(v version.Version) {
 		var feed download.JSONFeed
 		feed.Versions = append(feed.Versions, download.ToolsVersion{Version: v.StringWithoutPre(), Downloads: dls})
 
-		marshalledFeed, err := json.MarshalIndent(feed, "", "  ")
-		check(err, "marshal feed")
-
 		feedFilename := "release.json"
 		feedFile, err := os.Create(feedFilename)
 		check(err, "create release.json")
 		defer feedFile.Close()
-		_, err = feedFile.Write(marshalledFeed)
-		check(err, "write release.json")
+
+		jsonEncoder := json.NewEncoder(feedFile)
+		jsonEncoder.SetIndent("", "  ")
+		err = jsonEncoder.Encode(feed)
+		check(err, "encode json feed")
 
 		fmt.Printf("    uploading to https://s3.amazonaws.com/downloads.mongodb.org/tools/db/%s\n", feedFilename)
 		awsClient.UploadFile("downloads.mongodb.org", "/tools/db", feedFilename)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2471

This PR adds JSON feed generation to our `release.go` file for the download center. It's modeled after the [server JSON here](http://downloads.mongodb.org.s3.amazonaws.com/full.json) (~14 MBs of text as a fair warning).

The first commit is a preliminary idea to make sure we're okay with the JSON format. Since we have no sign tasks for testing, I had to mess around with the boolean conditions, comment out AWS uploads, etc. to download the artifacts for a random commit hash. I'm not including those changes here though.

Here's a sample output of what the JSON looks like for the first 5 sign tasks of some commit:
```
$ go run release/release.go upload-release 9ebaaf60989732c5f869f5f5592aa34d3e351688

{
  "Versions": [
    {
      "Version": "4.3.2",
      "Downloads": [
        {
          "Name": "amazon",
          "Arch": "x86_64",
          "Archive": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon-x86_64-latest-stable.tgz",
            "Md5": "4ec762c08c27a6416133b67bf9ac5e37",
            "Sha1": "3269b5bf0df8bc297f7d36967a93f77fe12d0b38",
            "Sha256": "0b679402d2c81a902ebeec83d753d747b63c43851be7df1b274617e8194627e5"
          },
          "Package": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon-x86_64-latest-stable.rpm",
            "Md5": "5b352971aecd8543ddbc808fe98bd31d",
            "Sha1": "b07cbe47bebdab0fa306c47b8f26cd9ca6ebe386",
            "Sha256": "f6e7a1433089d8dd478a9bfa9b0bea281d387e22f5ef03159d24464104bde817"
          }
        },
        {
          "Name": "amazon2",
          "Arch": "x86_64",
          "Archive": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon2-x86_64-latest-stable.tgz",
            "Md5": "36447e3c61aaef587e2921c5e0b841c0",
            "Sha1": "f844e4d63b385c0b74e3e74ecb6efd6defbbc122",
            "Sha256": "db0efa36d76592cf6e0d2049c46391e6c7da072e379d02c501b4d9a4060a05f6"
          },
          "Package": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon2-x86_64-latest-stable.rpm",
            "Md5": "fd5b777db056d05caa08020e1256193c",
            "Sha1": "818b041b05eec58ad826773c0b45bbd65893bcd4",
            "Sha256": "b47f041ad1cd14a56e96d3c7609fa3c0721dc84bc2389e7905e3bb661933a728"
          }
        },
        {
          "Name": "debian81",
          "Arch": "x86_64",
          "Archive": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-debian81-x86_64-latest-stable.tgz",
            "Md5": "0fd90c37ae0c957b58f7e1718bf33afa",
            "Sha1": "a12f57bc11807af0c9cde5f857be0a08a6f582a8",
            "Sha256": "13b233410ca06c8eff9ae3a7591601f3f39ddea5c1dac3ac0fc92bc25dd6c78e"
          },
          "Package": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-debian81-x86_64-latest-stable.deb",
            "Md5": "096151b253d135f6f3f4e0baa2ff69de",
            "Sha1": "655c156b9bbf091cd74a2d2dad4d067cb8acd89e",
            "Sha256": "4c5d21f0412de1bbc1397ab25716eb690276376fc1ae124ebeb77f8c6422c377"
          }
        },
        {
          "Name": "debian92",
          "Arch": "x86_64",
          "Archive": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-debian92-x86_64-latest-stable.tgz",
            "Md5": "43fe99778dbad96d06613459f76ed677",
            "Sha1": "cf23c2811eaa627dd8925bf87a3fb45f6dcc44e9",
            "Sha256": "0c7549a6b571ec35e7e97809a7cd33848266a39f555ccc7e7d7dc391538f80c9"
          },
          "Package": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-debian92-x86_64-latest-stable.deb",
            "Md5": "4e66c8f951846ff572f286fb969bc624",
            "Sha1": "d91c82a0f0a3be36480a24f511123f1030294a39",
            "Sha256": "d67ba7959276e3ed0520c61609dd59c4b22d3df920bc057521882b49ff46bcd3"
          }
        },
        {
          "Name": "macos",
          "Arch": "x86_64",
          "Archive": {
            "URL": "fastdl.mongodb.org/tools/db/mongodb-database-tools-macos-x86_64-latest-stable.tgz",
            "Md5": "928341eb2068e12414e7559bfafc25d6",
            "Sha1": "e90dfdd1c3ab008d6d78482d0f5762498a9799f5",
            "Sha256": "80e855342abda5c99373642528d6d5af80af960c773498fa9138ba5d5d2c7bb4"
          },
          "Package": {
            "URL": "",
            "Md5": "",
            "Sha1": "",
            "Sha256": ""
          }
        }
      ]
    }
  ]
}
```