### PR TITLE
Revert "TOOLS-2707: Build mongo-tools with go 1.15"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,7 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:93e10526bf458ed550400530b1add59048df0734fb4747e66fe5915b9cb3fdfb"
+  digest = "1:f032041666256e74c215a1c75ce222f921f185fde38b4142d40cebc81dbb4266"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -166,8 +166,8 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "2597acf25752f22d58d99e5b4127da68d5d8132b"
-  version = "4.0.7"
+  revision = "12d17b45edc8fc3d19d52fda2bce7ff58c3e07d4"
+  version = "v4.0.6"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v4.0.7"
+  version = "v4.0.6"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Report any bugs, improvements, or new feature requests at https://jira.mongodb.o
 Building Tools
 ---------------
 
-We currently build the tools with Go version 1.15, other Go versions may work but they are untested. `go get` will not 
+We currently build the tools with Go version 1.12, other Go versions may work but they are untested. `go get` will not 
 work; you need to clone the repository to build it. Be sure to clone the repository into your Go workspace inside your 
 $GOPATH.
 

--- a/set_goenv.sh
+++ b/set_goenv.sh
@@ -11,11 +11,11 @@ set_goenv() {
     UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
     case $UNAME_S in
         CYGWIN*)
-            PREF_GOROOT="c:/golang/go1.15"
-            PREF_PATH="/cygdrive/c/golang/go1.15/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
+            PREF_GOROOT="c:/golang/go1.12"
+            PREF_PATH="/cygdrive/c/golang/go1.12/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
         ;;
         *)
-            PREF_GOROOT="/opt/golang/go1.15"
+            PREF_GOROOT="/opt/golang/go1.12"
             # XXX might not need mongodbtoolchain anymore
             PREF_PATH="$PREF_GOROOT/bin:/opt/mongodbtoolchain/v3/bin/:$PATH"
         ;;
@@ -113,10 +113,7 @@ buildflags() {
     case $UNAME_S in
         Linux)
             flags="-buildmode=pie"
-            ;;
-        CYGWIN*)
-            flags='-buildmode=exe'
-            ;;
+        ;;
     esac
     echo "$flags"
 }

--- a/vendor/github.com/mongodb/mongo-tools-common/json/scanner.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/json/scanner.go
@@ -650,7 +650,7 @@ func quoteChar(c int) string {
 	}
 
 	// use quoted string with different quotation marks
-	s := strconv.Quote(string(rune(c)))
+	s := strconv.Quote(string(c))
 	return "'" + s[1:len(s)-1] + "'"
 }
 

--- a/vendor/github.com/mongodb/mongo-tools-common/set_goenv.sh
+++ b/vendor/github.com/mongodb/mongo-tools-common/set_goenv.sh
@@ -11,14 +11,11 @@ set_goenv() {
     UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
     case $UNAME_S in
         CYGWIN*)
-            PREF_GOROOT="c:/golang/go1.15"
-            PREF_PATH="/cygdrive/c/golang/go1.15/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
-            if [[ $GOCACHE != C:* ]]; then
-                export GOCACHE="C:$GOCACHE"
-            fi
+            PREF_GOROOT="c:/golang/go1.11"
+            PREF_PATH="/cygdrive/c/golang/go1.11/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
         ;;
         *)
-            PREF_GOROOT="/opt/golang/go1.15"
+            PREF_GOROOT="/opt/golang/go1.11"
             # XXX might not need mongodbtoolchain anymore
             PREF_PATH="$PREF_GOROOT/bin:/opt/mongodbtoolchain/v3/bin/:$PATH"
         ;;


### PR DESCRIPTION
Reverts mongodb/mongo-tools#303

SUSE and ZAP build variants don't have go 1.15 installed, which is causing failures.

Sorry @varsha804, I have to revert this to do the 100.2.0 release. We can merge it again once the release is cut. Are there BUILD tickets to fix the missing go binaries on SUSE and ZAP?