### PR TITLE
Revendor Tools to use v4.0.0 of MTC

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,7 +167,7 @@
   ]
   pruneopts = "T"
   revision = "1413136c98b7bc91c36001b8c2299297abab73d4"
-  version = "v3.0.13"
+  version = "v4.0.0"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,7 +167,7 @@
   ]
   pruneopts = "T"
   revision = "1413136c98b7bc91c36001b8c2299297abab73d4"
-  version = "v3.0.13"
+  version = "4.0.0"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,7 +167,7 @@
   ]
   pruneopts = "T"
   revision = "1413136c98b7bc91c36001b8c2299297abab73d4"
-  version = "4.0.0"
+  version = "v3.0.13"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v3.0.13"
+  version = "v4.0.0"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v3.0.13"
+  version = "4.0.0"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "4.0.0"
+  version = "v3.0.13"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"


### PR DESCRIPTION
TOOLS-2287 should have done this, but only revendors by patch, i.e. v.3.0.13. Instead, it should have bumped the major version, since it involved a breaking change.

The proper MTC version has now been created - this PR is to revendor on the Tools' side.