### PR TITLE
TOOLS-2609: Remove broken .sig file links from release json feed

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -912,7 +912,7 @@ func uploadReleaseJSON(v version.Version) {
 	for _, task := range signTasks {
 		pf, ok := platform.GetByVariant(task.Variant)
 		if !ok {
-			log.Fatalf("clould not find platform for variant %q", task.Variant)
+			log.Fatalf("could not find platform for variant %q", task.Variant)
 		}
 
 		log.Printf("\ngetting artifacts for %s\n", task.Variant)
@@ -932,7 +932,7 @@ func uploadReleaseJSON(v version.Version) {
 		dl.Arch = pf.Arch
 		for _, a := range artifacts {
 			ext := path.Ext(a.URL)
-			if ext == "sig" {
+			if ext == ".sig" {
 				continue
 			}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2609

We weren't correctly ignoring .sig files, since `path.Ext()` returns the extension with the dot included (this is done right for `upload-release` though).

I tested the change on the 100.0.2 release and entries with URLs ending in .sig got correctly replaced with ones ending in .rpm / .deb, e.g. :

```
"package": {
     "url": "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon-x86_64-4.3.2-106-ge09bae2c.sig",
    "md5": "041f4dfbb7d3ef50e0bb921a17a9e511",
    "sha1": "871b2f681166f7eff4557c307c6c9f09c03a16d1",
    "sha256": "83d337f06b49a5db1f81676de06821bba466bef736ee8a4796c8eb3843930487"
}
```
became
```
"package": {
    "url": "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon-x86_64-4.3.2-106-ge09bae2c.rpm",
    "md5": "ea88e0d50b6e7e00c398321e1cbc12c0",
    "sha1": "b7aeeaf304d4a61232504a1d2259657a3afac8cd",
    "sha256": "bdc94ef727f3c60654781f72984ca0b03f05e28b8cea648c1f44b42c20515f35"
}
```