### PR TITLE
TOOLS-2667: Support list of files for put and get subcommands in mongofiles (verify behavior of $in query)

### DIFF
--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -62,7 +62,7 @@ type MongoFiles struct {
 	Id string
 
 	// List of filenames for use as supporting
-	// arguments in --put and --get
+	// arguments in put and get commands
 	FileNameList []string
 
 	// GridFS bucket to operate on
@@ -116,8 +116,8 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 			mf.FileName = args[1]
 		}
 	case Put, Get:
-		// monogofiles --put and mongofiles --get should work over
-		// a list of files, i.e. by using mf.FileNameList
+		// monogofiles put ... and mongofiles get ... should work
+		// over a list of files, i.e. by using mf.FileNameList
 		if len(args) == 1 || args[1] == "" {
 			return fmt.Errorf("'%v' argument missing", args[0])
 		}
@@ -238,9 +238,9 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 	var gridFiles []*gfsFile
 	var err error
 
-	// If mongofiles --get ... is called, then query for all files
+	// If mongofiles get ... is called, then query for all files
 	// specified in mf.FileNameList -- otherwise, preserve correct
-	// behavior for mongofiles --get_id ...
+	// behavior for mongofiles get_id ...
 	if len(mf.FileNameList) > 0 {
 		query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -61,6 +61,10 @@ type MongoFiles struct {
 	// ID to put into GridFS
 	Id string
 
+        // List of filenames for use as supporting
+        // arguments in --put and --get
+        FileNameList []string
+
 	// GridFS bucket to operate on
 	bucket *gridfs.Bucket
 }
@@ -111,7 +115,19 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		} else {
 			mf.FileName = args[1]
 		}
-	case Search, Put, Get, Delete:
+	case Put, Get:
+		// monogofiles --put and mongofiles --get should work over
+                // a list of files, i.e. by using mf.FileNameList -- see
+                // TOOLS-2667 for user-level specification
+                if len(args) == 1 || args[1] == "" {
+			return fmt.Errorf("'%v' argument missing", args[0])
+                }
+
+		if len(args) == 2 {
+			mf.FileName = args[1]
+                }
+		mf.FileNameList = args[1:]
+	case Search, Delete:
 		if len(args) > 2 {
 			return fmt.Errorf("too many non-URI positional arguments (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)")
 		}
