### PR TITLE
TOOLS-2644: authenticate to barque using API key

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1075,7 +1075,7 @@ pre:
           export NOTARY_KEY_NAME='server-4.4'
           export NOTARY_TOKEN='${signing_auth_token_server_4_4}'
           export BARQUE_USERNAME='${evg_user}'
-          export BARQUE_PASSWORD='${evg_password}'
+          export BARQUE_API_KEY='${barque_api_key}'
           set -o xtrace
           set -o verbose
           set -o errexit

--- a/release/release.go
+++ b/release/release.go
@@ -1151,6 +1151,8 @@ func linuxRelease(v version.Version) {
 							"--edition", me,
 							"--version", mv,
 							"--packages", packagesURL,
+							"--username", os.Getenv("BARQUE_USERNAME"),
+							"--api_key", os.Getenv("BARQUE_API_KEY"),
 						}
 
 						if retries == maxRetries {

--- a/release/release.go
+++ b/release/release.go
@@ -1151,8 +1151,6 @@ func linuxRelease(v version.Version) {
 							"--edition", me,
 							"--version", mv,
 							"--packages", packagesURL,
-							"--username", os.Getenv("BARQUE_USERNAME"),
-							"--password", os.Getenv("BARQUE_PASSWORD"),
 						}
 
 						if retries == maxRetries {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/TOOLS-2644

This change just uses the barque service user's API key instead of LDAP username/password to auth because the LDAP server is not supported anymore.