### PR TITLE
TOOLS-2716 Improve package dependency resolution with older versions

### DIFF
--- a/installer/deb/control
+++ b/installer/deb/control
@@ -15,7 +15,8 @@ Description: mongodb-database-tools package provides tools for working with the 
 Homepage: http://www.mongodb.com
 Depends: libc6, libgssapi-krb5-2, libkrb5-3, libk5crypto3, libcomerr2, libkrb5support0, libkeyutils1
 Provides: mongodb-database-tools
-Conflicts: mongodb-org-tools (<= 4.3.2), mongodb-enterprise-tools (<= 4.3.2), mongodb-database-tools
-Replaces: mongodb-database-tools (<= @TOOLS_VERSION@)
+Conflicts: mongodb-database-tools
+Breaks: mongodb-org-tools (<= 4.3.2), mongodb-org-tools-unstable (<= 4.3.2), mongodb-enterprise-tools (<= 4.3.2), mongodb-enterprise-tools-unstable (<= 4.3.2)
+Replaces: mongodb-database-tools (<= @TOOLS_VERSION@), mongodb-org-tools (<= 4.3.2), mongodb-org-tools-unstable (<= 4.3.2), mongodb-enterprise-tools (<= 4.3.2), mongodb-enterprise-tools-unstable (<= 4.3.2)
 Section: database
 Priority: optional

--- a/installer/rpm/mongodb-database-tools.spec
+++ b/installer/rpm/mongodb-database-tools.spec
@@ -11,6 +11,7 @@ Vendor:     MongoDB
 BuildArchitectures: @ARCHITECTURE@
 Obsoletes:  mongodb-database-tools <= @TOOLS_VERSION@
 Requires: openssl, cyrus-sasl, cyrus-sasl-plain, cyrus-sasl-gssapi
+Conflicts: mongodb-org-tools <= 4.3.2, mongodb-org-unstable-tools <= 4.3.2, mongodb-enterprise-tools <= 4.3.2, mongodb-enterprise-unstable-tools <= 4.3.2
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}
 
 %description


### PR DESCRIPTION
Upgrades from MongoDB v4.2 to v4.4 were somewhat problematic due to
incorrect dependency resolution resulting in both the older
mongodb-*-tools package and this package being installed at the same
time, causing file conflicts. The dependency resolution is improved so
that the package manager has an easier time doing an automated upgrade.