@@ -182,16 +198,18 @@ func (mf *MongoFiles) getLocalFileName(gridFile *gfsFile) string {
 
 // handleGet contains the logic for the 'get' and 'get_id' commands
 func (mf *MongoFiles) handleGet() (err error) {
-	file, err := mf.getTargetGFSFile()
+	files, err := mf.getTargetGFSFile()
 	if err != nil {
 		return err
 	}
 
-	if err = mf.writeGFSFileToLocal(file); err != nil {
-		return err
-	}
+        for _, file := range files {
+		if err = mf.writeGFSFileToLocal(file); err != nil {
+			return err
+		}
+        }
 
-	return err
+	return nil
 }
 
 // Gets all GridFS files that match the given query.
@@ -216,40 +234,54 @@ func (mf *MongoFiles) findGFSFiles(query bson.M) (files []*gfsFile, err error) {
 }
 
 // Gets the GridFS file the options specify. Use this for the get family of commands.
-func (mf *MongoFiles) getTargetGFSFile() (*gfsFile, error) {
-	var gridFiles []*gfsFile
-	var err error
+func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
+	// If mongofiles --get ... is called, then query for all files
+        // specified in mf.FileNameList -- otherwise, preserve correct
+        // behavior for mongofiles --get_id ...
+	if len(mf.FileNameList) > 0 {
+                query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 
-	var queryProp string
-	var query string
-
-	if mf.Id != "" {
-		queryProp = "_id"
-		query = mf.Id
-
-		id, err := mf.parseOrCreateID()
+                gridFiles, err := mf.findGFSFiles(query)
 		if err != nil {
 			return nil, err
-		}
-		gridFiles, err = mf.findGFSFiles(bson.M{"_id": id})
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		queryProp = "name"
-		query = mf.FileName
+                }
 
-		gridFiles, err = mf.findGFSFiles(bson.M{"filename": mf.FileName})
-		if err != nil {
-			return nil, err
+                return gridFiles, nil
+        } else {
+		var gridFiles []*gfsFile
+		var err error
+
+		var queryProp string
+		var query string
+
+		if mf.Id != "" {
+			queryProp = "_id"
+			query = mf.Id
+
+			id, err := mf.parseOrCreateID()
+			if err != nil {
+				return nil, err
+			}
+			gridFiles, err = mf.findGFSFiles(bson.M{"_id": id})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			queryProp = "name"
+			query = mf.FileName
+
+			gridFiles, err = mf.findGFSFiles(bson.M{"filename": mf.FileName})
+			if err != nil {
+				return nil, err
+			}
 		}
-	}
 
-	if len(gridFiles) == 0 {
-		return nil, fmt.Errorf("no such file with %v: %v", queryProp, query)
-	}
-
-	return gridFiles[0], nil
+		if len(gridFiles) == 0 {
+			return nil, fmt.Errorf("no such file with %v: %v", queryProp, query)
+		}
+		
+		return gridFiles[0:], nil
+        }
 }
 
 // Delete all files with the given filename.
@@ -271,11 +303,12 @@ func (mf *MongoFiles) deleteAll(filename string) error {
 
 // handleDeleteID contains the logic for the 'delete_id' command
 func (mf *MongoFiles) handleDeleteID() error {
-	file, err := mf.getTargetGFSFile()
+	files, err := mf.getTargetGFSFile()
 	if err != nil {
 		return err
 	}
 
+        file := files[0]
 	if err := file.Delete(); err != nil {
 		return err
 	}
@@ -389,18 +422,41 @@ func (mf *MongoFiles) put(id interface{}, name string) (bytesWritten int64, err 
 
 // handlePut contains the logic for the 'put' and 'put_id' commands
 func (mf *MongoFiles) handlePut() error {
-	id, err := mf.parseOrCreateID()
-	if err != nil {
-		return err
-	}
+	// If mongofiles --put ... is called, i.e. with multiple supporting
+        // arguments, then add gridFiles specified in mf.FileNameList
+	// (see TOOLS-2667). Otherwise, if mongofiles --put_id is called, then
+        // preserve existing behavior.
+	if len(mf.FileNameList) > 0 {
+		for _, file := range mf.FileNameList {
+			id, err := mf.parseOrCreateID()
+			if err != nil {
+				return err
+			}
 
-	n, err := mf.put(id, mf.FileName)
-	if err != nil {
-		return err
-	}
+			log.Logvf(log.Always, "adding gridFile: %v\n", file)
 
-	log.Logvf(log.DebugLow, "copied %v bytes to server", n)
-	log.Logvf(log.Always, fmt.Sprintf("added gridFile: %v\n", mf.FileName))
+			n, err := mf.put(id, file)
+			if err != nil {
+				log.Logvf(log.Always, "error adding gridFile: %v\n", err)
+				return err
+			}
+			log.Logvf(log.DebugLow, "copied %v bytes to server", n)
+			log.Logvf(log.Always, "added gridFile: %v\n", file)
+		}
+                log.Logv(log.Always, "Finished adding gridFiles -- cleaning up")
+        } else {
+		id, err := mf.parseOrCreateID()
+		if err != nil {
+			return err
+		}
+		
+		n, err := mf.put(id, mf.FileName)
+		if err != nil {
+			return err
+		}
+		log.Logvf(log.DebugLow, "copied %v bytes to server", n)
+		log.Logvf(log.Always, fmt.Sprintf("added gridFile: %v\n", mf.FileName))
+        }
 
 	return nil
 }

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -237,7 +237,7 @@ func (mf *MongoFiles) findGFSFiles(query bson.M) (files []*gfsFile, err error) {
 func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
 	var gridFiles []*gfsFile
 	var err error
-	
+
 	// If mongofiles --get ... is called, then query for all files
 	// specified in mf.FileNameList -- otherwise, preserve correct
 	// behavior for mongofiles --get_id ...
@@ -279,7 +279,7 @@ func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
 		}
 	}
 
-        return gridFiles, err
+	return gridFiles, err
 }
 
 // Delete all files with the given filename.

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -61,9 +61,9 @@ type MongoFiles struct {
 	// ID to put into GridFS
 	Id string
 
-        // List of filenames for use as supporting
-        // arguments in --put and --get
-        FileNameList []string
+	// List of filenames for use as supporting
+	// arguments in --put and --get
+	FileNameList []string
 
 	// GridFS bucket to operate on
 	bucket *gridfs.Bucket
@@ -117,15 +117,15 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		}
 	case Put, Get:
 		// monogofiles --put and mongofiles --get should work over
-                // a list of files, i.e. by using mf.FileNameList -- see
-                // TOOLS-2667 for user-level specification
-                if len(args) == 1 || args[1] == "" {
+		// a list of files, i.e. by using mf.FileNameList -- see
+		// TOOLS-2667 for user-level specification
+		if len(args) == 1 || args[1] == "" {
 			return fmt.Errorf("'%v' argument missing", args[0])
-                }
+		}
 
 		if len(args) == 2 {
 			mf.FileName = args[1]
-                }
+		}
 		mf.FileNameList = args[1:]
 	case Search, Delete:
 		if len(args) > 2 {
@@ -203,11 +203,11 @@ func (mf *MongoFiles) handleGet() (err error) {
 		return err
 	}
 
-        for _, file := range files {
+	for _, file := range files {
 		if err = mf.writeGFSFileToLocal(file); err != nil {
 			return err
 		}
-        }
+	}
 
 	return nil
 }
@@ -236,18 +236,18 @@ func (mf *MongoFiles) findGFSFiles(query bson.M) (files []*gfsFile, err error) {
 // Gets the GridFS file the options specify. Use this for the get family of commands.
 func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
 	// If mongofiles --get ... is called, then query for all files
-        // specified in mf.FileNameList -- otherwise, preserve correct
-        // behavior for mongofiles --get_id ...
+	// specified in mf.FileNameList -- otherwise, preserve correct
+	// behavior for mongofiles --get_id ...
 	if len(mf.FileNameList) > 0 {
-                query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
+		query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 
-                gridFiles, err := mf.findGFSFiles(query)
+		gridFiles, err := mf.findGFSFiles(query)
 		if err != nil {
 			return nil, err
-                }
+		}
 
-                return gridFiles, nil
-        } else {
+		return gridFiles, nil
+	} else {
 		var gridFiles []*gfsFile
 		var err error
 
@@ -279,9 +279,9 @@ func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
 		if len(gridFiles) == 0 {
 			return nil, fmt.Errorf("no such file with %v: %v", queryProp, query)
 		}
-		
+
 		return gridFiles[0:], nil
-        }
+	}
 }
 
 // Delete all files with the given filename.
