### PR TITLE
TOOLS-2708: Atlas recommended connection string for mongostat doesn't work

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:4956acb8a817f289c9b80ab1f110c1c51af3795a5130dea14d36d7a2d50f7c00"
+  branch = "TOOLS-2708"
+  digest = "1:417d47241cc58da0ee59e0a2cece742e42b3c8ef4f539f3760e32b7bc1026af4"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -166,8 +167,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "fe0c68c04a06609225a90e6be8a02a4bc7dc7cef"
-  version = "v4.0.9"
+  revision = "c6674509e9eee21ff92602adeaea9b5b0a3b3d33"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,7 +145,7 @@
 
 [[projects]]
   branch = "TOOLS-2708"
-  digest = "1:417d47241cc58da0ee59e0a2cece742e42b3c8ef4f539f3760e32b7bc1026af4"
+  digest = "1:cdffea5e57e45949bcd9a7adca1b665f1aeaed4b7b07d96d3a8ff3aea2871dea"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -167,7 +167,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "c6674509e9eee21ff92602adeaea9b5b0a3b3d33"
+  revision = "cb89285257bb89fb01c3934898b2073f5b471343"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,6 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "TOOLS-2708"
   digest = "1:cdffea5e57e45949bcd9a7adca1b665f1aeaed4b7b07d96d3a8ff3aea2871dea"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
