### PR TITLE
TOOLS-2700: Use tag-triggered versions for releasing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,26 +47,18 @@ Those changes will need to be made before we can do a new major release.
 At the time when the major release process is formalized, this section will be replaced with more specific instructions.
 
 #### Minor/Patch Release
-##### Determine the new version
-First, determine the version number of the new release.
-The new version should be the smallest possible minor or patch increment from the current version.
 
-For example, consider the version `<x>.<y>.<z>`.
-Bumping the patch version would give version `<x>.<y>.<z+1>`.
-Bumping the minor version would give version `<x>.<y+1>.0`.
+##### Ensure evergreen version created
+Check the [Database Tools Waterfall](https://evergreen.mongodb.com/waterfall/mongo-tools) to ensure that an evergreen version has been created for the most recent commit updating the changelog.
 
-##### Create the bump commit
-Ensure you have the `master` branch checked out.
-Create an empty commit with a commit message of the following format:
-```
-git commit --allow-empty -m 'TOOLS-XXXX: Release vX.Y.Z'
-```
+##### Ensure master up to date
+Ensure you have the `master` branch checked out, and that you have pulled the latest commit from `mongodb/mongo-tools`.
 
 ##### Create the tag and push
 Create an annotated tag and push it:
 ```
 git tag -a -m vX.Y.Z X.Y.Z
-git push && git push --tags
+git push --tags
 ```
 
 ### Post-Release Tasks
@@ -128,7 +120,7 @@ Bugs and feature requests can be reported in the [Database Tools Jira](https://j
     ### Build Failure
     ```
 - Insert a brief description of the release in place of `<INSERT-DESCRIPTION>`. Don't go into too much unnecessary detail. 
-- Submit a PR with your changes.
+- Submit a PR with your changes under the release ticket number, and merge once approved.
 
 #### Update the changelog in the docs
 

--- a/common.yml
+++ b/common.yml
@@ -1182,6 +1182,7 @@ timeout:
 
 tasks:
 - name: dist
+  tags: ["git_tag"]
   depends_on:
   commands:
     - func: "fetch source"
@@ -1248,6 +1249,7 @@ tasks:
 # amazon1-2018-test for this purpose. The notary client is not
 # available on all distros, which is why sign must be a separate task.
 - name: sign
+  tags: ["git_tag"]
   depends_on:
     - name: dist
   commands:
@@ -1259,6 +1261,7 @@ tasks:
     - func: "upload signed release artifacts"
 
 - name: push
+  tags: ["git_tag"]
   depends_on:
     - name: sign
   commands:
@@ -2002,6 +2005,7 @@ buildvariants:
 
 - name: release
   display_name: 'Release Manager'
+  tags: ["git_tag"]
   run_on:
   - amazon1-2018-test
   tasks:


### PR DESCRIPTION
This PR updates the release process in RELEASE.md to use evergreen's tag-triggered versions for releases. `common.yml` has been updated with tags for the tasks that should run on tag-triggered versions.