@@ -308,7 +308,7 @@ func (mf *MongoFiles) handleDeleteID() error {
 		return err
 	}
 
-        file := files[0]
+	file := files[0]
 	if err := file.Delete(); err != nil {
 		return err
 	}
@@ -423,9 +423,9 @@ func (mf *MongoFiles) put(id interface{}, name string) (bytesWritten int64, err 
 // handlePut contains the logic for the 'put' and 'put_id' commands
 func (mf *MongoFiles) handlePut() error {
 	// If mongofiles --put ... is called, i.e. with multiple supporting
-        // arguments, then add gridFiles specified in mf.FileNameList
+	// arguments, then add gridFiles specified in mf.FileNameList
 	// (see TOOLS-2667). Otherwise, if mongofiles --put_id is called, then
-        // preserve existing behavior.
+	// preserve existing behavior.
 	if len(mf.FileNameList) > 0 {
 		for _, file := range mf.FileNameList {
 			id, err := mf.parseOrCreateID()
@@ -443,20 +443,20 @@ func (mf *MongoFiles) handlePut() error {
 			log.Logvf(log.DebugLow, "copied %v bytes to server", n)
 			log.Logvf(log.Always, "added gridFile: %v\n", file)
 		}
-                log.Logv(log.Always, "Finished adding gridFiles -- cleaning up")
-        } else {
+		log.Logv(log.Always, "Finished adding gridFiles -- cleaning up")
+	} else {
 		id, err := mf.parseOrCreateID()
 		if err != nil {
 			return err
 		}
-		
+
 		n, err := mf.put(id, mf.FileName)
 		if err != nil {
 			return err
 		}
 		log.Logvf(log.DebugLow, "copied %v bytes to server", n)
 		log.Logvf(log.Always, fmt.Sprintf("added gridFile: %v\n", mf.FileName))
-        }
+	}
 
 	return nil
 }

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -235,22 +235,20 @@ func (mf *MongoFiles) findGFSFiles(query bson.M) (files []*gfsFile, err error) {
 
 // Gets the GridFS file the options specify. Use this for the get family of commands.
 func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
+	var gridFiles []*gfsFile
+	var err error
+	
 	// If mongofiles --get ... is called, then query for all files
 	// specified in mf.FileNameList -- otherwise, preserve correct
 	// behavior for mongofiles --get_id ...
 	if len(mf.FileNameList) > 0 {
 		query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 
-		gridFiles, err := mf.findGFSFiles(query)
+		gridFiles, err = mf.findGFSFiles(query)
 		if err != nil {
 			return nil, err
 		}
-
-		return gridFiles, nil
 	} else {
-		var gridFiles []*gfsFile
-		var err error
-
 		var queryProp string
 		var query string
 
@@ -279,9 +277,9 @@ func (mf *MongoFiles) getTargetGFSFile() ([]*gfsFile, error) {
 		if len(gridFiles) == 0 {
 			return nil, fmt.Errorf("no such file with %v: %v", queryProp, query)
 		}
-
-		return gridFiles[0:], nil
 	}
+
+        return gridFiles, err
 }
 
 // Delete all files with the given filename.

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -122,10 +122,6 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 			return fmt.Errorf("'%v' argument missing", args[0])
 		}
 
-		if len(args) == 2 {
-			mf.FileName = args[1]
-		}
-
 		mf.FileNameList = args[1:]
 	case Search, Delete:
 		if len(args) > 2 {

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -265,8 +265,8 @@ func TestValidArguments(t *testing.T) {
 			So(err.Error(), ShouldEqual, "no command specified")
 		})
 
-		Convey("(list|get|put|delete|search|get_id|delete_id) should error out when more than 1 positional argument (except URI) is provided", func() {
-			for _, command := range []string{"list", "get", "put", "delete", "search", "get_id", "delete_id"} {
+		Convey("(list|delete|search|get_id|delete_id) should error out when more than 1 positional argument (except URI) is provided", func() {
+			for _, command := range []string{"list", "delete", "search", "get_id", "delete_id"} {
 				args := []string{command, "arg1", "arg2"}
 				err := mf.ValidateCommand(args)
 				So(err, ShouldNotBeNil)

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-        "io"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -122,10 +122,10 @@ func simpleMongoFilesInstanceWithMultipleFileNames(command string, fnames ...str
 	mongofiles, err := simpleMongoFilesInstanceCommandOnly(command)
 	if err != nil {
 		return nil, err
-        }
+	}
 
-        mongofiles.FileNameList = fnames
-        return mongofiles, nil
+	mongofiles.FileNameList = fnames
+	return mongofiles, nil
 }
 
 func simpleMongoFilesInstanceWithFilenameAndID(command, fname, ID string) (*MongoFiles, error) {
@@ -306,15 +306,15 @@ func TestValidArguments(t *testing.T) {
 
 		Convey("It should not error out when the get command is given multiple supporting arguments", func() {
 			args := []string{"get", "foo", "bar", "baz"}
-                        So(mf.ValidateCommand(args), ShouldBeNil)
-                        So(mf.FileNameList, ShouldResemble, []string{"foo", "bar", "baz"})
-                })
+			So(mf.ValidateCommand(args), ShouldBeNil)
+			So(mf.FileNameList, ShouldResemble, []string{"foo", "bar", "baz"})
+		})
 
 		Convey("It should not error out when the put command is given multiple supporting arguments", func() {
 			args := []string{"put", "foo", "bar", "baz"}
-                        So(mf.ValidateCommand(args), ShouldBeNil)
-                        So(mf.FileNameList, ShouldResemble, []string{"foo", "bar", "baz"})
-                })
+			So(mf.ValidateCommand(args), ShouldBeNil)
+			So(mf.FileNameList, ShouldResemble, []string{"foo", "bar", "baz"})
+		})
 
 		Convey("It should error out when any of (get|put|delete|search|get_id|delete_id) not given supporting argument", func() {
 			for _, command := range []string{"get", "put", "delete", "search", "get_id", "delete_id"} {
@@ -454,51 +454,51 @@ func TestMongoFilesCommands(t *testing.T) {
 			})
 		})
 
-                Convey("Testing the 'get;;; command with multiple files that are in GridFS should", func() {
+		Convey("Testing the 'get;;; command with multiple files that are in GridFS should", func() {
 			testFiles := []string{"testfile1", "testfile2", "testfile3"}
 			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("get", testFiles...)
-                        So(err, ShouldBeNil)
-                        So(mf, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(mf, ShouldNotBeNil)
 
-                        var buff bytes.Buffer
-                        log.SetWriter(&buff)
+			var buff bytes.Buffer
+			log.SetWriter(&buff)
 
-                        str, err := mf.Run(false)
-                        So(err, ShouldBeNil)
-                        So(str, ShouldBeEmpty)
+			str, err := mf.Run(false)
+			So(err, ShouldBeNil)
+			So(str, ShouldBeEmpty)
 
-                        Convey("log an event specifying the completion of each file", func() {
+			Convey("log an event specifying the completion of each file", func() {
 				logOutput := buff.String()
 
-                                for _, testFile := range testFiles {
+				for _, testFile := range testFiles {
 					logEvent := fmt.Sprintf("finished writing to %v", testFile)
 					So(logOutput, ShouldContainSubstring, logEvent)
-                                }
-                        })
+				}
+			})
 
-                        Convey("copy the files to the local filesystem", func() {
+			Convey("copy the files to the local filesystem", func() {
 				for _, testFileName := range testFiles {
 					testFile, err := os.Open(testFileName)
-                                        So(err, ShouldBeNil)
-                                        defer testFile.Close()
+					So(err, ShouldBeNil)
+					defer testFile.Close()
 
-                                        bytesGotten, err := ioutil.ReadAll(testFile)
-                                        So(err, ShouldBeNil)
-                                        So(len(bytesGotten), ShouldEqual, bytesExpected[testFileName])
-                                }
-                        })
+					bytesGotten, err := ioutil.ReadAll(testFile)
+					So(err, ShouldBeNil)
+					So(len(bytesGotten), ShouldEqual, bytesExpected[testFileName])
+				}
+			})
 
-                        // Remove test files from local FS so that there
-                        // no naming collisions
-                        Reset(func() {
+			// Remove test files from local FS so that there
+			// no naming collisions
+			Reset(func() {
 				for _, testFile := range testFiles {
 					if fileExists(testFile) {
 						err = os.Remove(testFile)
-                                                So(err, ShouldBeNil)
-                                        }
-                                }
-                        })
-                })
+						So(err, ShouldBeNil)
+					}
+				}
+			})
+		})
 
 		Convey("Testing the 'get_id' command with a file that is in GridFS should", func() {
 			mf, _ := simpleMongoFilesInstanceWithFilename("get", "testfile1")
@@ -607,18 +607,17 @@ func TestMongoFilesCommands(t *testing.T) {
 
 		})
 
-                Convey("Testing the 'put' command with multiple copies of the lorem ipsum file with 287613 bytes should", func() {
+		Convey("Testing the 'put' command with multiple copies of the lorem ipsum file with 287613 bytes should", func() {
 			const (
-				numCopies = 3
-                                numBytes = 287613
-                                copyFormat = "lorem_ipsum_copy_%v.txt"
+				numCopies  = 3
+				numBytes   = 287613
+				copyFormat = "lorem_ipsum_copy_%v.txt"
 			)
 
 			originalFile := util.ToUniversalPath("testdata/lorem_ipsum_287613_bytes.txt")
-			
-                        
-                        testFiles := make([]string, numCopies)
-                        for i := 0; i < numCopies; i++ {
+
+			testFiles := make([]string, numCopies)
+			for i := 0; i < numCopies; i++ {
 				newFile := util.ToUniversalPath("testdata/" + fmt.Sprintf(copyFormat, i))
 
 				// Makes new copies of lorem ipsum file
@@ -639,57 +638,57 @@ func TestMongoFilesCommands(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					
+
 					return nil
-                                }(originalFile, newFile)
-                                So(err, ShouldBeNil)
-                                
+				}(originalFile, newFile)
+				So(err, ShouldBeNil)
+
 				testFiles[i] = newFile
-                        }
+			}
 
-                        mf, err := simpleMongoFilesInstanceWithMultipleFileNames("put", testFiles...)
-                        So(err, ShouldBeNil)
+			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("put", testFiles...)
+			So(err, ShouldBeNil)
 
-                        var buff bytes.Buffer
-                        log.SetWriter(&buff)
+			var buff bytes.Buffer
+			log.SetWriter(&buff)
 
-                        str, err := mf.Run(false)
-                        So(err, ShouldBeNil)
-                        So(str, ShouldBeEmpty)
+			str, err := mf.Run(false)
+			So(err, ShouldBeNil)
+			So(str, ShouldBeEmpty)
 
-                        Convey("log an event specifying the completion of each file", func() {
+			Convey("log an event specifying the completion of each file", func() {
 				const (
 					logAdding = "adding gridFile: %v"
-                                        logAdded = "added gridFile: %v"
-                                )
+					logAdded  = "added gridFile: %v"
+				)
 
-                                logOutput := buff.String()
+				logOutput := buff.String()
 
-                                for _, testFile := range testFiles {
+				for _, testFile := range testFiles {
 					So(logOutput, ShouldContainSubstring, fmt.Sprintf(logAdding, testFile))
 					So(logOutput, ShouldContainSubstring, fmt.Sprintf(logAdded, testFile))
 
-                                }
-                        })
+				}
+			})
 
-                        Convey("and files should exist in GridFS", func() {
+			Convey("and files should exist in GridFS", func() {
 				bytesGotten, err := getFilesAndBytesListFromGridFS()
-                                So(err, ShouldBeNil)
+				So(err, ShouldBeNil)
 
 				for _, testFile := range testFiles {
-                                        So(bytesGotten, ShouldContainKey, testFile)
-                                        So(bytesGotten[testFile], ShouldEqual, numBytes)
+					So(bytesGotten, ShouldContainKey, testFile)
+					So(bytesGotten[testFile], ShouldEqual, numBytes)
 				}
-                        })
+			})
 
 			Convey("and each file should have exactly the same content as the original file", func() {
 				loremIpsumOrig, err := os.Open(util.ToUniversalPath("testdata/lorem_ipsum_287613_bytes.txt"))
 				So(err, ShouldBeNil)
-                                defer loremIpsumOrig.Close()
+				defer loremIpsumOrig.Close()
 
 				const localFileName = "lorem_ipsum_copy.txt"
 				buff.Truncate(0)
-                                for _, testFile := range testFiles {
+				for _, testFile := range testFiles {
 					mfAfter, err := simpleMongoFilesInstanceWithFilename("get", testFile)
 					So(err, ShouldBeNil)
 					So(mf, ShouldNotBeNil)
@@ -704,12 +703,12 @@ func TestMongoFilesCommands(t *testing.T) {
 						loremIpsumCopy, err := os.Open(localFileName)
 						So(err, ShouldBeNil)
 						defer loremIpsumCopy.Close()
-						
+
 						isContentSame, err := fileContentsCompare(loremIpsumOrig, loremIpsumCopy, t)
 						So(err, ShouldBeNil)
 						So(isContentSame, ShouldBeTrue)
 					})
-                                }
+				}
 
 				Reset(func() {
 					err = os.Remove(localFileName)
@@ -717,16 +716,16 @@ func TestMongoFilesCommands(t *testing.T) {
 				})
 
 			})
-                        
-                        Reset(func() {
+
+			Reset(func() {
 				for _, testFile := range testFiles {
 					if fileExists(testFile) {
 						err = os.Remove(testFile)
-                                        }
-                                        So(err, ShouldBeNil)
-                                }
-                        })
-                })
+					}
+					So(err, ShouldBeNil)
+				}
+			})
+		})
 
 		Convey("Testing the 'put_id' command by putting some lorem ipsum file with 287613 bytes with different ids should succeed", func() {
 			for _, idToTest := range []string{`test_id`, `{"a":"b"}`, `{"$numberLong":"999999999999999"}`, `{"a":{"b":{"c":{}}}}`} {

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -454,7 +454,7 @@ func TestMongoFilesCommands(t *testing.T) {
 			})
 		})
 
