### PR TITLE
TOOLS-2529: Output new filename format for long collection names

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,7 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:5b3086b96ffc4633efbbd34a56b4560aba3fa6c268b2874e76c9a851c438a02e"
+  digest = "1:ab971310c8461a349c0ef647a9674a0898511f54250cbb01fee183ecc87d97b1"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -166,8 +166,8 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "19850939ed518fbfab4f59b31d11b9422724a19d"
-  version = "v3.0.3"
+  revision = "0d34607c2646082c58a5434235af6d41da6c1016"
+  version = "v3.0.4"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v3.0.3"
+  version = "v3.0.4"
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -19,9 +19,10 @@ import (
 
 // Metadata holds information about a collection's options and indexes.
 type Metadata struct {
-	Options bson.M   `json:"options,omitempty"`
-	Indexes []bson.D `json:"indexes"`
-	UUID    string   `json:"uuid,omitempty"`
+	Options        bson.M   `json:"options,omitempty"`
+	Indexes        []bson.D `json:"indexes"`
+	UUID           string   `json:"uuid,omitempty"`
+	CollectionName string   `json:"collectionName"`
 }
 
 // IndexDocumentFromDB is used internally to preserve key ordering.
@@ -47,6 +48,8 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	// If a collection has a UUID, it was gathered while building the list of
 	// intents.  Otherwise, it will be the empty string.
 	meta.UUID = intent.UUID
+
+	meta.CollectionName = intent.C
 
 	// Second, we read the collection's index information by either calling
 	// listIndexes (pre-2.7 systems) or querying system.indexes.

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -19,10 +19,10 @@ import (
 
 // Metadata holds information about a collection's options and indexes.
 type Metadata struct {
-	Options        bson.M   `json:"options,omitempty"`
-	Indexes        []bson.D `json:"indexes"`
-	UUID           string   `json:"uuid,omitempty"`
-	CollectionName string   `json:"collectionName"`
+	Options        bson.M   `bson:"options,omitempty"`
+	Indexes        []bson.D `bson:"indexes"`
+	UUID           string   `bson:"uuid,omitempty"`
+	CollectionName string   `bson:"collectionName"`
 }
 
 // IndexDocumentFromDB is used internally to preserve key ordering.
@@ -49,6 +49,8 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	// intents.  Otherwise, it will be the empty string.
 	meta.UUID = intent.UUID
 
+	// Adding the collection name is useful if a long collection name results in a truncated
+	// bson or metadata file name, in which case the collection name can be found here.
 	meta.CollectionName = intent.C
 
 	// Second, we read the collection's index information by either calling

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1156,7 +1156,7 @@ func TestMongoDumpViews(t *testing.T) {
 }
 
 func TestMongoDumpCollectionOutputPath(t *testing.T) {
-	// testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	log.SetWriter(ioutil.Discard)
 
 	Convey("testing output paths for collection names of varying lengths", t, func() {

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -354,7 +354,7 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 					Buffer: &bytes.Buffer{},
 				}
 			} else {
-				path := nameGz(dump.OutputOptions.Gzip, dump.outputPath(dbName, ci.Name+".metadata.json"))
+				path := nameGz(dump.OutputOptions.Gzip, dump.outputPath(dbName, ci.Name)+".metadata.json")
 				intent.MetadataFile = &realMetadataFile{path: path, intent: intent}
 			}
 		}

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -208,6 +208,8 @@ func (dump *MongoDump) outputPath(dbName, colName string) string {
 
 		// First 208 bytes of col name + 3 bytes delimiter + 27 bytes base64 hash = 238 bytes.
 		colName = colNameTruncated + delimiter + colNameHashBase64
+	} else {
+		colName = util.EscapeCollectionName(colName)
 	}
 
 	return filepath.Join(root, dbName, colName)

--- a/vendor/github.com/mongodb/mongo-tools-common/util/file.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/util/file.go
@@ -8,11 +8,11 @@ package util
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net/url"
 	"os"
 	"path/filepath"
-	"context"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -45,11 +45,11 @@ func ToUniversalPath(path string) string {
 }
 
 func EscapeCollectionName(collName string) string {
-	return url.PathEscape(collName)
+	return url.QueryEscape(collName)
 }
 
 func UnescapeCollectionName(escapedCollName string) (string, error) {
-	return url.PathUnescape(escapedCollName)
+	return url.QueryUnescape(escapedCollName)
 }
 
 type WrappedReadCloser struct {
@@ -79,7 +79,6 @@ func (wwc *WrappedWriteCloser) Close() error {
 	}
 	return innerErr
 }
-
 
 // Wrapper that can capture errors that occur when closing the underlying closer.
 type DeferredCloser struct {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2529
Design Doc: [https://docs.google.com/document/d/...](https://docs.google.com/document/d/1LCsXHqjQrRWDzD1Of_pNX41pyQZqd231ni9uF9_noY8/edit#heading=h.qk6j6d5j4oc5)
Related PR: https://github.com/mongodb/mongo-tools/pull/233

This PR allows us to output a new filename format for collections whose names would result in filenames >255 characters long.

The functional change is in `prepare.go`, with a new unit test for `outputPath()`. There's also a tiny change in `mongo-tools-common` that I'll do separately after this PR gets approved.