### PR TITLE
TOOLS-2539: Use latest instead of githash

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -619,6 +619,7 @@ functions:
         target: src/github.com/mongodb/mongo-tools/upload.tgz
         source_dir: src/github.com/mongodb/mongo-tools
         include:
+          - "./release.*"
           - "*.deb"
           - "*.rpm"
     - command: s3.put

--- a/release/release.go
+++ b/release/release.go
@@ -184,9 +184,14 @@ func getDebFileName() string {
 	v, err := version.GetCurrent()
 	check(err, "get version")
 
+	vStr := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Pre != "" {
+		vStr += "~latest"
+	}
+
 	return fmt.Sprintf(
 		"mongodb-database-tools_%s_%s.deb",
-		v, p.DebianArch(),
+		vStr, p.DebianArch(),
 	)
 }
 
@@ -197,9 +202,14 @@ func getRPMFileName() string {
 	v, err := version.GetCurrent()
 	check(err, "get version")
 
+	vStr := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Pre != "" {
+		vStr += ".latest"
+	}
+
 	return fmt.Sprintf(
 		"mongodb-database-tools-%s.%s.rpm",
-		v, p.Arch,
+		vStr, p.Arch,
 	)
 }
 


### PR DESCRIPTION
ex: https://evergreen.mongodb.com/version/5e974e85c9ec4478197fb998