-		Convey("Testing the 'get;;; command with multiple files that are in GridFS should", func() {
+		Convey("Testing the 'get' command with multiple files that are in GridFS should", func() {
 			testFiles := []string{"testfile1", "testfile2", "testfile3"}
 			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("get", testFiles...)
 			So(err, ShouldBeNil)

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -436,6 +436,51 @@ func TestMongoFilesCommands(t *testing.T) {
 
 			})
 		})
+		Convey("Testing the 'get' command with a regex specifying multiple files should", func() {
+			testRegex := "test*"
+			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("get", testRegex)
+			So(err, ShouldBeNil)
+			So(mf, ShouldNotBeNil)
+
+			str, err := mf.Run(false)
+
+			Convey("result in a 'requested files not found: ...' error message", func() {
+				expectedErr := fmt.Sprintf("requested files not found: %v", mf.FileNameList)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, expectedErr)
+				So(str, ShouldBeEmpty)
+			})
+
+			Convey("not copy any files over to the local filesystem", func() {
+				for testFileName := range testFiles {
+					_, err := os.Stat(testFileName)
+					So(err, ShouldNotBeNil)
+				}
+			})
+		})
+
+		Convey("Testing the 'get' command with a regex specifying multiple files in the /<pattern>/ syntax should", func() {
+			testRegex := "/test*/"
+			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("get", testRegex)
+			So(err, ShouldBeNil)
+			So(mf, ShouldNotBeNil)
+
+			str, err := mf.Run(false)
+
+			Convey("result in a 'requested files not found: ...' error message", func() {
+				expectedErr := fmt.Sprintf("requested files not found: %v", mf.FileNameList)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, expectedErr)
+				So(str, ShouldBeEmpty)
+			})
+
+			Convey("not copy any files over to the local filesystem", func() {
+				for testFileName := range testFiles {
+					_, err := os.Stat(testFileName)
+					So(err, ShouldNotBeNil)
+				}
+			})
+		})
 
 		Convey("Testing the 'get' command with multiple files that are in GridFS should", func() {
 			testFiles := []string{"testfile1", "testfile2", "testfile3"}

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -215,11 +215,11 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				},
 			},
 			{
-				InputArgs: []string{"get", "foo"},
+				InputArgs: []string{"mongodb://foo", "get", "foo"},
 				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{
 						URI: &options.URI{
-							ConnectionString: "mongodb://localhost/",
+							ConnectionString: "mongodb://foo",
 						},
 					},
 				},

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -156,6 +156,20 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					Command:  "put",
 				},
 			},
