### PR TITLE
TOOLS-2548: Declare linux deps as the server did

### DIFF
--- a/installer/rpm/mongodb-database-tools.spec
+++ b/installer/rpm/mongodb-database-tools.spec
@@ -10,7 +10,7 @@ URL:        http://www.mongodb.com
 Vendor:     MongoDB
 BuildArchitectures: @ARCHITECTURE@
 Obsoletes:  mongodb-database-tools <= @TOOLS_VERSION@
-Requires: glibc >= 2.17, keyutils-libs >= 1.5.8, krb5-libs >= 1.15.1, libcom_err >= 1.43.5, libselinux >= 2.1.10, openssl >= 1.0.2k, zlib >= 1.2.8
+Requires: openssl, cyrus-sasl, cyrus-sasl-plain, cyrus-sasl-gssapi
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}
 
 %description


### PR DESCRIPTION
The deps listed in the RPM packages were making the database-tools package uninstallable on RHEL, SUSE, etc. While the deb packages don't seem to have any installation issues right now, the versions declared as dependencies seem likely to cause similar issues on debian and ubuntu in the future.

I went back to the server repo from before the tools were removed, and copied how they declared dependencies. Once the patch runs, I will manually verify that the rpms install successfully and report back here