### PR TITLE
TOOLS-2559: Fix rm message when uninstalling tools rpm package

### DIFF
--- a/installer/rpm/mongodb-database-tools.spec
+++ b/installer/rpm/mongodb-database-tools.spec
@@ -93,7 +93,7 @@ if test $1 = 0; then
    rm -f /usr/bin/mongotop
    rm -f /usr/share/doc/mongodb-database-tools/*
    # remove the symlink too.
-   rm /usr/doc/mongodb-database-tools
+   rm -f /usr/doc/mongodb-database-tools
 fi
 
 exit 0


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2559

This fixes the `rm` error message in the rpm installer.

It seems tough to test this through `yum erase` or something like that, so I just tested it independently on a CentOS 8 VM since it's simple:

```
[vagrant@localhost ~]$ sudo yum install mongodb-org
...

[vagrant@localhost ~]$ rm /usr/doc/mongodb-database-tools
rm: cannot remove '/usr/doc/mongodb-database-tools': No such file or directory

[vagrant@localhost ~]$ rm -f /usr/doc/mongodb-database-tools

[vagrant@localhost ~]$
```