+                        {
+				InputArgs: []string{"put", "foo", "bar", "baz"},
+				ExpectedOpts: Options{
+					ToolOptions: &options.ToolOptions{
+						URI: &options.URI{
+							ConnectionString: "mongodb://localhost/",
+						},
+					},
+				},
+				ExpectedMF: MongoFiles{
+					FileNameList: []string{"foo", "bar", "baz"},
+					Command:  "put",
+				},
+			},
 			{
 				InputArgs: []string{"mongodb://foo", "put", "foo"},
 				ExpectedOpts: Options{
@@ -215,7 +229,21 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				},
 			},
 			{
-				InputArgs: []string{"mongodb://foo", "get", "foo"},
+				InputArgs: []string{"get", "foo"},
+				ExpectedOpts: Options{
+					ToolOptions: &options.ToolOptions{
+						URI: &options.URI{
+							ConnectionString: "mongodb://localhost/",
+						},
+					},
+				},
+				ExpectedMF: MongoFiles{
+					FileName: "foo",
+					Command:  "get",
+				},
+			},
+			{
+				InputArgs: []string{"mongodb://foo", "get", "foo", "bar", "baz"},
 				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{
 						URI: &options.URI{
@@ -224,7 +252,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					},
 				},
 				ExpectedMF: MongoFiles{
-					FileName: "foo",
+					FileNameList: []string{"foo", "bar", "baz"},
 					Command:  "get",
 				},
 			},

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -156,7 +156,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					Command:  "put",
 				},
 			},
