### PR TITLE
TOOLS-2693: Fix race detector build failures

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1119,6 +1119,9 @@ pre:
           export EVG_IS_PATCH='${is_patch}'
           export EVG_BUILD_ID='${build_id}'
           export EVG_VARIANT='${build_variant}'
+          if [ '${_platform}' != '' ]; then
+            export EVG_VARIANT='${_platform}'
+          fi
           export EVG_USER='${evg_user}'
           export EVG_KEY='${evg_key}'
           export AWS_ACCESS_KEY_ID='${release_aws_access_key_id}'
@@ -2515,11 +2518,17 @@ buildvariants:
   run_on:
   - ubuntu1604-test
   expansions:
-    <<: *mongod_default_startup_args
-    <<: *mongo_default_startup_args
+    <<: *mongod_ssl_startup_args
+    <<: *mongo_ssl_startup_args
+    <<: *mongod_tls_startup_args
+    <<: *mongo_tls_startup_args
+    _platform: ubuntu1604-s390x
     mongo_os: "ubuntu1604"
     mongo_edition: "enterprise"
     build_tags: "failpoints sasl gssapi ssl"
     args: "-buildmode=default -race"
     excludes: requires_large_ram
+    resmoke_use_tls: _tls
+    resmoke_use_ssl: _ssl
+    USE_SSL: "true"
   tasks: *ubuntu_x86_64_race_tasks


### PR DESCRIPTION
There were two distinct problems causing build failures in the race-detector variant.

One was that some of our automation code tries to determine the platform from the build variant name. Since "ubuntu-race" is not itself a platform, I had to add a way to override the variant name.

The other was that a number of our integration tests have expansions that cause them to _always_ run with TLS on, while the race detector buildvariant was configured not to use SSL. The easy fix here was to change the race detector variant to use SSL, though I also filed https://jira.mongodb.org/browse/TOOLS-2694 to address the underlying configuration inconsistency