### PR TITLE
TOOLS-2668: Create regex interface for getting files from remote FS in mongofiles

### DIFF
--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -273,15 +273,15 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 	} else {
 		query = bson.M{"filename": mf.FileName}
 	}
-	
-	gridFiles, err = mf.findGFSFiles(query)
-        if err != nil {
-		return nil, err
-        }
 
-        if len(gridFiles) == 0 {
+	gridFiles, err = mf.findGFSFiles(query)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(gridFiles) == 0 {
 		return nil, fmt.Errorf("Could not find any files matching the query specified")
-        }
+	}
 
 	return gridFiles, err
 }

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -33,7 +33,7 @@ const (
 	PutID    = "put_id"
 	Get      = "get"
 	GetID    = "get_id"
-        GetRegex = "get_regex"
+	GetRegex = "get_regex"
 	Delete   = "delete"
 	DeleteID = "delete_id"
 )
@@ -66,9 +66,9 @@ type MongoFiles struct {
 	// arguments in put and get commands
 	FileNameList []string
 
-        // Regular expression as supporting argument
-        // for get_regex
-        FileNameRegex string
+	// Regular expression as supporting argument
+	// for get_regex
+	FileNameRegex string
 
 	// GridFS bucket to operate on
 	bucket *gridfs.Bucket
@@ -130,12 +130,12 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		mf.FileNameList = args[1:]
 	case GetRegex:
 		// mongofiles get_regex ... should work over a PCRE
-                // and a string of options passed to the $regex query
-                if len(args) == 1 {
+		// and a string of options passed to the $regex query
+		if len(args) == 1 {
 			return fmt.Errorf("'%v' argument missing", args[0])
-                }
+		}
 
-                mf.FileNameRegex = args[1]
+		mf.FileNameRegex = args[1]
 	case Search, Delete:
 		if len(args) > 2 {
 			return fmt.Errorf("too many non-URI positional arguments (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)")
@@ -262,16 +262,21 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 			return nil, fmt.Errorf("requested files not found: %v", mf.FileNameList)
 		}
 	} else if mf.FileNameRegex != "" {
-		query := bson.M{"filename": bson.M{"$regex": mf.FileNameRegex, "$options": mf.StorageOptions.RegexOptions}}
+		query := bson.M{
+			"filename": bson.M{
+				"$regex":   mf.FileNameRegex,
+				"$options": mf.StorageOptions.RegexOptions,
+			},
+		}
 
 		gridFiles, err = mf.findGFSFiles(query)
-                if err != nil {
+		if err != nil {
 			return nil, err
-                }
+		}
 
-                if len(gridFiles) == 0 {
+		if len(gridFiles) == 0 {
 			return nil, fmt.Errorf("files matching the following pattern were not found: %v", mf.FileNameRegex)
-                }
+		}
 	} else {
 		var queryProp string
 		var query string

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -133,6 +133,8 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		// and a string of options passed to the $regex query
 		if len(args) == 1 || args[1] == "" {
 			return fmt.Errorf("'%v' argument missing", args[0])
+		} else if len(args) > 2 {
+			return fmt.Errorf("too many non-URI positional arguments (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)")
 		}
 
 		mf.FileNameRegex = args[1]

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -249,66 +249,39 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 	var gridFiles []*gfsFile
 	var err error
 
+	var query bson.M
+
 	// If mongofiles get ... is called, then query for all files
 	// specified in mf.FileNameList -- otherwise, preserve correct
 	// behavior for mongofiles get_id ...
 	if len(mf.FileNameList) > 0 {
-		query := bson.M{"filename": bson.M{"$in": mf.FileNameList}}
-
-		gridFiles, err = mf.findGFSFiles(query)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(gridFiles) < len(mf.FileNameList) {
-			return nil, fmt.Errorf("requested files not found: %v", mf.FileNameList)
-		}
+		query = bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 	} else if mf.FileNameRegex != "" {
-		query := bson.M{
+		query = bson.M{
 			"filename": bson.M{
 				"$regex":   mf.FileNameRegex,
 				"$options": mf.StorageOptions.RegexOptions,
 			},
 		}
-
-		gridFiles, err = mf.findGFSFiles(query)
+	} else if mf.Id != "" {
+		id, err := mf.parseOrCreateID()
 		if err != nil {
 			return nil, err
 		}
 
-		if len(gridFiles) == 0 {
-			return nil, fmt.Errorf("files matching the following pattern were not found: %v", mf.FileNameRegex)
-		}
+		query = bson.M{"_id": id}
 	} else {
-		var queryProp string
-		var query string
-
-		if mf.Id != "" {
-			queryProp = "_id"
-			query = mf.Id
-
-			id, err := mf.parseOrCreateID()
-			if err != nil {
-				return nil, err
-			}
-			gridFiles, err = mf.findGFSFiles(bson.M{"_id": id})
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			queryProp = "name"
-			query = mf.FileName
-
-			gridFiles, err = mf.findGFSFiles(bson.M{"filename": mf.FileName})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if len(gridFiles) == 0 {
-			return nil, fmt.Errorf("no such file with %v: %v", queryProp, query)
-		}
+		query = bson.M{"filename": mf.FileName}
 	}
+	
+	gridFiles, err = mf.findGFSFiles(query)
+        if err != nil {
+		return nil, err
+        }
+
+        if len(gridFiles) == 0 {
+		return nil, fmt.Errorf("Could not find any files matching the query specified")
+        }
 
 	return gridFiles, err
 }

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -33,6 +33,7 @@ const (
 	PutID    = "put_id"
 	Get      = "get"
 	GetID    = "get_id"
+        GetRegex = "get_regex"
 	Delete   = "delete"
 	DeleteID = "delete_id"
 )
@@ -64,6 +65,10 @@ type MongoFiles struct {
 	// List of filenames for use as supporting
 	// arguments in put and get commands
 	FileNameList []string
+
+        // Regular expression as supporting argument
+        // for get_regex
+        FileNameRegex string
 
 	// GridFS bucket to operate on
 	bucket *gridfs.Bucket
@@ -123,6 +128,14 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		}
 
 		mf.FileNameList = args[1:]
+	case GetRegex:
+		// mongofiles get_regex ... should work over a PCRE
+                // and a string of options passed to the $regex query
+                if len(args) == 1 {
+			return fmt.Errorf("'%v' argument missing", args[0])
+                }
+
+                mf.FileNameRegex = args[1]
 	case Search, Delete:
 		if len(args) > 2 {
 			return fmt.Errorf("too many non-URI positional arguments (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)")
@@ -248,6 +261,17 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 		if len(gridFiles) < len(mf.FileNameList) {
 			return nil, fmt.Errorf("requested files not found: %v", mf.FileNameList)
 		}
+	} else if mf.FileNameRegex != "" {
+		query := bson.M{"filename": bson.M{"$regex": mf.FileNameRegex, "$options": mf.StorageOptions.RegexOptions}}
+
+		gridFiles, err = mf.findGFSFiles(query)
+                if err != nil {
+			return nil, err
+                }
+
+                if len(gridFiles) == 0 {
+			return nil, fmt.Errorf("files matching the following pattern were not found: %v", mf.FileNameRegex)
+                }
 	} else {
 		var queryProp string
 		var query string
@@ -503,7 +527,7 @@ func (mf *MongoFiles) Run(displayHost bool) (output string, finalErr error) {
 
 		output, err = mf.findAndDisplay(query)
 
-	case Get, GetID:
+	case Get, GetID, GetRegex:
 		err = mf.handleGet()
 
 	case Put, PutID:

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -247,7 +247,7 @@ func (mf *MongoFiles) findGFSFiles(query bson.M) (files []*gfsFile, err error) {
 // Gets the GridFS file the options specify. Use this for the get family of commands.
 func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 	var query bson.M
-	var minimumExpectedDocs int = 1
+	var minimumExpectedDocs = 1
 	var minimumExpectedDocsError error
 
 	if len(mf.FileNameList) > 0 {

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -131,7 +131,7 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 	case GetRegex:
 		// mongofiles get_regex ... should work over a PCRE
 		// and a string of options passed to the $regex query
-		if len(args) == 1 {
+		if len(args) == 1 || args[1] == "" {
 			return fmt.Errorf("'%v' argument missing", args[0])
 		}
 

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -531,6 +531,70 @@ func TestMongoFilesCommands(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 		})
+
+                Convey("Testing the 'get_regex' command should", func() {
+			mf, err := simpleMongoFilesInstanceCommandOnly(GetRegex)
+			So(err, ShouldBeNil)
+
+                        Convey("return expected test files, but no others, when called without any server options", func() {
+				mf.FileNameRegex = "testfile[1-3]"
+
+				str, err := mf.Run(false)
+				So(err, ShouldBeNil)
+				So(str, ShouldBeEmpty)
+
+				// Regex should get all testfiles but testfile4
+                                expectedTestFiles := map[string]struct{}{
+					"testfile1": {},
+                                        "testfile2": {},
+                                        "testfile3": {},
+                                }
+
+                                for testFile := range testFiles {
+					_, err := os.Stat(testFile)
+					if _, ok := expectedTestFiles[testFile]; ok {
+						So(err, ShouldBeNil)
+                                        } else {
+						So(err, ShouldNotBeNil)
+                                        }
+                                }
+                        })
+
+                        Convey("return expected test files, but no others, when called with server options", func() {
+				// Check with case-insensitivity
+				mf.FileNameRegex = "tEsTfIlE[1-2]"
+                                mf.StorageOptions.RegexOptions = "i"
+
+                                str, err := mf.Run(false)
+                                So(err, ShouldBeNil)
+                                So(str, ShouldBeEmpty)
+
+                                expectedTestFiles := map[string]struct{}{
+					"testfile1": {},
+                                        "testfile2": {},
+                                }
+
+                                for testFile := range testFiles {
+					_, err := os.Stat(testFile)
+					if _, ok := expectedTestFiles[testFile]; ok {
+						So(err, ShouldBeNil)
+                                        } else {
+						So(err, ShouldNotBeNil)
+                                        }
+                                }
+                        })
+
+                        Reset(func() {
+				// Remove any testfiles written to local filesystem
+                                for testFile := range testFiles {
+					if _, err := os.Stat(testFile); err == nil {
+						err = os.Remove(testFile)
+                                                So(err, ShouldBeNil)
+                                        }
+                                }
+                        })
+                })
+		
 		Convey("Testing the 'put' command with multiple lorem ipsum files bytes should", func() {
 			localTestFiles := []string{
 				util.ToUniversalPath("testdata/lorem_ipsum_multi_args_0.txt"),

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -532,11 +532,11 @@ func TestMongoFilesCommands(t *testing.T) {
 			})
 		})
 
-                Convey("Testing the 'get_regex' command should", func() {
+		Convey("Testing the 'get_regex' command should", func() {
 			mf, err := simpleMongoFilesInstanceCommandOnly(GetRegex)
 			So(err, ShouldBeNil)
 
-                        Convey("return expected test files, but no others, when called without any server options", func() {
+			Convey("return expected test files, but no others, when called without any server options", func() {
 				mf.FileNameRegex = "testfile[1-3]"
 
 				str, err := mf.Run(false)
@@ -544,57 +544,57 @@ func TestMongoFilesCommands(t *testing.T) {
 				So(str, ShouldBeEmpty)
 
 				// Regex should get all testfiles but testfile4
-                                expectedTestFiles := map[string]struct{}{
+				expectedTestFiles := map[string]struct{}{
 					"testfile1": {},
-                                        "testfile2": {},
-                                        "testfile3": {},
-                                }
+					"testfile2": {},
+					"testfile3": {},
+				}
 
-                                for testFile := range testFiles {
+				for testFile := range testFiles {
 					_, err := os.Stat(testFile)
 					if _, ok := expectedTestFiles[testFile]; ok {
 						So(err, ShouldBeNil)
-                                        } else {
+					} else {
 						So(err, ShouldNotBeNil)
-                                        }
-                                }
-                        })
+					}
+				}
+			})
 
-                        Convey("return expected test files, but no others, when called with server options", func() {
+			Convey("return expected test files, but no others, when called with server options", func() {
 				// Check with case-insensitivity
 				mf.FileNameRegex = "tEsTfIlE[1-2]"
-                                mf.StorageOptions.RegexOptions = "i"
+				mf.StorageOptions.RegexOptions = "i"
 
-                                str, err := mf.Run(false)
-                                So(err, ShouldBeNil)
-                                So(str, ShouldBeEmpty)
+				str, err := mf.Run(false)
+				So(err, ShouldBeNil)
+				So(str, ShouldBeEmpty)
 
-                                expectedTestFiles := map[string]struct{}{
+				expectedTestFiles := map[string]struct{}{
 					"testfile1": {},
-                                        "testfile2": {},
-                                }
+					"testfile2": {},
+				}
 
-                                for testFile := range testFiles {
+				for testFile := range testFiles {
 					_, err := os.Stat(testFile)
 					if _, ok := expectedTestFiles[testFile]; ok {
 						So(err, ShouldBeNil)
-                                        } else {
+					} else {
 						So(err, ShouldNotBeNil)
-                                        }
-                                }
-                        })
+					}
+				}
+			})
 
-                        Reset(func() {
+			Reset(func() {
 				// Remove any testfiles written to local filesystem
-                                for testFile := range testFiles {
+				for testFile := range testFiles {
 					if _, err := os.Stat(testFile); err == nil {
 						err = os.Remove(testFile)
-                                                So(err, ShouldBeNil)
-                                        }
-                                }
-                        })
-                })
-		
+						So(err, ShouldBeNil)
+					}
+				}
+			})
+		})
+
 		Convey("Testing the 'put' command with multiple lorem ipsum files bytes should", func() {
 			localTestFiles := []string{
 				util.ToUniversalPath("testdata/lorem_ipsum_multi_args_0.txt"),

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -28,7 +28,7 @@ Possible commands include:
 	put_id    - add a file with filename 'filename' and a given '_id'
 	get       - get files with filenames specified in the supporting arguments
 	get_id    - get a file with the given '_id'
-        get_regex - get files matching the supplied 'regex'
+	get_regex - get files matching the supplied 'regex'
 	delete    - delete all files with filename 'filename'
 	delete_id - delete a file with the given '_id'
 

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -104,7 +104,7 @@ type StorageOptions struct {
 	WriteConcern string `long:"writeConcern" value-name:"<write-concern>" default-mask:"-" description:"write concern options e.g. --writeConcern majority, --writeConcern '{w: 3, wtimeout: 500, fsync: true, j: true}'"`
 
 	// RegexOptions specifies the options passed to "$regex" queries that are used for get_regex
-        // The default is to use no options, i.e. standard PCRE syntax
+	// The default is to use no options, i.e. standard PCRE syntax
 	RegexOptions string `long:"options" value-name:"<regex-options>" short:"o" description:"regex options used for get_regex"`
 }
 

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -102,6 +102,10 @@ type StorageOptions struct {
 	// By default, mongofiles waits for a majority of members from the replica set to respond before returning.
 	// Cannot be used simultaneously with write concern options in a URI.
 	WriteConcern string `long:"writeConcern" value-name:"<write-concern>" default-mask:"-" description:"write concern options e.g. --writeConcern majority, --writeConcern '{w: 3, wtimeout: 500, fsync: true, j: true}'"`
+
+	// RegexOptions specifies the options passed to "$regex" queries that are used for get_regex
+        // The default is to use no options, i.e. standard PCRE syntax
+	RegexOptions string `long:"options" value-name:"<regex-options>" short:"o" description:"regex options used for get_regex"`
 }
 
 // Name returns a human-readable group name for storage options.

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -28,6 +28,7 @@ Possible commands include:
 	put_id    - add a file with filename 'filename' and a given '_id'
 	get       - get files with filenames specified in the supporting arguments
 	get_id    - get a file with the given '_id'
+        get_regex - get files matching the supplied 'regex'
 	delete    - delete all files with filename 'filename'
 	delete_id - delete a file with the given '_id'
 

--- a/mongofiles/options.go
+++ b/mongofiles/options.go
@@ -106,7 +106,7 @@ type StorageOptions struct {
 
 	// RegexOptions specifies the options passed to "$regex" queries that are used for get_regex
 	// The default is to use no options, i.e. standard PCRE syntax
-	RegexOptions string `long:"options" value-name:"<regex-options>" short:"o" description:"regex options used for get_regex"`
+	RegexOptions string `long:"regexOptions" default:"" value-name:"<regex-options>" description:"regex options used for get_regex"`
 }
 
 // Name returns a human-readable group name for storage options.

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -256,6 +256,37 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					Command:      "get",
 				},
 			},
+                        {
+				InputArgs: []string{"get_regex", "test_regex(\\d)"},
+                                ExpectedOpts: Options{
+					ToolOptions: &options.ToolOptions{
+						URI: &options.URI{
+							ConnectionString: "mongodb://localhost/",
+						},
+					},
+				},
+                                ExpectedMF: MongoFiles {
+					FileNameRegex: "test_regex(\\d)",
+					Command: "get_regex",
+                                },
+                        },
+                        {
+				InputArgs: []string{"get_regex", "another_regex[a-zA-Z]", "--options", "mx"},
+                                ExpectedOpts: Options{
+					ToolOptions: &options.ToolOptions{
+						URI: &options.URI{
+							ConnectionString: "mongodb://localhost/",
+						},
+					},
+				},
+                                ExpectedMF: MongoFiles {
+					FileNameRegex: "another_regex[a-zA-Z]",
+					Command: "get_regex",
+                                        StorageOptions: &StorageOptions{
+						RegexOptions: "mx",
+                                        },
+                                },
+			},
 			{
 				InputArgs: []string{"get_id", "id"},
 				ExpectedOpts: Options{
@@ -446,6 +477,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(mf.FileName, ShouldEqual, tc.ExpectedMF.FileName)
 				So(mf.FileNameList, ShouldResemble, tc.ExpectedMF.FileNameList)
+                                So(mf.FileNameRegex, ShouldEqual, tc.ExpectedMF.FileNameRegex)
 				So(mf.Command, ShouldEqual, tc.ExpectedMF.Command)
 				So(mf.Id, ShouldEqual, tc.ExpectedMF.Id)
 				So(opts.ConnectionString, ShouldEqual, tc.ExpectedOpts.ConnectionString)

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -482,4 +482,29 @@ func TestPositionalArgumentParsing(t *testing.T) {
 			}
 		}
 	})
+
+	Convey("Testing 'get_regex' with '--options' should parse the regex and the options properly", t, func() {
+		// This depends on (*MongoFiles).StorageOptions
+		// It needs to be checked separately from "Testing parsing positional arguments"
+		args := []string{
+			"get_regex",
+			"another_regex[a-zA-Z]",
+			"--options",
+			"mx",
+		}
+
+		opts, err := ParseOptions(args, "", "")
+		So(err, ShouldBeNil)
+
+		mf := &MongoFiles{
+			ToolOptions:    opts.ToolOptions,
+			StorageOptions: opts.StorageOptions,
+		}
+
+		err = mf.ValidateCommand(opts.ParsedArgs)
+		So(err, ShouldBeNil)
+
+		So(mf.FileNameRegex, ShouldEqual, args[1])
+		So(mf.StorageOptions.RegexOptions, ShouldEqual, args[3])
+	})
 }

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -256,36 +256,36 @@ func TestPositionalArgumentParsing(t *testing.T) {
 					Command:      "get",
 				},
 			},
-                        {
+			{
 				InputArgs: []string{"get_regex", "test_regex(\\d)"},
-                                ExpectedOpts: Options{
+				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{
 						URI: &options.URI{
 							ConnectionString: "mongodb://localhost/",
 						},
 					},
 				},
-                                ExpectedMF: MongoFiles {
+				ExpectedMF: MongoFiles{
 					FileNameRegex: "test_regex(\\d)",
-					Command: "get_regex",
-                                },
-                        },
-                        {
+					Command:       "get_regex",
+				},
+			},
+			{
 				InputArgs: []string{"get_regex", "another_regex[a-zA-Z]", "--options", "mx"},
-                                ExpectedOpts: Options{
+				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{
 						URI: &options.URI{
 							ConnectionString: "mongodb://localhost/",
 						},
 					},
 				},
-                                ExpectedMF: MongoFiles {
+				ExpectedMF: MongoFiles{
 					FileNameRegex: "another_regex[a-zA-Z]",
-					Command: "get_regex",
-                                        StorageOptions: &StorageOptions{
+					Command:       "get_regex",
+					StorageOptions: &StorageOptions{
 						RegexOptions: "mx",
-                                        },
-                                },
+					},
+				},
 			},
 			{
 				InputArgs: []string{"get_id", "id"},
@@ -477,7 +477,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(mf.FileName, ShouldEqual, tc.ExpectedMF.FileName)
 				So(mf.FileNameList, ShouldResemble, tc.ExpectedMF.FileNameList)
-                                So(mf.FileNameRegex, ShouldEqual, tc.ExpectedMF.FileNameRegex)
+				So(mf.FileNameRegex, ShouldEqual, tc.ExpectedMF.FileNameRegex)
 				So(mf.Command, ShouldEqual, tc.ExpectedMF.Command)
 				So(mf.Id, ShouldEqual, tc.ExpectedMF.Id)
 				So(opts.ConnectionString, ShouldEqual, tc.ExpectedOpts.ConnectionString)

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -489,7 +489,7 @@ func TestPositionalArgumentParsing(t *testing.T) {
 		args := []string{
 			"get_regex",
 			"another_regex[a-zA-Z]",
-			"--options",
+			"--regexOptions",
 			"mx",
 		}
 

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -271,23 +271,6 @@ func TestPositionalArgumentParsing(t *testing.T) {
 				},
 			},
 			{
-				InputArgs: []string{"get_regex", "another_regex[a-zA-Z]", "--options", "mx"},
-				ExpectedOpts: Options{
-					ToolOptions: &options.ToolOptions{
-						URI: &options.URI{
-							ConnectionString: "mongodb://localhost/",
-						},
-					},
-				},
-				ExpectedMF: MongoFiles{
-					FileNameRegex: "another_regex[a-zA-Z]",
-					Command:       "get_regex",
-					StorageOptions: &StorageOptions{
-						RegexOptions: "mx",
-					},
-				},
-			},
-			{
 				InputArgs: []string{"get_id", "id"},
 				ExpectedOpts: Options{
 					ToolOptions: &options.ToolOptions{

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -482,6 +482,10 @@ func TestPositionalArgumentParsing(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestGetRegexWithOptions(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Testing 'get_regex' with '--options' should parse the regex and the options properly", t, func() {
 		// This depends on (*MongoFiles).StorageOptions


### PR DESCRIPTION
This PR should enable the user to query GridFS by regex, i.e. PCRE, over filenames. The command should be as follows:

`mongofiles ... get_regex "<regex>" --regexOptions "<options>"`

`<options>` are optional additional arguments to the underlying _$regex_ query -- the possible options are [enumerated in the reference manual](https://docs.mongodb.com/manual/reference/operator/query/regex/#op._S_options).

**Test Plan**: Include two integration tests to check the `get_regex` command -- one without any options specified, and the other with the option for case-insensitivity.

Additionally, include two unittests to similarly check for cases of user input including and not including server options.