-                        {
+			{
 				InputArgs: []string{"put", "foo", "bar", "baz"},
 				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{
@@ -167,7 +167,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				},
 				ExpectedMF: MongoFiles{
 					FileNameList: []string{"foo", "bar", "baz"},
-					Command:  "put",
+					Command:      "put",
 				},
 			},
 			{
@@ -253,7 +253,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				},
 				ExpectedMF: MongoFiles{
 					FileNameList: []string{"foo", "bar", "baz"},
-					Command:  "get",
+					Command:      "get",
 				},
 			},
 			{

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -152,8 +152,8 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					},
 				},
 				ExpectedMF: MongoFiles{
-					FileName: "foo",
-					Command:  "put",
+					FileNameList: []string{"foo"},
+					Command:      "put",
 				},
 			},
 			{
@@ -180,8 +180,8 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					},
 				},
 				ExpectedMF: MongoFiles{
-					FileName: "foo",
-					Command:  "put",
+					FileNameList: []string{"foo"},
+					Command:      "put",
 				},
 			},
 			{
@@ -224,8 +224,8 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					},
 				},
 				ExpectedMF: MongoFiles{
-					FileName: "foo",
-					Command:  "get",
+					FileNameList: []string{"foo"},
+					Command:      "get",
 				},
 			},
 			{
@@ -238,8 +238,8 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					},
 				},
 				ExpectedMF: MongoFiles{
-					FileName: "foo",
-					Command:  "get",
+					FileNameList: []string{"foo"},
+					Command:      "get",
 				},
 			},
 			{
@@ -445,6 +445,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 			} else {
 				So(err, ShouldBeNil)
 				So(mf.FileName, ShouldEqual, tc.ExpectedMF.FileName)
+				So(mf.FileNameList, ShouldResemble, tc.ExpectedMF.FileNameList)
 				So(mf.Command, ShouldEqual, tc.ExpectedMF.Command)
 				So(mf.Id, ShouldEqual, tc.ExpectedMF.Id)
 				So(opts.ConnectionString, ShouldEqual, tc.ExpectedOpts.ConnectionString)


### PR DESCRIPTION
This PR verifies _mongofiles_ behavior under the "$in" query supplied in #283, as specified by the [request for investigation](https://github.com/mongodb/mongo-tools/pull/283#discussion_r460248574) into the matter by @huan-Mongo. It is supplied here to be separately reviewed -- however, we do not need to merge it, since it only exists to test some behavior that we previously weren't sure about.