@@ -167,7 +166,8 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "cb89285257bb89fb01c3934898b2073f5b471343"
+  revision = "d4a090fedd3d457640f7661a7ef1c24c0fe6a382"
+  version = "v4.0.10"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  branch = "TOOLS-2708"
+  version = "v4.0.10"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v4.0.9"
+  branch = "TOOLS-2708"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -237,18 +237,15 @@ func NewNodeMonitor(opts options.ToolOptions, fullHost string) (*NodeMonitor, er
 	optsCopy.Connection.Host = host
 	optsCopy.Connection.Port = port
 	uriCopy := *opts.URI
-	optsCopy.URI = &uriCopy
-
-	if len(optsCopy.ConnString.Hosts) > 1 {
-		optsCopy.Direct = false
-	} else {
-		optsCopy.Direct = true
-		newCS, err := rewriteURI(uriCopy.ConnectionString, fullHost)
-		if err != nil {
-			return nil, err
-		}
-		uriCopy.ConnectionString = newCS
+	newCS, err := rewriteURI(uriCopy.ConnectionString, fullHost)
+	if err != nil {
+		return nil, err
 	}
+	uriCopy.ConnectionString = newCS
+	optsCopy.URI = &uriCopy
+	optsCopy.Direct = true
+	optsCopy.ConnString.Hosts = []string{fullHost}
+
 	sessionProvider, err := db.NewSessionProvider(optsCopy)
 	if err != nil {
 		return nil, err

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -237,17 +237,17 @@ func NewNodeMonitor(opts options.ToolOptions, fullHost string) (*NodeMonitor, er
 	optsCopy.Connection.Host = host
 	optsCopy.Connection.Port = port
 	uriCopy := *opts.URI
-	newCS, err := rewriteURI(uriCopy.ConnectionString, fullHost)
-	if err != nil {
-		return nil, err
-	}
-	uriCopy.ConnectionString = newCS
 	optsCopy.URI = &uriCopy
 
 	if len(optsCopy.ConnString.Hosts) > 1 {
 		optsCopy.Direct = false
 	} else {
 		optsCopy.Direct = true
+		newCS, err := rewriteURI(uriCopy.ConnectionString, fullHost)
+		if err != nil {
+			return nil, err
+		}
+		uriCopy.ConnectionString = newCS
 	}
 	sessionProvider, err := db.NewSessionProvider(optsCopy)
 	if err != nil {

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -243,8 +243,12 @@ func NewNodeMonitor(opts options.ToolOptions, fullHost string) (*NodeMonitor, er
 	}
 	uriCopy.ConnectionString = newCS
 	optsCopy.URI = &uriCopy
-	optsCopy.Direct = true
-	optsCopy.ConnString.Hosts = []string{fullHost}
+
+	if len(optsCopy.ConnString.Hosts) > 1 {
+		optsCopy.Direct = false
+	} else {
+		optsCopy.Direct = true
+	}
 	sessionProvider, err := db.NewSessionProvider(optsCopy)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/mongodb/mongo-tools-common/options/options.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/options/options.go
@@ -597,19 +597,35 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 				}
 			}
 		} else if len(cs.Hosts) > 0 {
-			hostPort := strings.Split(cs.Hosts[0], ":")
-			opts.Host = hostPort[0]
+			if cs.ReplicaSet != "" {
+				opts.Host = cs.ReplicaSet + "/"
+			}
 
-			// a port might not be specified, e.g. `mongostat --discover`
-			if len(hostPort) == 2 {
-				if opts.Port != "" {
-					if hostPort[1] != opts.Port {
-						return ConflictingArgsErrorFormat("port", strings.Join(cs.Hosts, ","), opts.Port, "--port")
+			// check if there is a <host:port> pair with a port that matches --port <port>
+			conflictingPorts := true
+			for _, host := range cs.Hosts {
+				hostPort := strings.Split(host, ":")
+				opts.Host += hostPort[0] + ","
+
+				// a port might not be specified, e.g. `mongostat --discover`
+				if len(hostPort) == 2 {
+					if opts.Port != "" {
+						if hostPort[1] == opts.Port {
+							conflictingPorts = false
+						}
+					} else {
+						opts.Port = hostPort[1]
+						conflictingPorts = false
 					}
 				} else {
-					opts.Port = hostPort[1]
+					conflictingPorts = false
 				}
 			}
+			if conflictingPorts {
+				return ConflictingArgsErrorFormat("port", strings.Join(cs.Hosts, ","), opts.Port, "--port")
+			}
+			// remove trailing comma
+			opts.Host = opts.Host[:len(opts.Host)-1]
 		}
 
 		if opts.Connection.ServerSelectionTimeout != 0 && cs.ServerSelectionTimeoutSet {

--- a/vendor/github.com/mongodb/mongo-tools-common/options/options.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/options/options.go
@@ -534,7 +534,7 @@ func (opts *ToolOptions) handleUnknownOption(option string, arg flags.SplitArgum
 // which is eventually added to the connString field.
 // Most CLI and URI options are normalized in three steps:
 //
-// 1. If both CLI option and URI option are set, throw an erroor if they conflict.
+// 1. If both CLI option and URI option are set, throw an error if they conflict.
 // 2. If the CLI option is set, but the URI option isn't, set the URI option
 // 3. If the URI option is set, but the CLI option isn't, set the CLI option
 //
@@ -594,6 +594,20 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 			for host := range csHostSet {
 				if _, ok := optionHostSet[host]; !ok {
 					return ConflictingArgsErrorFormat("host", strings.Join(cs.Hosts, ","), opts.Host, "--host")
+				}
+			}
+		} else if len(cs.Hosts) > 0 {
+			hostPort := strings.Split(cs.Hosts[0], ":")
+			opts.Host = hostPort[0]
+
+			// a port might not be specified, e.g. `mongostat --discover`
+			if len(hostPort) == 2 {
+				if opts.Port != "" {
+					if hostPort[1] != opts.Port {
+						return ConflictingArgsErrorFormat("port", strings.Join(cs.Hosts, ","), opts.Port, "--port")
+					}
+				} else {
+					opts.Port = hostPort[1]
 				}
 			}
 		}


### PR DESCRIPTION
The connection string failure seems to be a result of [this](https://github.com/mongodb/mongo-tools/commit/2aa1d7079b20817d17649ff7b43b2d79b69f1c8e) code change. Since `opts.Port` and `opts.Host` are not set when a user only uses `--uri`, `fullhost` gets set to `localhost:27017`, thereby incorrectly rewriting the hostname to `localhost`.

Manual testing:
1. Atlas cluster
2. mlaunch cluster
3. `--discover` without a connection string
4. Connection string as a positional argument without `--uri`
<img width="1227" alt="Screen Shot 2020-09-15 at 2 41 38 PM" src="https://user-images.githubusercontent.com/22038275/93257727-edff2b00-f762-11ea-9e10-84ca62855476.png">
