### PR TITLE
TOOLS-2523: Remove debian71 and ubuntu1204 platforms

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1615,17 +1615,6 @@ buildvariants:
 #     Debian x86_64 Buildvariants     #
 #######################################
 
-- name: debian71
-  display_name: Debian 7.1
-  run_on:
-    - debian71-test
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
-
 - name: debian81
   display_name: Debian 8.1
   run_on:
@@ -1752,17 +1741,6 @@ buildvariants:
 #######################################
 #    Ubuntu x86_64 Buildvariants      #
 #######################################
-
-- name: ubuntu1204
-  display_name: Ubuntu 12.04
-  run_on:
-    - ubuntu1204-test
-  expansions:
-    build_tags: "sasl gssapi ssl"
-  tasks:
-    - name: dist
-    - name: sign
-      run_on: amazon1-2018-test
 
 - name: ubuntu1404
   display_name: Ubuntu 14.04

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -108,12 +108,6 @@ var platforms = []Platform{
 		Pkg:  PkgRPM,
 	},
 	{
-		Name: "debian71",
-		Arch: "x86_64",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
-	},
-	{
 		Name: "debian81",
 		Arch: "x86_64",
 		OS:   OSLinux,
@@ -165,12 +159,6 @@ var platforms = []Platform{
 		Arch: "x86_64",
 		OS:   OSLinux,
 		Pkg:  PkgRPM,
-	},
-	{
-		Name: "ubuntu1204",
-		Arch: "x86_64",
-		OS:   OSLinux,
-		Pkg:  PkgDeb,
 	},
 	{
 		Name: "ubuntu1404",


### PR DESCRIPTION
debian71 and ubuntu1204 have been disabled in evergreen, and are slated for complete removal. We need to remove them so that release automation work can proceed.