### PR TITLE
TOOLS-2706: Fix implausibly old time stamps in tarballs

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -782,9 +782,10 @@ func addToTarball(tw *tar.Writer, dst, src string) {
 	check(err, "stat file")
 
 	header := &tar.Header{
-		Name: dst,
-		Size: stat.Size(),
-		Mode: int64(stat.Mode()),
+		Name:    dst,
+		Size:    stat.Size(),
+		Mode:    int64(stat.Mode()),
+		ModTime: time.Now(),
 	}
 
 	err = tw.WriteHeader(header)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2706

We were getting the Unix epoch time because we weren't specifying a `ModTime` in the tar header, though the [Go documentation makes that kind of unclear](https://github.com/golang/go/blob/d7ab277eed4d2e5ede4f3361adf42d4ad76ced8f/src/archive/tar/common.go#L156) in my opinion. Then [this line in the header code](https://github.com/golang/go/blob/d7ab277eed4d2e5ede4f3361adf42d4ad76ced8f/src/archive/tar/writer.go#L89) ended up rounding an empty `time.Time{}` which just left it at the Unix epoch.

Either way, specifying `ModTime: time.Now()` seems to fix it:

```
// Before ----------------------------------------------------------------------------------------------

$ tar xf ./old-release.tgz
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/LICENSE.md: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/README.md: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/THIRD-PARTY-NOTICES: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/bsondump: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongodump: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongoexport: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongofiles: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongoimport: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongorestore: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongostat: implausibly old time stamp 1970-01-01 00:00:00
tar: mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/bin/mongotop: implausibly old time stamp 1970-01-01 00:00:00

$ ls -l ./mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/
total 192
-rw-r--r-- 1 ec2-user ec2-user    554 Jan  1  1970 LICENSE.md
-rw-r--r-- 1 ec2-user ec2-user   2873 Jan  1  1970 README.md
-rw-r--r-- 1 ec2-user ec2-user 183512 Jan  1  1970 THIRD-PARTY-NOTICES
drwxrwxr-x 2 ec2-user ec2-user   4096 Sep 10 18:47 bin

// After ----------------------------------------------------------------------------------------------

$ tar xf ./new-release.tgz

$ ls -l ./mongodb-database-tools-macos-x86_64-4.3.2-167-g3478fc05-dirty/
total 192
-rw-r--r-- 1 ec2-user ec2-user    554 Sep 10 18:28 LICENSE.md
-rw-r--r-- 1 ec2-user ec2-user   2873 Sep 10 18:28 README.md
-rw-r--r-- 1 ec2-user ec2-user 183512 Sep 10 18:28 THIRD-PARTY-NOTICES
drwxrwxr-x 2 ec2-user ec2-user   4096 Sep 10 18:31 bin
```