### PR TITLE
TOOLS-2740: Change log level names in mongo-tools

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,7 +145,7 @@
 
 [[projects]]
   branch = "TOOLS-2740"
-  digest = "1:8bb3e655639efdf35836a42f1b186cf9e25588d9bfc6d0540acec67513e64d41"
+  digest = "1:e8f7ba84d7a96f3ad62d3a63f7690e5161d54ab086c5f9dae925e2038ead6042"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -167,7 +167,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "8130d33534e7bb7ffbb09e3ef9a3ed02b8762692"
+  revision = "f900af76f9619c7083f79fc57fa85bf916cf7013"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,7 +144,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:f032041666256e74c215a1c75ce222f921f185fde38b4142d40cebc81dbb4266"
+  branch = "TOOLS-2740"
+  digest = "1:8bb3e655639efdf35836a42f1b186cf9e25588d9bfc6d0540acec67513e64d41"
   name = "github.com/mongodb/mongo-tools-common"
   packages = [
     "archive",
@@ -166,8 +167,7 @@
     "util",
   ]
   pruneopts = "T"
-  revision = "12d17b45edc8fc3d19d52fda2bce7ff58c3e07d4"
-  version = "v4.0.6"
+  revision = "8130d33534e7bb7ffbb09e3ef9a3ed02b8762692"
 
 [[projects]]
   digest = "1:f363c75e8cac5653bc5c0c2b90cbd8a522fdc48c13a5f8d85078750f82d1a009"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = ["github.com/3rf/mongo-lint"]
 
 [[constraint]]
   name = "github.com/mongodb/mongo-tools-common"
-  version = "v4.0.6"
+  branch = "TOOLS-2740"
 
 [[constraint]]
   name = "github.com/nsf/termbox-go"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,8 +13,8 @@ We will use the following guidelines to determine when each version component wi
 
 The team recognizes that log messages, while intended to be informational, may cause breakage if scripts attempt to parse output.
 While we will not commit to a formal versioning policy for log message changes, we will attempt to adhere to the following guidelines:
-- **log.Always** level (the default): adding logging is a "minor" change; changing or removing logging is a "major" change.
-- **log.Info** and higher levels (-v to -vvv): additions, modifications and removals are "patch" changes. We make no promises about message stability at these levels. 
+- **log.Error, log.Info, and log.Warn** levels (the default): adding logging is a "minor" change; changing or removing logging is a "major" change.
+- **log.Debug** and higher levels (-v to -vvv): additions, modifications and removals are "patch" changes. We make no promises about message stability at these levels. 
 
 At the moment, there are no pre-release (alpha, beta, rc, etc.) versions of the Tools.
 If there is a need to support pre-release versions of the Tools, we will need to update our release infrastructure to support them.

--- a/bsondump/bsondump.go
+++ b/bsondump/bsondump.go
@@ -146,7 +146,7 @@ func (bd *BSONDump) JSON() (int, error) {
 		}
 
 		if bytes, err := formatJSON(&result, bd.OutputOptions.Pretty); err != nil {
-			log.Logvf(log.Always, "unable to dump document %v: %v", numFound+1, err)
+			log.Logvf(log.Error, false, "unable to dump document %v: %v", numFound+1, err)
 
 			//if objcheck is turned on, stop now. otherwise keep on dumpin'
 			if bd.OutputOptions.ObjCheck {
@@ -199,7 +199,7 @@ func (bd *BSONDump) Debug() (int, error) {
 		}
 		err := printBSON(result, 0, bd.OutputWriter)
 		if err != nil {
-			log.Logvf(log.Always, "encountered error debugging BSON data: %v", err)
+			log.Logvf(log.Error, false, "encountered error debugging BSON data: %v", err)
 		}
 		numFound++
 	}

--- a/bsondump/main/bsondump.go
+++ b/bsondump/main/bsondump.go
@@ -25,8 +25,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := bsondump.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "%v", err)
-		log.Logvf(log.Always, util.ShortUsage("bsondump"))
+		log.Logvf(log.Error, false,  "%v", err)
+		log.Logvf(log.Info, false,  util.ShortUsage("bsondump"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -44,18 +44,18 @@ func main() {
 
 	dumper, err := bsondump.New(opts)
 	if err != nil {
-		log.Logv(log.Always, err.Error())
+		log.Logv(log.Error, false,  err.Error())
 		os.Exit(util.ExitFailure)
 	}
 	defer func() {
 		err := dumper.Close()
 		if err != nil {
-			log.Logvf(log.Always, "error cleaning up: %v", err)
+			log.Logvf(log.Error, false,  "error cleaning up: %v", err)
 			os.Exit(util.ExitFailure)
 		}
 	}()
 
-	log.Logvf(log.DebugLow, "running bsondump with --objcheck: %v", opts.ObjCheck)
+	log.Logvf(log.Trace, false,  "running bsondump with --objcheck: %v", opts.ObjCheck)
 
 	var numFound int
 	if opts.Type == bsondump.DebugOutputType {
@@ -64,9 +64,9 @@ func main() {
 		numFound, err = dumper.JSON()
 	}
 
-	log.Logvf(log.Always, "%v objects found", numFound)
+	log.Logvf(log.Info, false,  "%v objects found", numFound)
 	if err != nil {
-		log.Logv(log.Always, err.Error())
+		log.Logv(log.Error, false,  err.Error())
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/bsondump/main/bsondump.go
+++ b/bsondump/main/bsondump.go
@@ -25,8 +25,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := bsondump.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,  "%v", err)
-		log.Logvf(log.Info, false,  util.ShortUsage("bsondump"))
+		log.Logvf(log.Error, false, "%v", err)
+		log.Logvf(log.Info, false, util.ShortUsage("bsondump"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -44,18 +44,18 @@ func main() {
 
 	dumper, err := bsondump.New(opts)
 	if err != nil {
-		log.Logv(log.Error, false,  err.Error())
+		log.Logv(log.Error, false, err.Error())
 		os.Exit(util.ExitFailure)
 	}
 	defer func() {
 		err := dumper.Close()
 		if err != nil {
-			log.Logvf(log.Error, false,  "error cleaning up: %v", err)
+			log.Logvf(log.Error, false, "error cleaning up: %v", err)
 			os.Exit(util.ExitFailure)
 		}
 	}()
 
-	log.Logvf(log.Trace, false,  "running bsondump with --objcheck: %v", opts.ObjCheck)
+	log.Logvf(log.Trace, false, "running bsondump with --objcheck: %v", opts.ObjCheck)
 
 	var numFound int
 	if opts.Type == bsondump.DebugOutputType {
@@ -64,9 +64,9 @@ func main() {
 		numFound, err = dumper.JSON()
 	}
 
-	log.Logvf(log.Info, false,  "%v objects found", numFound)
+	log.Logvf(log.Info, false, "%v objects found", numFound)
 	if err != nil {
-		log.Logv(log.Error, false,  err.Error())
+		log.Logv(log.Error, false, err.Error())
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongodump/main/mongodump.go
+++ b/mongodump/main/mongodump.go
@@ -32,13 +32,13 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongodump.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Info, false,  util.ShortUsage("mongodump"))
+		log.Logvf(log.Error, false, "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false, util.ShortUsage("mongodump"))
 		os.Exit(util.ExitFailure)
 	}
 
 	// print help, if specified
-	if opts.PrintHelp( false) {
+	if opts.PrintHelp(false) {
 		return
 	}
 
@@ -69,12 +69,12 @@ func main() {
 	defer close(finishedChan)
 
 	if err = dump.Init(); err != nil {
-		log.Logvf(log.Error, false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 
 	if err = dump.Dump(); err != nil {
-		log.Logvf(log.Error, false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongodump/main/mongodump.go
+++ b/mongodump/main/mongodump.go
@@ -32,13 +32,13 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongodump.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Always, util.ShortUsage("mongodump"))
+		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false,  util.ShortUsage("mongodump"))
 		os.Exit(util.ExitFailure)
 	}
 
 	// print help, if specified
-	if opts.PrintHelp(false) {
+	if opts.PrintHelp( false) {
 		return
 	}
 
@@ -69,12 +69,12 @@ func main() {
 	defer close(finishedChan)
 
 	if err = dump.Init(); err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 
 	if err = dump.Dump(); err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -58,7 +58,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	// We keep a running list of all the indexes
 	// for the current collection as we iterate over the cursor, and include
 	// that list as the "indexes" field of the metadata document.
-	log.Logvf(log.DebugHigh, "\treading indexes for `%v`", intent.Namespace())
+	log.Logvf(log.Trace, false,  "\treading indexes for `%v`", intent.Namespace())
 
 	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
@@ -66,7 +66,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	}
 
 	if dump.OutputOptions.ViewsAsCollections || intent.IsView() {
-		log.Logvf(log.DebugLow, "not dumping indexes metadata for '%v' because it is a view", intent.Namespace())
+		log.Logvf(log.Trace, false,  "not dumping indexes metadata for '%v' because it is a view", intent.Namespace())
 	} else {
 		// get the indexes
 		indexesIter, err := db.GetIndexes(session.Database(intent.DB).Collection(intent.C))
@@ -74,7 +74,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 			return err
 		}
 		if indexesIter == nil {
-			log.Logvf(log.Always, "the collection %v appears to have been dropped after the dump started", intent.Namespace())
+			log.Logvf(log.Info, false,  "the collection %v appears to have been dropped after the dump started", intent.Namespace())
 			return nil
 		}
 		defer indexesIter.Close(context.Background())

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -58,7 +58,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	// We keep a running list of all the indexes
 	// for the current collection as we iterate over the cursor, and include
 	// that list as the "indexes" field of the metadata document.
-	log.Logvf(log.Trace, false,  "\treading indexes for `%v`", intent.Namespace())
+	log.Logvf(log.Trace, false, "\treading indexes for `%v`", intent.Namespace())
 
 	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
@@ -66,7 +66,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 	}
 
 	if dump.OutputOptions.ViewsAsCollections || intent.IsView() {
-		log.Logvf(log.Trace, false,  "not dumping indexes metadata for '%v' because it is a view", intent.Namespace())
+		log.Logvf(log.Trace, false, "not dumping indexes metadata for '%v' because it is a view", intent.Namespace())
 	} else {
 		// get the indexes
 		indexesIter, err := db.GetIndexes(session.Database(intent.DB).Collection(intent.C))
@@ -74,7 +74,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent, buffer resettableOut
 			return err
 		}
 		if indexesIter == nil {
-			log.Logvf(log.Info, false,  "the collection %v appears to have been dropped after the dump started", intent.Namespace())
+			log.Logvf(log.Info, false, "the collection %v appears to have been dropped after the dump started", intent.Namespace())
 			return nil
 		}
 		defer indexesIter.Close(context.Background())

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -131,7 +131,7 @@ func (dump *MongoDump) ValidateOptions() error {
 
 // Init performs preliminary setup operations for MongoDump.
 func (dump *MongoDump) Init() error {
-	log.Logvf(log.Trace, false,  "initializing mongodump object")
+	log.Logvf(log.Trace, false, "initializing mongodump object")
 
 	// this would be default, but explicit setting protects us from any
 	// redefinition of the constants.
@@ -167,7 +167,7 @@ func (dump *MongoDump) Init() error {
 
 	// warn if we are trying to dump from a secondary in a sharded cluster
 	if dump.isMongos && pref != readpref.Primary() {
-		log.Logvf(log.Warn, false,  db.WarningNonPrimaryMongosConnection)
+		log.Logvf(log.Warn, false, db.WarningNonPrimaryMongosConnection)
 	}
 
 	dump.manager = intents.NewIntentManager()
@@ -200,12 +200,12 @@ func (dump *MongoDump) Dump() (err error) {
 		return fmt.Errorf("error verifying collection info: %v", err)
 	}
 	if !exists {
-		log.Logvf(log.Warn, false,  "namespace with DB %s and collection %s does not exist",
+		log.Logvf(log.Warn, false, "namespace with DB %s and collection %s does not exist",
 			dump.ToolOptions.Namespace.DB, dump.ToolOptions.Namespace.Collection)
 		return nil
 	}
 
-	log.Logvf(log.Trace, false,  "starting Dump()")
+	log.Logvf(log.Trace, false, "starting Dump()")
 
 	dump.shutdownIntentsNotifier = newNotifier()
 
@@ -231,7 +231,7 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("error getting auth schema version for dumpDbUsersAndRoles: %v", err)
 		}
-		log.Logvf(log.Info, false,  "using auth schema version %v", dump.authVersion)
+		log.Logvf(log.Info, false, "using auth schema version %v", dump.authVersion)
 		if dump.authVersion < 3 {
 			return fmt.Errorf("backing up users and roles is only supported for "+
 				"deployments with auth schema versions >= 3, found: %v", dump.authVersion)
@@ -263,9 +263,9 @@ func (dump *MongoDump) Dump() (err error) {
 				} else {
 					err = fmt.Errorf("archive writer: %v", muxErr)
 				}
-				log.Logvf(log.Trace, false,  "%v", err)
+				log.Logvf(log.Trace, false, "%v", err)
 			} else {
-				log.Logvf(log.Trace, false,  "mux completed successfully")
+				log.Logvf(log.Trace, false, "mux completed successfully")
 			}
 		}()
 	}
@@ -311,7 +311,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// metadata, users, roles, and versions
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.Trace, false,  "dump phase I: metadata, indexes, users, roles, version")
+	log.Logvf(log.Trace, false, "dump phase I: metadata, indexes, users, roles, version")
 
 	err = dump.DumpMetadata()
 	if err != nil {
@@ -321,7 +321,7 @@ func (dump *MongoDump) Dump() (err error) {
 	if dump.OutputOptions.Archive != "" {
 		serverVersion, err := dump.SessionProvider.ServerVersion()
 		if err != nil {
-			log.Logvf(log.Warn, false,  "warning, couldn't get version information from server: %v", err)
+			log.Logvf(log.Warn, false, "warning, couldn't get version information from server: %v", err)
 			serverVersion = "unknown"
 		}
 		dump.archive.Prelude, err = archive.NewPrelude(dump.manager, dump.OutputOptions.NumParallelCollections, serverVersion, dump.ToolOptions.VersionStr)
@@ -347,9 +347,9 @@ func (dump *MongoDump) Dump() (err error) {
 			}
 		}
 		if dump.OutputOptions.DumpDBUsersAndRoles {
-			log.Logvf(log.Info, false,  "dumping users and roles for %v", dump.ToolOptions.DB)
+			log.Logvf(log.Info, false, "dumping users and roles for %v", dump.ToolOptions.DB)
 			if dump.ToolOptions.DB == "admin" {
-				log.Logvf(log.Info, false,  "skipping users/roles dump, already dumped admin database")
+				log.Logvf(log.Info, false, "skipping users/roles dump, already dumped admin database")
 			} else {
 				err = dump.DumpUsersAndRolesForDB(dump.ToolOptions.DB)
 				if err != nil {
@@ -368,7 +368,7 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("error finding oplog: %v", err)
 		}
-		log.Logvf(log.Debug, false,  "getting most recent oplog timestamp")
+		log.Logvf(log.Debug, false, "getting most recent oplog timestamp")
 		dump.oplogStart, err = dump.getOplogCopyStartTime()
 		if err != nil {
 			return fmt.Errorf("error getting oplog start: %v", err)
@@ -376,7 +376,7 @@ func (dump *MongoDump) Dump() (err error) {
 	}
 
 	if failpoint.Enabled(failpoint.PauseBeforeDumping) {
-		log.Logvf(log.Debug, false,  "failpoint.PauseBeforeDumping: sleeping 15 sec")
+		log.Logvf(log.Debug, false, "failpoint.PauseBeforeDumping: sleeping 15 sec")
 		time.Sleep(15 * time.Second)
 	}
 
@@ -384,7 +384,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// regular collections
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.Trace, false,  "dump phase II: regular collections")
+	log.Logvf(log.Trace, false, "dump phase II: regular collections")
 
 	// begin dumping intents
 	if err := dump.DumpIntents(); err != nil {
@@ -395,7 +395,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// oplog
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.Trace, false,  "dump phase III: the oplog")
+	log.Logvf(log.Trace, false, "dump phase III: the oplog")
 
 	// If we are capturing the oplog, we dump all oplog entries that occurred
 	// while dumping the database. Before and after dumping the oplog,
@@ -407,7 +407,7 @@ func (dump *MongoDump) Dump() (err error) {
 			return fmt.Errorf("error getting oplog end: %v", err)
 		}
 
-		log.Logvf(log.Trace, false,  "checking if oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false, "checking if oplog entry %v still exists", dump.oplogStart)
 		exists, err := dump.checkOplogTimestampExists(dump.oplogStart)
 		if !exists {
 			return fmt.Errorf(
@@ -416,9 +416,9 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
-		log.Logvf(log.Trace, false,  "oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false, "oplog entry %v still exists", dump.oplogStart)
 
-		log.Logvf(log.Info, false,  "writing captured oplog to %v", dump.manager.Oplog().Location)
+		log.Logvf(log.Info, false, "writing captured oplog to %v", dump.manager.Oplog().Location)
 
 		err = dump.DumpOplogBetweenTimestamps(dump.oplogStart, dump.oplogEnd)
 		if err != nil {
@@ -428,7 +428,7 @@ func (dump *MongoDump) Dump() (err error) {
 		// check the oplog for a rollover one last time, to avoid a race condition
 		// wherein the oplog rolls over in the time after our first check, but before
 		// we copy it.
-		log.Logvf(log.Trace, false,  "checking again if oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false, "checking again if oplog entry %v still exists", dump.oplogStart)
 		exists, err = dump.checkOplogTimestampExists(dump.oplogStart)
 		if !exists {
 			return fmt.Errorf(
@@ -437,10 +437,10 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
-		log.Logvf(log.Trace, false,  "oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false, "oplog entry %v still exists", dump.oplogStart)
 	}
 
-	log.Logvf(log.Trace, false,  "finishing dump")
+	log.Logvf(log.Trace, false, "finishing dump")
 
 	return err
 }
@@ -484,17 +484,17 @@ func (dump *MongoDump) DumpIntents() error {
 		dump.manager.Finalize(intents.Legacy)
 	}
 
-	log.Logvf(log.Debug, false,  "dumping up to %v collections in parallel", jobs)
+	log.Logvf(log.Debug, false, "dumping up to %v collections in parallel", jobs)
 
 	// start a goroutine for each job thread
 	for i := 0; i < jobs; i++ {
 		go func(id int) {
 			buffer := dump.getResettableOutputBuffer()
-			log.Logvf(log.Trace, false,  "starting dump routine with id=%v", id)
+			log.Logvf(log.Trace, false, "starting dump routine with id=%v", id)
 			for {
 				intent := dump.manager.Pop()
 				if intent == nil {
-					log.Logvf(log.Trace, false,  "ending dump routine with id=%v, no more work to do", id)
+					log.Logvf(log.Trace, false, "ending dump routine with id=%v, no more work to do", id)
 					resultChan <- nil
 					return
 				}
@@ -579,21 +579,21 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 	var dumpCount int64
 
 	if dump.OutputOptions.Out == "-" {
-		log.Logvf(log.Info, false,  "writing %v to stdout", intent.Namespace())
+		log.Logvf(log.Info, false, "writing %v to stdout", intent.Namespace())
 		dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer)
 		if err == nil {
 			// on success, print the document count
-			log.Logvf(log.Info, false,  "dumped %v %v", dumpCount, docPlural(dumpCount))
+			log.Logvf(log.Info, false, "dumped %v %v", dumpCount, docPlural(dumpCount))
 		}
 		return err
 	}
 
-	log.Logvf(log.Info, false,  "writing %v to %v", intent.Namespace(), intent.Location)
+	log.Logvf(log.Info, false, "writing %v to %v", intent.Namespace(), intent.Location)
 	if dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer); err != nil {
 		return err
 	}
 
-	log.Logvf(log.Info, false,  "done dumping %v (%v %v)", intent.Namespace(), dumpCount, docPlural(dumpCount))
+	log.Logvf(log.Info, false, "done dumping %v (%v %v)", intent.Namespace(), dumpCount, docPlural(dumpCount))
 	return nil
 }
 
@@ -613,7 +613,7 @@ func (dump *MongoDump) dumpQueryToIntent(
 // the oplog collection to avoid the performance issue in TOOLS-2068.
 func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent) (int64, error) {
 	if len(dump.query) != 0 || intent.IsOplog() {
-		log.Logvf(log.Trace, false,  "not counting query on %v", intent.Namespace())
+		log.Logvf(log.Trace, false, "not counting query on %v", intent.Namespace())
 		return 0, nil
 	}
 
@@ -622,7 +622,7 @@ func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent)
 		return 0, fmt.Errorf("error getting count from db: %v", err)
 	}
 
-	log.Logvf(log.Trace, false,  "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
+	log.Logvf(log.Trace, false, "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
 	return int64(total), nil
 }
 
@@ -709,7 +709,7 @@ func (dump *MongoDump) dumpValidatedIterToWriter(
 		for {
 			select {
 			case <-dump.shutdownIntentsNotifier.notified:
-				log.Logvf(log.Trace, false,  "terminating writes")
+				log.Logvf(log.Trace, false, "terminating writes")
 				termErr = util.ErrTerminated
 				close(buffChan)
 				return

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -231,7 +231,7 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("error getting auth schema version for dumpDbUsersAndRoles: %v", err)
 		}
-		log.Logvf(log.Info, false, "using auth schema version %v", dump.authVersion)
+		log.Logvf(log.Trace, false, "using auth schema version %v", dump.authVersion)
 		if dump.authVersion < 3 {
 			return fmt.Errorf("backing up users and roles is only supported for "+
 				"deployments with auth schema versions >= 3, found: %v", dump.authVersion)

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -131,7 +131,7 @@ func (dump *MongoDump) ValidateOptions() error {
 
 // Init performs preliminary setup operations for MongoDump.
 func (dump *MongoDump) Init() error {
-	log.Logvf(log.DebugHigh, "initializing mongodump object")
+	log.Logvf(log.Trace, false,  "initializing mongodump object")
 
 	// this would be default, but explicit setting protects us from any
 	// redefinition of the constants.
@@ -167,7 +167,7 @@ func (dump *MongoDump) Init() error {
 
 	// warn if we are trying to dump from a secondary in a sharded cluster
 	if dump.isMongos && pref != readpref.Primary() {
-		log.Logvf(log.Always, db.WarningNonPrimaryMongosConnection)
+		log.Logvf(log.Warn, false,  db.WarningNonPrimaryMongosConnection)
 	}
 
 	dump.manager = intents.NewIntentManager()
@@ -200,12 +200,12 @@ func (dump *MongoDump) Dump() (err error) {
 		return fmt.Errorf("error verifying collection info: %v", err)
 	}
 	if !exists {
-		log.Logvf(log.Always, "namespace with DB %s and collection %s does not exist",
+		log.Logvf(log.Warn, false,  "namespace with DB %s and collection %s does not exist",
 			dump.ToolOptions.Namespace.DB, dump.ToolOptions.Namespace.Collection)
 		return nil
 	}
 
-	log.Logvf(log.DebugHigh, "starting Dump()")
+	log.Logvf(log.Trace, false,  "starting Dump()")
 
 	dump.shutdownIntentsNotifier = newNotifier()
 
@@ -231,7 +231,7 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("error getting auth schema version for dumpDbUsersAndRoles: %v", err)
 		}
-		log.Logvf(log.DebugLow, "using auth schema version %v", dump.authVersion)
+		log.Logvf(log.Info, false,  "using auth schema version %v", dump.authVersion)
 		if dump.authVersion < 3 {
 			return fmt.Errorf("backing up users and roles is only supported for "+
 				"deployments with auth schema versions >= 3, found: %v", dump.authVersion)
@@ -263,9 +263,9 @@ func (dump *MongoDump) Dump() (err error) {
 				} else {
 					err = fmt.Errorf("archive writer: %v", muxErr)
 				}
-				log.Logvf(log.DebugLow, "%v", err)
+				log.Logvf(log.Trace, false,  "%v", err)
 			} else {
-				log.Logvf(log.DebugLow, "mux completed successfully")
+				log.Logvf(log.Trace, false,  "mux completed successfully")
 			}
 		}()
 	}
@@ -311,7 +311,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// metadata, users, roles, and versions
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.DebugHigh, "dump phase I: metadata, indexes, users, roles, version")
+	log.Logvf(log.Trace, false,  "dump phase I: metadata, indexes, users, roles, version")
 
 	err = dump.DumpMetadata()
 	if err != nil {
@@ -321,7 +321,7 @@ func (dump *MongoDump) Dump() (err error) {
 	if dump.OutputOptions.Archive != "" {
 		serverVersion, err := dump.SessionProvider.ServerVersion()
 		if err != nil {
-			log.Logvf(log.Always, "warning, couldn't get version information from server: %v", err)
+			log.Logvf(log.Warn, false,  "warning, couldn't get version information from server: %v", err)
 			serverVersion = "unknown"
 		}
 		dump.archive.Prelude, err = archive.NewPrelude(dump.manager, dump.OutputOptions.NumParallelCollections, serverVersion, dump.ToolOptions.VersionStr)
@@ -347,9 +347,9 @@ func (dump *MongoDump) Dump() (err error) {
 			}
 		}
 		if dump.OutputOptions.DumpDBUsersAndRoles {
-			log.Logvf(log.Always, "dumping users and roles for %v", dump.ToolOptions.DB)
+			log.Logvf(log.Info, false,  "dumping users and roles for %v", dump.ToolOptions.DB)
 			if dump.ToolOptions.DB == "admin" {
-				log.Logvf(log.Always, "skipping users/roles dump, already dumped admin database")
+				log.Logvf(log.Info, false,  "skipping users/roles dump, already dumped admin database")
 			} else {
 				err = dump.DumpUsersAndRolesForDB(dump.ToolOptions.DB)
 				if err != nil {
@@ -368,7 +368,7 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("error finding oplog: %v", err)
 		}
-		log.Logvf(log.Info, "getting most recent oplog timestamp")
+		log.Logvf(log.Debug, false,  "getting most recent oplog timestamp")
 		dump.oplogStart, err = dump.getOplogCopyStartTime()
 		if err != nil {
 			return fmt.Errorf("error getting oplog start: %v", err)
@@ -376,7 +376,7 @@ func (dump *MongoDump) Dump() (err error) {
 	}
 
 	if failpoint.Enabled(failpoint.PauseBeforeDumping) {
-		log.Logvf(log.Info, "failpoint.PauseBeforeDumping: sleeping 15 sec")
+		log.Logvf(log.Debug, false,  "failpoint.PauseBeforeDumping: sleeping 15 sec")
 		time.Sleep(15 * time.Second)
 	}
 
@@ -384,7 +384,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// regular collections
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.DebugHigh, "dump phase II: regular collections")
+	log.Logvf(log.Trace, false,  "dump phase II: regular collections")
 
 	// begin dumping intents
 	if err := dump.DumpIntents(); err != nil {
@@ -395,7 +395,7 @@ func (dump *MongoDump) Dump() (err error) {
 	// oplog
 
 	// TODO, either remove this debug or improve the language
-	log.Logvf(log.DebugLow, "dump phase III: the oplog")
+	log.Logvf(log.Trace, false,  "dump phase III: the oplog")
 
 	// If we are capturing the oplog, we dump all oplog entries that occurred
 	// while dumping the database. Before and after dumping the oplog,
@@ -407,7 +407,7 @@ func (dump *MongoDump) Dump() (err error) {
 			return fmt.Errorf("error getting oplog end: %v", err)
 		}
 
-		log.Logvf(log.DebugLow, "checking if oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false,  "checking if oplog entry %v still exists", dump.oplogStart)
 		exists, err := dump.checkOplogTimestampExists(dump.oplogStart)
 		if !exists {
 			return fmt.Errorf(
@@ -416,9 +416,9 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
-		log.Logvf(log.DebugHigh, "oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false,  "oplog entry %v still exists", dump.oplogStart)
 
-		log.Logvf(log.Always, "writing captured oplog to %v", dump.manager.Oplog().Location)
+		log.Logvf(log.Info, false,  "writing captured oplog to %v", dump.manager.Oplog().Location)
 
 		err = dump.DumpOplogBetweenTimestamps(dump.oplogStart, dump.oplogEnd)
 		if err != nil {
@@ -428,7 +428,7 @@ func (dump *MongoDump) Dump() (err error) {
 		// check the oplog for a rollover one last time, to avoid a race condition
 		// wherein the oplog rolls over in the time after our first check, but before
 		// we copy it.
-		log.Logvf(log.DebugLow, "checking again if oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false,  "checking again if oplog entry %v still exists", dump.oplogStart)
 		exists, err = dump.checkOplogTimestampExists(dump.oplogStart)
 		if !exists {
 			return fmt.Errorf(
@@ -437,10 +437,10 @@ func (dump *MongoDump) Dump() (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
-		log.Logvf(log.DebugHigh, "oplog entry %v still exists", dump.oplogStart)
+		log.Logvf(log.Trace, false,  "oplog entry %v still exists", dump.oplogStart)
 	}
 
-	log.Logvf(log.DebugLow, "finishing dump")
+	log.Logvf(log.Trace, false,  "finishing dump")
 
 	return err
 }
@@ -484,17 +484,17 @@ func (dump *MongoDump) DumpIntents() error {
 		dump.manager.Finalize(intents.Legacy)
 	}
 
-	log.Logvf(log.Info, "dumping up to %v collections in parallel", jobs)
+	log.Logvf(log.Debug, false,  "dumping up to %v collections in parallel", jobs)
 
 	// start a goroutine for each job thread
 	for i := 0; i < jobs; i++ {
 		go func(id int) {
 			buffer := dump.getResettableOutputBuffer()
-			log.Logvf(log.DebugHigh, "starting dump routine with id=%v", id)
+			log.Logvf(log.Trace, false,  "starting dump routine with id=%v", id)
 			for {
 				intent := dump.manager.Pop()
 				if intent == nil {
-					log.Logvf(log.DebugHigh, "ending dump routine with id=%v, no more work to do", id)
+					log.Logvf(log.Trace, false,  "ending dump routine with id=%v, no more work to do", id)
 					resultChan <- nil
 					return
 				}
@@ -554,7 +554,7 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 		dump.storageEngine = storageEngineModern
 		isMMAPV1, err := db.IsMMAPV1(intendedDB, intent.C)
 		if err != nil {
-			log.Logvf(log.Always,
+			log.Logvf(log.Error, false,
 				"failed to determine storage engine, an mmapv1 storage engine could result in"+
 					" inconsistent dump results, error was: %v", err)
 		} else if isMMAPV1 {
@@ -579,21 +579,21 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 	var dumpCount int64
 
 	if dump.OutputOptions.Out == "-" {
-		log.Logvf(log.Always, "writing %v to stdout", intent.Namespace())
+		log.Logvf(log.Info, false,  "writing %v to stdout", intent.Namespace())
 		dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer)
 		if err == nil {
 			// on success, print the document count
-			log.Logvf(log.Always, "dumped %v %v", dumpCount, docPlural(dumpCount))
+			log.Logvf(log.Info, false,  "dumped %v %v", dumpCount, docPlural(dumpCount))
 		}
 		return err
 	}
 
-	log.Logvf(log.Always, "writing %v to %v", intent.Namespace(), intent.Location)
+	log.Logvf(log.Info, false,  "writing %v to %v", intent.Namespace(), intent.Location)
 	if dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer); err != nil {
 		return err
 	}
 
-	log.Logvf(log.Always, "done dumping %v (%v %v)", intent.Namespace(), dumpCount, docPlural(dumpCount))
+	log.Logvf(log.Info, false,  "done dumping %v (%v %v)", intent.Namespace(), dumpCount, docPlural(dumpCount))
 	return nil
 }
 
@@ -613,7 +613,7 @@ func (dump *MongoDump) dumpQueryToIntent(
 // the oplog collection to avoid the performance issue in TOOLS-2068.
 func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent) (int64, error) {
 	if len(dump.query) != 0 || intent.IsOplog() {
-		log.Logvf(log.DebugLow, "not counting query on %v", intent.Namespace())
+		log.Logvf(log.Trace, false,  "not counting query on %v", intent.Namespace())
 		return 0, nil
 	}
 
@@ -622,7 +622,7 @@ func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent)
 		return 0, fmt.Errorf("error getting count from db: %v", err)
 	}
 
-	log.Logvf(log.DebugLow, "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
+	log.Logvf(log.Trace, false,  "counted %v %v in %v", total, docPlural(int64(total)), intent.Namespace())
 	return int64(total), nil
 }
 
@@ -709,7 +709,7 @@ func (dump *MongoDump) dumpValidatedIterToWriter(
 		for {
 			select {
 			case <-dump.shutdownIntentsNotifier.notified:
-				log.Logvf(log.DebugHigh, "terminating writes")
+				log.Logvf(log.Trace, false,  "terminating writes")
 				termErr = util.ErrTerminated
 				close(buffChan)
 				return

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -29,18 +29,18 @@ func (dump *MongoDump) determineOplogCollectionName() error {
 		return fmt.Errorf("error running command: %v", err)
 	}
 	if _, ok := masterDoc["hosts"]; ok {
-		log.Logvf(log.DebugLow, "determined cluster to be a replica set")
-		log.Logvf(log.DebugHigh, "oplog located in local.oplog.rs")
+		log.Logvf(log.Trace, false, "determined cluster to be a replica set")
+		log.Logvf(log.Trace, false, "oplog located in local.oplog.rs")
 		dump.oplogCollection = "oplog.rs"
 		return nil
 	}
 	if isMaster := masterDoc["ismaster"]; util.IsFalsy(isMaster) {
-		log.Logvf(log.Info, "mongodump is not connected to a master")
+		log.Logvf(log.Debug, false, "mongodump is not connected to a master")
 		return fmt.Errorf("not connected to master")
 	}
 
-	log.Logvf(log.DebugLow, "not connected to a replica set, assuming master/slave")
-	log.Logvf(log.DebugHigh, "oplog located in local.oplog.$main")
+	log.Logvf(log.Trace, false, "not connected to a replica set, assuming master/slave")
+	log.Logvf(log.Trace, false, "oplog located in local.oplog.$main")
 	dump.oplogCollection = "oplog.$main"
 	return nil
 
@@ -114,9 +114,9 @@ func (dump *MongoDump) checkOplogTimestampExists(ts primitive.Timestamp) (bool, 
 		return false, err
 	}
 
-	log.Logvf(log.DebugHigh, "oldest oplog entry has timestamp %v", oldestOplogEntry.Timestamp)
+	log.Logvf(log.Trace, false, "oldest oplog entry has timestamp %v", oldestOplogEntry.Timestamp)
 	if util.TimestampGreaterThan(oldestOplogEntry.Timestamp, ts) {
-		log.Logvf(log.Info, "oldest oplog entry of timestamp %v is newer than %v",
+		log.Logvf(log.Debug, false, "oldest oplog entry of timestamp %v is newer than %v",
 			oldestOplogEntry.Timestamp, ts)
 		return false, nil
 	}
@@ -156,7 +156,7 @@ func (dump *MongoDump) DumpOplogBetweenTimestamps(start, end primitive.Timestamp
 	}
 	oplogCount, err := dump.dumpValidatedQueryToIntent(oplogQuery, dump.manager.Oplog(), dump.getResettableOutputBuffer(), oplogDocumentValidator)
 	if err == nil {
-		log.Logvf(log.Always, "\tdumped %v oplog %v",
+		log.Logvf(log.Info, false, "\tdumped %v oplog %v",
 			oplogCount, util.Pluralize(int(oplogCount), "entry", "entries"))
 	}
 	return err

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -271,7 +271,7 @@ func (dump *MongoDump) CreateUsersRolesVersionIntentsForDB(db string) error {
 // puts it into the intent manager.
 func (dump *MongoDump) CreateCollectionIntent(dbName, colName string) error {
 	if dump.shouldSkipCollection(colName) {
-		log.Logvf(log.DebugLow, "skipping dump of %v.%v, it is excluded", dbName, colName)
+		log.Logvf(log.Trace, false,  "skipping dump of %v.%v, it is excluded", dbName, colName)
 		return nil
 	}
 
@@ -327,7 +327,7 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 		} else {
 			// otherwise, it's a view and the options specify not dumping a view
 			// so don't dump it.
-			log.Logvf(log.DebugLow, "not dumping data for %v.%v because it is a view", dbName, ci.Name)
+			log.Logvf(log.Trace,false,  "not dumping data for %v.%v because it is a view", dbName, ci.Name)
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && ci.IsView() {
@@ -391,16 +391,16 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 			return fmt.Errorf("error decoding collection info: %v", err)
 		}
 		if shouldSkipSystemNamespace(dbName, collInfo.Name) {
-			log.Logvf(log.DebugHigh, "will not dump system collection '%s.%s'", dbName, collInfo.Name)
+			log.Logvf(log.Trace, false, "will not dump system collection '%s.%s'", dbName, collInfo.Name)
 			continue
 		}
 		if dump.shouldSkipCollection(collInfo.Name) {
-			log.Logvf(log.DebugLow, "skipping dump of %v.%v, it is excluded", dbName, collInfo.Name)
+			log.Logvf(log.Trace,false,  "skipping dump of %v.%v, it is excluded", dbName, collInfo.Name)
 			continue
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && !collInfo.IsView() {
-			log.Logvf(log.DebugLow, "skipping dump of %v.%v because it is not a view", dbName, collInfo.Name)
+			log.Logvf(log.Trace,false,  "skipping dump of %v.%v because it is not a view", dbName, collInfo.Name)
 			continue
 		}
 		intent, err := dump.NewIntentFromOptions(dbName, collInfo)
@@ -419,7 +419,7 @@ func (dump *MongoDump) CreateAllIntents() error {
 	if err != nil {
 		return fmt.Errorf("error getting database names: %v", err)
 	}
-	log.Logvf(log.DebugHigh, "found databases: %v", strings.Join(dbs, ", "))
+	log.Logvf(log.Trace,false,  "found databases: %v", strings.Join(dbs, ", "))
 	for _, dbName := range dbs {
 		if dbName == "local" {
 			// local can only be explicitly dumped

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -271,7 +271,7 @@ func (dump *MongoDump) CreateUsersRolesVersionIntentsForDB(db string) error {
 // puts it into the intent manager.
 func (dump *MongoDump) CreateCollectionIntent(dbName, colName string) error {
 	if dump.shouldSkipCollection(colName) {
-		log.Logvf(log.Trace, false,  "skipping dump of %v.%v, it is excluded", dbName, colName)
+		log.Logvf(log.Trace, false, "skipping dump of %v.%v, it is excluded", dbName, colName)
 		return nil
 	}
 
@@ -327,7 +327,7 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 		} else {
 			// otherwise, it's a view and the options specify not dumping a view
 			// so don't dump it.
-			log.Logvf(log.Trace,false,  "not dumping data for %v.%v because it is a view", dbName, ci.Name)
+			log.Logvf(log.Trace, false, "not dumping data for %v.%v because it is a view", dbName, ci.Name)
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && ci.IsView() {
@@ -395,12 +395,12 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 			continue
 		}
 		if dump.shouldSkipCollection(collInfo.Name) {
-			log.Logvf(log.Trace,false,  "skipping dump of %v.%v, it is excluded", dbName, collInfo.Name)
+			log.Logvf(log.Trace, false, "skipping dump of %v.%v, it is excluded", dbName, collInfo.Name)
 			continue
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && !collInfo.IsView() {
-			log.Logvf(log.Trace,false,  "skipping dump of %v.%v because it is not a view", dbName, collInfo.Name)
+			log.Logvf(log.Trace, false, "skipping dump of %v.%v because it is not a view", dbName, collInfo.Name)
 			continue
 		}
 		intent, err := dump.NewIntentFromOptions(dbName, collInfo)
@@ -419,7 +419,7 @@ func (dump *MongoDump) CreateAllIntents() error {
 	if err != nil {
 		return fmt.Errorf("error getting database names: %v", err)
 	}
-	log.Logvf(log.Trace,false,  "found databases: %v", strings.Join(dbs, ", "))
+	log.Logvf(log.Trace, false, "found databases: %v", strings.Join(dbs, ", "))
 	for _, dbName := range dbs {
 		if dbName == "local" {
 			// local can only be explicitly dumped

--- a/mongoexport/main/mongoexport.go
+++ b/mongoexport/main/mongoexport.go
@@ -24,7 +24,7 @@ var (
 func main() {
 	opts, err := mongoexport.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,"error parsing command line options: %v", err)
+		log.Logvf(log.Error, false, "error parsing command line options: %v", err)
 		log.Logvf(log.Info, false, util.ShortUsage("mongoexport"))
 		os.Exit(util.ExitFailure)
 	}

--- a/mongoexport/main/mongoexport.go
+++ b/mongoexport/main/mongoexport.go
@@ -24,8 +24,8 @@ var (
 func main() {
 	opts, err := mongoexport.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, util.ShortUsage("mongoexport"))
+		log.Logvf(log.Error, false,"error parsing command line options: %v", err)
+		log.Logvf(log.Info, false, util.ShortUsage("mongoexport"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -43,10 +43,10 @@ func main() {
 
 	exporter, err := mongoexport.New(opts)
 	if err != nil {
-		log.Logvf(log.Always, "%v", err)
+		log.Logvf(log.Error, false, "%v", err)
 
 		if se, ok := err.(util.SetupError); ok && se.Message != "" {
-			log.Logv(log.Always, se.Message)
+			log.Logv(log.Error, false, se.Message)
 		}
 
 		os.Exit(util.ExitFailure)
@@ -55,7 +55,7 @@ func main() {
 
 	writer, err := exporter.GetOutputWriter()
 	if err != nil {
-		log.Logvf(log.Always, "error opening output stream: %v", err)
+		log.Logvf(log.Error, false, "error opening output stream: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 	if writer == nil {
@@ -66,14 +66,14 @@ func main() {
 
 	numDocs, err := exporter.Export(writer)
 	if err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 
 	if numDocs == 1 {
-		log.Logvf(log.Always, "exported %v record", numDocs)
+		log.Logvf(log.Info, false, "exported %v record", numDocs)
 	} else {
-		log.Logvf(log.Always, "exported %v records", numDocs)
+		log.Logvf(log.Info, false, "exported %v records", numDocs)
 	}
 
 }

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -111,7 +111,7 @@ func New(opts Options) (*MongoExport, error) {
 		return nil, util.SetupError{Err: err}
 	}
 
-	log.Logvf(log.Always, "connected to: %v", util.SanitizeURI(opts.URI.ConnectionString))
+	log.Logvf(log.Info, false, "connected to: %v", util.SanitizeURI(opts.URI.ConnectionString))
 
 	isMongos, err := provider.IsMongos()
 	if err != nil {
@@ -122,7 +122,7 @@ func New(opts Options) (*MongoExport, error) {
 	// warn if we are trying to export from a secondary in a sharded cluster
 	pref := opts.ToolOptions.ReadPreference
 	if isMongos && pref != nil && pref.Mode() != readpref.PrimaryMode {
-		log.Logvf(log.Always, db.WarningNonPrimaryMongosConnection)
+		log.Logvf(log.Warn, false, db.WarningNonPrimaryMongosConnection)
 	}
 
 	progressManager := progress.NewBarWriter(log.Writer(0), progressBarWaitTime, progressBarLength, false)
@@ -164,7 +164,7 @@ func (exp *MongoExport) validateSettings() error {
 	exp.OutputOpts.Type = strings.ToLower(exp.OutputOpts.Type)
 
 	if exp.OutputOpts.CSVOutputType {
-		log.Logv(log.Always, "csv flag is deprecated; please use --type=csv instead")
+		log.Logv(log.Warn, false, "csv flag is deprecated; please use --type=csv instead")
 		exp.OutputOpts.Type = CSV
 	}
 
@@ -333,7 +333,7 @@ func (exp *MongoExport) getCursor() (*mongo.Cursor, error) {
 		collection := intendedDB.Collection(exp.ToolOptions.Namespace.Collection)
 		collectionInfo, err := db.GetCollectionInfo(collection)
 		if err != nil || !collectionInfo.IsView() {
-			log.Logvf(log.Always,
+			log.Logvf(log.Error, false,
 				"failed to determine storage engine, an mmapv1 storage engine could"+
 					" result in inconsistent export results, error was: %v", err)
 		}

--- a/mongoexport/options.go
+++ b/mongoexport/options.go
@@ -132,7 +132,7 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 			return Options{}, fmt.Errorf("--slaveOk can't be specified when --readPreference is specified")
 		}
 
-		log.Logvf(log.Always, "--slaveOk is deprecated and --readPreference=nearest should be used instead")
+		log.Logvf(log.Warn, false, "--slaveOk is deprecated and --readPreference=nearest should be used instead")
 		inputOpts.ReadPreference = "nearest"
 	}
 

--- a/mongofiles/main/mongofiles.go
+++ b/mongofiles/main/mongofiles.go
@@ -25,8 +25,8 @@ var (
 func main() {
 	opts, err := mongofiles.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %s", err.Error())
-		log.Logv(log.Always, util.ShortUsage("mongofiles"))
+		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
+		log.Logv(log.Info, false,  util.ShortUsage("mongofiles"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -44,9 +44,9 @@ func main() {
 
 	mf, err := mongofiles.New(opts)
 	if err != nil {
-		log.Logv(log.Always, err.Error())
+		log.Logv(log.Error,false,  err.Error())
 		if setupErr, ok := err.(util.SetupError); ok && setupErr.Message != "" {
-			log.Logvf(log.Always, setupErr.Message)
+			log.Logvf(log.Error, false,  setupErr.Message)
 		}
 		os.Exit(util.ExitFailure)
 	}
@@ -54,7 +54,7 @@ func main() {
 
 	output, err := mf.Run(true)
 	if err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error,false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 	fmt.Printf("%s", output)

--- a/mongofiles/main/mongofiles.go
+++ b/mongofiles/main/mongofiles.go
@@ -25,8 +25,8 @@ var (
 func main() {
 	opts, err := mongofiles.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
-		log.Logv(log.Info, false,  util.ShortUsage("mongofiles"))
+		log.Logvf(log.Error, false, "error parsing command line options: %s", err.Error())
+		log.Logv(log.Info, false, util.ShortUsage("mongofiles"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -44,9 +44,9 @@ func main() {
 
 	mf, err := mongofiles.New(opts)
 	if err != nil {
-		log.Logv(log.Error,false,  err.Error())
+		log.Logv(log.Error, false, err.Error())
 		if setupErr, ok := err.(util.SetupError); ok && setupErr.Message != "" {
-			log.Logvf(log.Error, false,  setupErr.Message)
+			log.Logvf(log.Error, false, setupErr.Message)
 		}
 		os.Exit(util.ExitFailure)
 	}
@@ -54,7 +54,7 @@ func main() {
 
 	output, err := mf.Run(true)
 	if err != nil {
-		log.Logvf(log.Error,false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 	fmt.Printf("%s", output)

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -305,7 +305,7 @@ func (mf *MongoFiles) deleteAll(filename string) error {
 			return err
 		}
 	}
-	log.Logvf(log.Always, "successfully deleted all instances of '%v' from GridFS\n", mf.FileName)
+	log.Logvf(log.Info, false, "successfully deleted all instances of '%v' from GridFS\n", mf.FileName)
 
 	return nil
 }
@@ -321,7 +321,7 @@ func (mf *MongoFiles) handleDeleteID() error {
 	if err := file.Delete(); err != nil {
 		return err
 	}
-	log.Logvf(log.Always, fmt.Sprintf("successfully deleted file with _id %v from GridFS", mf.Id))
+	log.Logvf(log.Info, false, fmt.Sprintf("successfully deleted file with _id %v from GridFS", mf.Id))
 
 	return nil
 }
@@ -363,7 +363,7 @@ func (mf *MongoFiles) writeGFSFileToLocal(gridFile *gfsFile) (err error) {
 		}
 		dc := util.DeferredCloser{Closer: localFile}
 		defer dc.CloseWithErrorCapture(&err)
-		log.Logvf(log.DebugLow, "created local file '%v'", localFileName)
+		log.Logvf(log.Trace, false, "created local file '%v'", localFileName)
 	}
 
 	stream, err := gridFile.OpenStreamForReading()
@@ -377,7 +377,7 @@ func (mf *MongoFiles) writeGFSFileToLocal(gridFile *gfsFile) (err error) {
 		return fmt.Errorf("error while writing Data into local file '%v': %v", localFileName, err)
 	}
 
-	log.Logvf(log.Always, fmt.Sprintf("finished writing to %s\n", localFileName))
+	log.Logvf(log.Info, false, fmt.Sprintf("finished writing to %s\n", localFileName))
 	return nil
 }
 
@@ -400,7 +400,7 @@ func (mf *MongoFiles) put(id interface{}, name string) (bytesWritten int64, err 
 		}
 		dc := util.DeferredCloser{Closer: localFile}
 		defer dc.CloseWithErrorCapture(&err)
-		log.Logvf(log.DebugLow, "creating GridFS gridFile '%v' from local gridFile '%v'", mf.FileName, localFileName)
+		log.Logvf(log.Trace, false, "creating GridFS gridFile '%v' from local gridFile '%v'", mf.FileName, localFileName)
 	}
 
 	// check if --replace flag turned on
@@ -441,15 +441,15 @@ func (mf *MongoFiles) handlePut() error {
 			return err
 		}
 
-		log.Logvf(log.Always, "adding gridFile: %v\n", filename)
+		log.Logvf(log.Info, false, "adding gridFile: %v\n", filename)
 
 		n, err := mf.put(id, filename)
 		if err != nil {
-			log.Logvf(log.Always, "error adding gridFile: %v\n", err)
+			log.Logvf(log.Error, false, "error adding gridFile: %v\n", err)
 			return err
 		}
-		log.Logvf(log.DebugLow, "copied %v bytes to server", n)
-		log.Logvf(log.Always, "added gridFile: %v\n", filename)
+		log.Logvf(log.Info, false,"copied %v bytes to server", n)
+		log.Logvf(log.Info, false,"added gridFile: %v\n", filename)
 	}
 
 	return nil
@@ -466,7 +466,7 @@ func (mf *MongoFiles) Run(displayHost bool) (output string, finalErr error) {
 		return "", fmt.Errorf("error determining type of node connected: %v", err)
 	}
 
-	log.Logvf(log.DebugLow, "connected to node type: %v", nodeType)
+	log.Logvf(log.Trace, false, "connected to node type: %v", nodeType)
 
 	client, err := mf.SessionProvider.GetSession()
 	if err != nil {
@@ -485,7 +485,7 @@ func (mf *MongoFiles) Run(displayHost bool) (output string, finalErr error) {
 	}
 
 	if displayHost {
-		log.Logvf(log.Always, "connected to: %v", util.SanitizeURI(mf.ToolOptions.URI.ConnectionString))
+		log.Logvf(log.Info, false, "connected to: %v", util.SanitizeURI(mf.ToolOptions.URI.ConnectionString))
 	}
 
 	// first validate the namespaces we'll be using: <db>.<prefix>.files and <db>.<prefix>.chunks

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -448,7 +448,7 @@ func (mf *MongoFiles) handlePut() error {
 			log.Logvf(log.Error, false, "error adding gridFile: %v\n", err)
 			return err
 		}
-		log.Logvf(log.Info, false, "copied %v bytes to server", n)
+		log.Logvf(log.Trace, false, "copied %v bytes to server", n)
 		log.Logvf(log.Info, false, "added gridFile: %v\n", filename)
 	}
 

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -448,8 +448,8 @@ func (mf *MongoFiles) handlePut() error {
 			log.Logvf(log.Error, false, "error adding gridFile: %v\n", err)
 			return err
 		}
-		log.Logvf(log.Info, false,"copied %v bytes to server", n)
-		log.Logvf(log.Info, false,"added gridFile: %v\n", filename)
+		log.Logvf(log.Info, false, "copied %v bytes to server", n)
+		log.Logvf(log.Info, false, "added gridFile: %v\n", filename)
 	}
 
 	return nil

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -496,7 +496,7 @@ func (mf *MongoFiles) Run(displayHost bool) (output string, finalErr error) {
 		return "", err
 	}
 
-	log.Logvf(log.Info, "handling mongofiles '%v' command...", mf.Command)
+	log.Logvf(log.Debug, false, "handling mongofiles '%v' command...", mf.Command)
 
 	switch mf.Command {
 

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -785,7 +785,7 @@ func validateReaderFields(fields []string, useArrayIndexFields bool) error {
 		return err
 	}
 	if len(fields) == 1 {
-		log.Logvf(log.Debug, false,"using field: %v", fields[0])
+		log.Logvf(log.Debug, false, "using field: %v", fields[0])
 	} else {
 		log.Logvf(log.Debug, false, "using fields: %v", strings.Join(fields, ","))
 	}

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -224,7 +224,7 @@ func getUpsertValue(field string, document bson.D) interface{} {
 	left := field[0:index]
 	subDoc, _ := bsonutil.FindValueByKey(left, &document)
 	if subDoc == nil {
-		log.Logvf(log.DebugHigh, "no subdoc found for '%v'", left)
+		log.Logvf(log.Trace, false, "no subdoc found for '%v'", left)
 		return nil
 	}
 	switch subDoc.(type) {
@@ -235,7 +235,7 @@ func getUpsertValue(field string, document bson.D) interface{} {
 		subDocD := subDoc.(*bson.D)
 		return getUpsertValue(field[index+1:], *subDocD)
 	default:
-		log.Logvf(log.DebugHigh, "subdoc found for '%v', but couldn't coerce to bson.D", left)
+		log.Logvf(log.Trace, false, "subdoc found for '%v', but couldn't coerce to bson.D", left)
 		return nil
 	}
 }
@@ -491,7 +491,7 @@ func (coercionError) Error() string { return "coercionError" }
 // tokensToBSON reads in slice of records - along with ordered column names -
 // and returns a BSON document for the record.
 func tokensToBSON(colSpecs []ColumnSpec, tokens []string, numProcessed uint64, ignoreBlanks bool, useArrayIndexFields bool) (bson.D, error) {
-	log.Logvf(log.DebugHigh, "got line: %v", tokens)
+	log.Logvf(log.Trace, false, "got line: %v", tokens)
 	var parsedValue interface{}
 	document := bson.D{}
 	for index, token := range tokens {
@@ -501,7 +501,7 @@ func tokensToBSON(colSpecs []ColumnSpec, tokens []string, numProcessed uint64, i
 		if index < len(colSpecs) {
 			parsedValue, err := colSpecs[index].Parser.Parse(token)
 			if err != nil {
-				log.Logvf(log.DebugHigh, "parse failure in document #%d for column '%s',"+
+				log.Logvf(log.Trace, false, "parse failure in document #%d for column '%s',"+
 					"could not parse token '%s' to type %s",
 					numProcessed, colSpecs[index].Name, token, colSpecs[index].TypeName)
 				switch colSpecs[index].ParseGrace {
@@ -510,7 +510,7 @@ func tokensToBSON(colSpecs []ColumnSpec, tokens []string, numProcessed uint64, i
 				case pgSkipField:
 					continue
 				case pgSkipRow:
-					log.Logvf(log.Always, "skipping row #%d: %v", numProcessed, tokens)
+					log.Logvf(log.Info, false, "skipping row #%d: %v", numProcessed, tokens)
 					return nil, coercionError{}
 				case pgStop:
 					return nil, fmt.Errorf("type coercion failure in document #%d for column '%s', "+
@@ -785,9 +785,9 @@ func validateReaderFields(fields []string, useArrayIndexFields bool) error {
 		return err
 	}
 	if len(fields) == 1 {
-		log.Logvf(log.Info, "using field: %v", fields[0])
+		log.Logvf(log.Debug, false,"using field: %v", fields[0])
 	} else {
-		log.Logvf(log.Info, "using fields: %v", strings.Join(fields, ","))
+		log.Logvf(log.Debug, false, "using fields: %v", strings.Join(fields, ","))
 	}
 	return nil
 }

--- a/mongoimport/json.go
+++ b/mongoimport/json.go
@@ -174,13 +174,13 @@ func (c JSONConverter) convertLegacyExtJSON() (bson.D, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling bytes on document #%v: %v", c.index, err)
 	}
-	log.Logvf(log.DebugHigh, "got line: %v", document)
+	log.Logvf(log.Trace, false, "got line: %v", document)
 
 	bsonD, err := bsonutil.GetExtendedBsonD(document)
 	if err != nil {
 		return nil, fmt.Errorf("error getting extended BSON for document #%v: %v", c.index, err)
 	}
-	log.Logvf(log.DebugHigh, "got extended line: %#v", bsonD)
+	log.Logvf(log.Trace, false, "got extended line: %#v", bsonD)
 	return bsonD, nil
 }
 

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -24,8 +24,8 @@ var (
 func main() {
 	opts, err := mongoimport.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %v", err)
-		log.Logvf(log.Always, util.ShortUsage("mongoimport"))
+		log.Logvf(log.Error, false, "error parsing command line options: %v", err)
+		log.Logvf(log.Info, false, util.ShortUsage("mongoimport"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -43,7 +43,7 @@ func main() {
 
 	m, err := mongoimport.New(opts)
 	if err != nil {
-		log.Logvf(log.Always, err.Error())
+		log.Logvf(log.Error, false, err.Error())
 		os.Exit(util.ExitFailure)
 	}
 	defer m.Close()
@@ -51,16 +51,16 @@ func main() {
 	numDocs, numFailure, err := m.ImportDocuments()
 	if !opts.Quiet {
 		if err != nil {
-			log.Logvf(log.Always, "Failed: %v", err)
+			log.Logvf(log.Error, false, "Failed: %v", err)
 		}
 		if m.ToolOptions.WriteConcern.Acknowledged() {
 			if opts.Mode == "delete" {
-				log.Logvf(log.Always, "%v document(s) deleted successfully. %v document(s) failed to delete.", numDocs, numFailure)
+				log.Logvf(log.Info, false, "%v document(s) deleted successfully. %v document(s) failed to delete.", numDocs, numFailure)
 			} else {
-				log.Logvf(log.Always, "%v document(s) imported successfully. %v document(s) failed to import.", numDocs, numFailure)
+				log.Logvf(log.Info, false, "%v document(s) imported successfully. %v document(s) failed to import.", numDocs, numFailure)
 			}
 		} else {
-			log.Logvf(log.Always, "done")
+			log.Logvf(log.Info, false, "done")
 		}
 	}
 	if err != nil {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -236,7 +236,7 @@ func (imp *MongoImport) validateSettings(args []string) error {
 
 	if imp.IngestOptions.Mode != modeInsert {
 		imp.IngestOptions.MaintainInsertionOrder = true
-		log.Logvf(log.Info, "using upsert fields: %v", imp.upsertFields)
+		log.Logvf(log.Debug, false,"using upsert fields: %v", imp.upsertFields)
 	}
 
 	if imp.IngestOptions.MaintainInsertionOrder {
@@ -252,8 +252,8 @@ func (imp *MongoImport) validateSettings(args []string) error {
 			imp.IngestOptions.NumInsertionWorkers = 1
 		}
 	}
-	log.Logvf(log.DebugLow, "using %v decoding workers", imp.IngestOptions.NumDecodingWorkers)
-	log.Logvf(log.DebugLow, "using %v insert workers", imp.IngestOptions.NumInsertionWorkers)
+	log.Logvf(log.Trace, false, "using %v decoding workers", imp.IngestOptions.NumDecodingWorkers)
+	log.Logvf(log.Trace, false, "using %v insert workers", imp.IngestOptions.NumInsertionWorkers)
 
 	// get the number of documents per batch
 	if imp.IngestOptions.BulkBufferSize <= 0 || imp.IngestOptions.BulkBufferSize > 1000 {
@@ -262,13 +262,13 @@ func (imp *MongoImport) validateSettings(args []string) error {
 
 	// ensure we have a valid string to use for the collection
 	if imp.ToolOptions.Collection == "" {
-		log.Logvf(log.Always, "no collection specified")
+		log.Logvf(log.Info, false, "no collection specified")
 		fileBaseName := filepath.Base(imp.InputOptions.File)
 		lastDotIndex := strings.LastIndex(fileBaseName, ".")
 		if lastDotIndex != -1 {
 			fileBaseName = fileBaseName[0:lastDotIndex]
 		}
-		log.Logvf(log.Always, "using filename '%v' as collection", fileBaseName)
+		log.Logvf(log.Info, false, "using filename '%v' as collection", fileBaseName)
 		imp.ToolOptions.Collection = fileBaseName
 	}
 	err = util.ValidateCollectionName(imp.ToolOptions.Collection)
@@ -291,11 +291,11 @@ func (imp *MongoImport) getSourceReader() (io.ReadCloser, int64, error) {
 		if err != nil {
 			return nil, -1, err
 		}
-		log.Logvf(log.Info, "filesize: %v bytes", fileStat.Size())
+		log.Logvf(log.Debug, false, "filesize: %v bytes", fileStat.Size())
 		return file, int64(fileStat.Size()), err
 	}
 
-	log.Logvf(log.Info, "reading from stdin")
+	log.Logvf(log.Debug, false, "reading from stdin")
 
 	// Stdin has undefined max size, so return 0
 	return os.Stdin, 0, nil
@@ -361,9 +361,9 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (uint64, uint64
 		return 0, 0, err
 	}
 
-	log.Logvf(log.Always, "connected to: %v", util.SanitizeURI(imp.ToolOptions.URI.ConnectionString))
+	log.Logvf(log.Info, false, "connected to: %v", util.SanitizeURI(imp.ToolOptions.URI.ConnectionString))
 
-	log.Logvf(log.Info, "ns: %v.%v",
+	log.Logvf(log.Debug, false, "ns: %v.%v",
 		imp.ToolOptions.Namespace.DB,
 		imp.ToolOptions.Namespace.Collection)
 
@@ -372,11 +372,11 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (uint64, uint64
 	if err != nil {
 		return 0, 0, fmt.Errorf("error checking connected node type: %v", err)
 	}
-	log.Logvf(log.Info, "connected to node type: %v", imp.nodeType)
+	log.Logvf(log.Debug, false,"connected to node type: %v", imp.nodeType)
 
 	// drop the database if necessary
 	if imp.IngestOptions.Drop {
-		log.Logvf(log.Always, "dropping: %v.%v",
+		log.Logvf(log.Info, false, "dropping: %v.%v",
 			imp.ToolOptions.DB,
 			imp.ToolOptions.Collection)
 		collection := session.Database(imp.ToolOptions.DB).
@@ -506,7 +506,7 @@ func (imp *MongoImport) importDocument(inserter *db.BufferedBulkInserter, docume
 		}
 	} else if imp.IngestOptions.Mode == modeDelete {
 		if selector == nil {
-			log.Logvf(log.Info, "Could not construct selector from %v, skipping document", imp.upsertFields)
+			log.Logvf(log.Debug, false, "Could not construct selector from %v, skipping document", imp.upsertFields)
 		} else {
 			result, err = inserter.Delete(selector, document)
 		}
@@ -521,7 +521,7 @@ func (imp *MongoImport) importDocument(inserter *db.BufferedBulkInserter, docume
 }
 
 func (imp *MongoImport) fallbackToInsert(inserter *db.BufferedBulkInserter, document bson.D) (result *mongo.BulkWriteResult, err error) {
-	log.Logvf(log.Info, "Could not construct selector from %v, falling back to insert mode", imp.upsertFields)
+	log.Logvf(log.Debug, false, "Could not construct selector from %v, falling back to insert mode", imp.upsertFields)
 	result, err = inserter.Insert(document)
 	return
 }

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -236,7 +236,7 @@ func (imp *MongoImport) validateSettings(args []string) error {
 
 	if imp.IngestOptions.Mode != modeInsert {
 		imp.IngestOptions.MaintainInsertionOrder = true
-		log.Logvf(log.Debug, false,"using upsert fields: %v", imp.upsertFields)
+		log.Logvf(log.Debug, false, "using upsert fields: %v", imp.upsertFields)
 	}
 
 	if imp.IngestOptions.MaintainInsertionOrder {
@@ -372,7 +372,7 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (uint64, uint64
 	if err != nil {
 		return 0, 0, fmt.Errorf("error checking connected node type: %v", err)
 	}
-	log.Logvf(log.Debug, false,"connected to node type: %v", imp.nodeType)
+	log.Logvf(log.Debug, false, "connected to node type: %v", imp.nodeType)
 
 	// drop the database if necessary
 	if imp.IngestOptions.Drop {

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -25,8 +25,8 @@ func main() {
 	opts, err := mongorestore.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Always, util.ShortUsage("mongorestore"))
+		log.Logvf(log.Error, false, "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false, util.ShortUsage("mongorestore"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -41,7 +41,7 @@ func main() {
 
 	restore, err := mongorestore.New(opts)
 	if err != nil {
-		log.Logvf(log.Always, err.Error())
+		log.Logvf(log.Error, false, err.Error())
 		os.Exit(util.ExitFailure)
 	}
 	defer restore.Close()
@@ -51,13 +51,13 @@ func main() {
 
 	result := restore.Restore()
 	if result.Err != nil {
-		log.Logvf(log.Always, "Failed: %v", result.Err)
+		log.Logvf(log.Error, false, "Failed: %v", result.Err)
 	}
 
 	if restore.ToolOptions.WriteConcern.Acknowledged() {
-		log.Logvf(log.Always, "%v document(s) restored successfully. %v document(s) failed to restore.", result.Successes, result.Failures)
+		log.Logvf(log.Info, false, "%v document(s) restored successfully. %v document(s) failed to restore.", result.Successes, result.Failures)
 	} else {
-		log.Logvf(log.Always, "done")
+		log.Logvf(log.Info, false, "done")
 	}
 
 	if result.Err != nil {

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -355,7 +355,7 @@ func (restore *MongoRestore) Restore() Result {
 		if err != nil {
 			return Result{Err: err}
 		}
-		log.Logvf(log.Trace, false,`archive format version "%v"`, restore.archive.Prelude.Header.FormatVersion)
+		log.Logvf(log.Trace, false, `archive format version "%v"`, restore.archive.Prelude.Header.FormatVersion)
 		log.Logvf(log.Trace, false, `archive server version "%v"`, restore.archive.Prelude.Header.ServerVersion)
 		log.Logvf(log.Trace, false, `archive tool version "%v"`, restore.archive.Prelude.Header.ToolVersion)
 		target, err = restore.archive.Prelude.NewPreludeExplorer()

--- a/mongorestore/mongorestore_archive_test.go
+++ b/mongorestore/mongorestore_archive_test.go
@@ -60,7 +60,7 @@ func TestMongorestoreShortArchive(t *testing.T) {
 		fileSize := fi.Size()
 
 		for i := fileSize; i >= 0; i -= fileSize / 10 {
-			log.Logvf(log.Always, "Restoring from the first %v bytes of a archive of size %v", i, fileSize)
+			log.Logvf(log.Info, false, "Restoring from the first %v bytes of a archive of size %v", i, fileSize)
 
 			_, err = file.Seek(0, 0)
 			So(err, ShouldBeNil)

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -38,7 +38,7 @@ type oplogContext struct {
 // shouldIgnoreNamespace returns true if the given namespace should be ignored during applyOps.
 func shouldIgnoreNamespace(ns string) bool {
 	if strings.HasPrefix(ns, "config.cache.") || ns == "config.system.sessions" || ns == "config.system.indexBuilds" {
-		log.Logv(log.Always, "skipping applying the "+ns+" namespace in applyOps")
+		log.Logv(log.Info, false, "skipping applying the "+ns+" namespace in applyOps")
 		return true
 	}
 	return false
@@ -46,11 +46,11 @@ func shouldIgnoreNamespace(ns string) bool {
 
 // RestoreOplog attempts to restore a MongoDB oplog.
 func (restore *MongoRestore) RestoreOplog() error {
-	log.Logv(log.Always, "replaying oplog")
+	log.Logv(log.Info, false, "replaying oplog")
 	intent := restore.manager.Oplog()
 	if intent == nil {
 		// this should not be reached
-		log.Logv(log.Always, "no oplog file provided, skipping oplog application")
+		log.Logv(log.Info, false, "no oplog file provided, skipping oplog application")
 		return nil
 	}
 	if err := intent.BSONFile.Open(); err != nil {
@@ -114,14 +114,14 @@ func (restore *MongoRestore) RestoreOplog() error {
 		if entryAsOplog.Operation == "c" && len(entryAsOplog.Object) > 0 {
 			entryName := entryAsOplog.Object[0].Key
 			if entryName == "startIndexBuild" || entryName == "abortIndexBuild" {
-				log.Logv(log.Always, "skipping applying the oplog entry "+entryName)
+				log.Logv(log.Info, false, "skipping applying the oplog entry "+entryName)
 				continue
 			}
 		}
 
 		if !restore.TimestampBeforeLimit(entryAsOplog.Timestamp) {
 			log.Logvf(
-				log.DebugLow,
+				log.Trace, false,
 				"timestamp %v is not below limit of %v; ending oplog restoration",
 				entryAsOplog.Timestamp,
 				restore.oplogLimit,
@@ -151,7 +151,7 @@ func (restore *MongoRestore) RestoreOplog() error {
 		fileNeedsIOBuffer.ReleaseIOBuffer()
 	}
 
-	log.Logvf(log.Always, "applied %v oplog entries", oplogCtx.totalOps)
+	log.Logvf(log.Info, false, "applied %v oplog entries", oplogCtx.totalOps)
 	if err := decodedBsonSource.Err(); err != nil {
 		return fmt.Errorf("error reading oplog bson input: %v", err)
 	}

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -210,7 +210,7 @@ func getTargetDirFromArgs(extraArgs []string, dirFlag string) (string, error) {
 
 	case dirFlag != "":
 		// if we have no extra args and a --dir flag, use the --dir flag
-		log.Logv(log.Info, "using "+DirectoryOption+" flag instead of arguments")
+		log.Logv(log.Debug, false, "using "+DirectoryOption+" flag instead of arguments")
 		return dirFlag, nil
 
 	default:

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -58,8 +58,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongostat.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Info, false,  util.ShortUsage("mongostat"))
+		log.Logvf(log.Error, false, "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false, util.ShortUsage("mongostat"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -82,31 +82,31 @@ func main() {
 	if opts.Auth.Username != "" && opts.GetAuthenticationDatabase() == "" && !opts.Auth.RequiresExternalDB() {
 		// add logic to have different error if using uri
 		if opts.URI != nil && opts.URI.ConnectionString != "" {
-			log.Logvf(log.Error, false,  "authSource is required when authenticating against a non $external database")
+			log.Logvf(log.Error, false, "authSource is required when authenticating against a non $external database")
 			os.Exit(util.ExitFailure)
 		}
 
-		log.Logvf(log.Error, false,  "--authenticationDatabase is required when authenticating against a non $external database")
+		log.Logvf(log.Error, false, "--authenticationDatabase is required when authenticating against a non $external database")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Interactive && opts.Json {
-		log.Logvf(log.Error, false,  "cannot use output formats --json and --interactive together")
+		log.Logvf(log.Error, false, "cannot use output formats --json and --interactive together")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Deprecated && !opts.Json {
-		log.Logvf(log.Error, false,  "--useDeprecatedJsonKeys can only be used when --json is also specified")
+		log.Logvf(log.Error, false, "--useDeprecatedJsonKeys can only be used when --json is also specified")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Columns != "" && opts.AppendColumns != "" {
-		log.Logvf(log.Error, false,  "-O cannot be used if -o is also specified")
+		log.Logvf(log.Error, false, "-O cannot be used if -o is also specified")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.HumanReadable != "true" && opts.HumanReadable != "false" {
-		log.Logvf(log.Error, false,  "--humanReadable must be set to either 'true' or 'false'")
+		log.Logvf(log.Error, false, "--humanReadable must be set to either 'true' or 'false'")
 		os.Exit(util.ExitFailure)
 	}
 
@@ -115,7 +115,7 @@ func main() {
 	if opts.Auth.ShouldAskForPassword() {
 		pass, err := password.Prompt()
 		if err != nil {
-			log.Logvf(log.Error, false,  "Failed: %v", err)
+			log.Logvf(log.Error, false, "Failed: %v", err)
 			os.Exit(util.ExitFailure)
 		}
 		opts.Auth.Password = pass
@@ -211,7 +211,7 @@ func main() {
 
 	for _, v := range seedHosts {
 		if err := stat.AddNewNode(v); err != nil {
-			log.Logv(log.Error, false,  err.Error())
+			log.Logv(log.Error, false, err.Error())
 			os.Exit(util.ExitFailure)
 		}
 	}
@@ -223,7 +223,7 @@ func main() {
 	}
 	formatter.Finish()
 	if err != nil {
-		log.Logvf(log.Error, false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -58,8 +58,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongostat.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Always, util.ShortUsage("mongostat"))
+		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false,  util.ShortUsage("mongostat"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -82,31 +82,31 @@ func main() {
 	if opts.Auth.Username != "" && opts.GetAuthenticationDatabase() == "" && !opts.Auth.RequiresExternalDB() {
 		// add logic to have different error if using uri
 		if opts.URI != nil && opts.URI.ConnectionString != "" {
-			log.Logvf(log.Always, "authSource is required when authenticating against a non $external database")
+			log.Logvf(log.Error, false,  "authSource is required when authenticating against a non $external database")
 			os.Exit(util.ExitFailure)
 		}
 
-		log.Logvf(log.Always, "--authenticationDatabase is required when authenticating against a non $external database")
+		log.Logvf(log.Error, false,  "--authenticationDatabase is required when authenticating against a non $external database")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Interactive && opts.Json {
-		log.Logvf(log.Always, "cannot use output formats --json and --interactive together")
+		log.Logvf(log.Error, false,  "cannot use output formats --json and --interactive together")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Deprecated && !opts.Json {
-		log.Logvf(log.Always, "--useDeprecatedJsonKeys can only be used when --json is also specified")
+		log.Logvf(log.Error, false,  "--useDeprecatedJsonKeys can only be used when --json is also specified")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Columns != "" && opts.AppendColumns != "" {
-		log.Logvf(log.Always, "-O cannot be used if -o is also specified")
+		log.Logvf(log.Error, false,  "-O cannot be used if -o is also specified")
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.HumanReadable != "true" && opts.HumanReadable != "false" {
-		log.Logvf(log.Always, "--humanReadable must be set to either 'true' or 'false'")
+		log.Logvf(log.Error, false,  "--humanReadable must be set to either 'true' or 'false'")
 		os.Exit(util.ExitFailure)
 	}
 
@@ -115,7 +115,7 @@ func main() {
 	if opts.Auth.ShouldAskForPassword() {
 		pass, err := password.Prompt()
 		if err != nil {
-			log.Logvf(log.Always, "Failed: %v", err)
+			log.Logvf(log.Error, false,  "Failed: %v", err)
 			os.Exit(util.ExitFailure)
 		}
 		opts.Auth.Password = pass
@@ -211,7 +211,7 @@ func main() {
 
 	for _, v := range seedHosts {
 		if err := stat.AddNewNode(v); err != nil {
-			log.Logv(log.Always, err.Error())
+			log.Logv(log.Error, false,  err.Error())
 			os.Exit(util.ExitFailure)
 		}
 	}
@@ -223,7 +223,7 @@ func main() {
 	}
 	formatter.Finish()
 	if err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -285,17 +285,17 @@ func (node *NodeMonitor) Poll(discover chan string, checkShards bool) (*status.S
 	result := session.Database("admin").RunCommand(nil, bson.D{{"serverStatus", 1}, {"recordStats", 0}})
 	err = result.Err()
 	if err != nil {
-		log.Logvf(log.Trace, false,  "got error calling serverStatus against server %v", node.host)
+		log.Logvf(log.Trace, false, "got error calling serverStatus against server %v", node.host)
 		return nil, err
 	}
 	tempBson, err := result.DecodeBytes()
 	if err != nil {
-		log.Logvf(log.Error, false,  "Encountered error decoding serverStatus: %v\n", err)
+		log.Logvf(log.Error, false, "Encountered error decoding serverStatus: %v\n", err)
 		return nil, fmt.Errorf("Error decoding serverStatus: %v\n", err)
 	}
 	err = bson.Unmarshal(tempBson, &stat)
 	if err != nil {
-		log.Logvf(log.Error, false,  "Encountered error reading serverStatus: %v\n", err)
+		log.Logvf(log.Error, false, "Encountered error reading serverStatus: %v\n", err)
 		return nil, fmt.Errorf("Error reading serverStatus: %v\n", err)
 	}
 	// The flattened version is required by some lookup functions
@@ -347,11 +347,11 @@ func (node *NodeMonitor) Poll(discover chan string, checkShards bool) (*status.S
 func (node *NodeMonitor) Watch(sleep time.Duration, discover chan string, cluster ClusterMonitor) {
 	var cycle uint64
 	for ticker := time.Tick(sleep); ; <-ticker {
-		log.Logvf(log.Trace, false,  "polling server: %v", node.host)
+		log.Logvf(log.Trace, false, "polling server: %v", node.host)
 		stat, err := node.Poll(discover, cycle%10 == 0)
 
 		if stat != nil {
-			log.Logvf(log.Trace, false,  "successfully got statline from host: %v", node.host)
+			log.Logvf(log.Trace, false, "successfully got statline from host: %v", node.host)
 		}
 		var nodeError *status.NodeError
 		if err != nil {
@@ -387,7 +387,7 @@ func (mstat *MongoStat) AddNewNode(fullhost string) error {
 			return nil
 		}
 	}
-	log.Logvf(log.Trace, false,  "adding new host to monitoring: %v", fullhost)
+	log.Logvf(log.Trace, false, "adding new host to monitoring: %v", fullhost)
 	// Create a new node monitor for this host
 	node, err := NewNodeMonitor(*mstat.Options, fullhost)
 	if err != nil {
@@ -407,7 +407,7 @@ func (mstat *MongoStat) Run() error {
 				newHost := <-mstat.Discovered
 				err := mstat.AddNewNode(newHost)
 				if err != nil {
-					log.Logvf(log.Error, false,  "can't add discovered node %v: %v", newHost, err)
+					log.Logvf(log.Error, false, "can't add discovered node %v: %v", newHost, err)
 				}
 			}
 		}()

--- a/mongotop/main/mongotop.go
+++ b/mongotop/main/mongotop.go
@@ -28,8 +28,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongotop.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Always, "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Always, util.ShortUsage("mongotop"))
+		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false,  util.ShortUsage("mongotop"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -50,16 +50,16 @@ func main() {
 	opts.URI.LogUnsupportedOptions()
 
 	if opts.RowCount < 0 {
-		log.Logvf(log.Always, "invalid value for --rowcount: %v", opts.RowCount)
+		log.Logvf(log.Error, false,  "invalid value for --rowcount: %v", opts.RowCount)
 		os.Exit(util.ExitFailure)
 	}
 
 	if opts.Auth.Username != "" && opts.Auth.Source == "" && !opts.Auth.RequiresExternalDB() {
 		if opts.URI != nil && opts.URI.ConnectionString != "" {
-			log.Logvf(log.Always, "authSource is required when authenticating against a non $external database")
+			log.Logvf(log.Error, false, "authSource is required when authenticating against a non $external database")
 			os.Exit(util.ExitFailure)
 		}
-		log.Logvf(log.Always, "--authenticationDatabase is required when authenticating against a non $external database")
+		log.Logvf(log.Error, false, "--authenticationDatabase is required when authenticating against a non $external database")
 		os.Exit(util.ExitFailure)
 	}
 
@@ -70,18 +70,18 @@ func main() {
 	// create a session provider to connect to the db
 	sessionProvider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		log.Logvf(log.Always, "error connecting to host: %v", err)
+		log.Logvf(log.Error, false, "error connecting to host: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 
 	// fail fast if connecting to a mongos
 	isMongos, err := sessionProvider.IsMongos()
 	if err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 	if isMongos {
-		log.Logvf(log.Always, "cannot run mongotop against a mongos")
+		log.Logvf(log.Error, false,  "cannot run mongotop against a mongos")
 		os.Exit(util.ExitFailure)
 	}
 
@@ -95,7 +95,7 @@ func main() {
 
 	// kick it off
 	if err := top.Run(); err != nil {
-		log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Error, false,  "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongotop/main/mongotop.go
+++ b/mongotop/main/mongotop.go
@@ -28,8 +28,8 @@ func main() {
 	// initialize command-line opts
 	opts, err := mongotop.ParseOptions(os.Args[1:], VersionStr, GitCommit)
 	if err != nil {
-		log.Logvf(log.Error, false,  "error parsing command line options: %s", err.Error())
-		log.Logvf(log.Info, false,  util.ShortUsage("mongotop"))
+		log.Logvf(log.Error, false, "error parsing command line options: %s", err.Error())
+		log.Logvf(log.Info, false, util.ShortUsage("mongotop"))
 		os.Exit(util.ExitFailure)
 	}
 
@@ -50,7 +50,7 @@ func main() {
 	opts.URI.LogUnsupportedOptions()
 
 	if opts.RowCount < 0 {
-		log.Logvf(log.Error, false,  "invalid value for --rowcount: %v", opts.RowCount)
+		log.Logvf(log.Error, false, "invalid value for --rowcount: %v", opts.RowCount)
 		os.Exit(util.ExitFailure)
 	}
 
@@ -77,11 +77,11 @@ func main() {
 	// fail fast if connecting to a mongos
 	isMongos, err := sessionProvider.IsMongos()
 	if err != nil {
-		log.Logvf(log.Error, false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 	if isMongos {
-		log.Logvf(log.Error, false,  "cannot run mongotop against a mongos")
+		log.Logvf(log.Error, false, "cannot run mongotop against a mongos")
 		os.Exit(util.ExitFailure)
 	}
 
@@ -95,7 +95,7 @@ func main() {
 
 	// kick it off
 	if err := top.Run(); err != nil {
-		log.Logvf(log.Error, false,  "Failed: %v", err)
+		log.Logvf(log.Error, false, "Failed: %v", err)
 		os.Exit(util.ExitFailure)
 	}
 }

--- a/mongotop/mongotop.go
+++ b/mongotop/mongotop.go
@@ -120,14 +120,14 @@ func (mt *MongoTop) Run() error {
 				return err
 			}
 
-			log.Logvf(log.Always, "Error: %v\n", err)
+			log.Logvf(log.Error, false,  "Error: %v\n", err)
 			time.Sleep(mt.Sleeptime)
 		}
 
 		// if this is the first time and the connection is successful, print
 		// the connection message
 		if !hasData && !mt.OutputOptions.Json {
-			log.Logvf(log.Always, "connected to: %v\n", util.SanitizeURI(mt.Options.URI.ConnectionString))
+			log.Logvf(log.Info,  false, "connected to: %v\n", util.SanitizeURI(mt.Options.URI.ConnectionString))
 		}
 
 		hasData = true

--- a/mongotop/mongotop.go
+++ b/mongotop/mongotop.go
@@ -120,14 +120,14 @@ func (mt *MongoTop) Run() error {
 				return err
 			}
 
-			log.Logvf(log.Error, false,  "Error: %v\n", err)
+			log.Logvf(log.Error, false, "Error: %v\n", err)
 			time.Sleep(mt.Sleeptime)
 		}
 
 		// if this is the first time and the connection is successful, print
 		// the connection message
 		if !hasData && !mt.OutputOptions.Json {
-			log.Logvf(log.Info,  false, "connected to: %v\n", util.SanitizeURI(mt.Options.URI.ConnectionString))
+			log.Logvf(log.Info, false, "connected to: %v\n", util.SanitizeURI(mt.Options.URI.ConnectionString))
 		}
 
 		hasData = true

--- a/vendor/github.com/mongodb/mongo-tools-common/archive/demultiplexer.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/archive/demultiplexer.go
@@ -72,10 +72,10 @@ func (demux *Demultiplexer) Run() error {
 	parser := Parser{In: demux.In}
 	err := parser.ReadAllBlocks(demux)
 	if len(demux.outs) > 0 {
-		log.Logvf(log.Always, "demux finishing when there are still outs (%v)", len(demux.outs))
+		log.Logvf(log.Info, false, "demux finishing when there are still outs (%v)", len(demux.outs))
 	}
 
-	log.Logvf(log.DebugLow, "demux finishing (err:%v)", err)
+	log.Logvf(log.Trace, false, "demux finishing (err:%v)", err)
 	return err
 }
 
@@ -116,7 +116,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 	if err != nil {
 		return newWrappedError("header bson doesn't unmarshal as a collection header", err)
 	}
-	log.Logvf(log.DebugHigh, "demux namespaceHeader: %v", colHeader)
+	log.Logvf(log.Trace, false, "demux namespaceHeader: %v", colHeader)
 	if colHeader.Collection == "" {
 		return newError("collection header is missing a Collection")
 	}
@@ -158,12 +158,12 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 					colHeader.CRC,
 				)
 			}
-			log.Logvf(log.DebugHigh,
-				"demux checksum for namespace %v is correct (%v), %v bytes",
+			log.Logvf(log.Trace,
+				false, "demux checksum for namespace %v is correct (%v), %v bytes",
 				demux.currentNamespace, crc, length)
 		} else {
-			log.Logvf(log.DebugHigh,
-				"demux checksum for namespace %v was not calculated.",
+			log.Logvf(log.Trace,
+				false, "demux checksum for namespace %v was not calculated.",
 				demux.currentNamespace)
 		}
 		delete(demux.outs, demux.currentNamespace)
@@ -177,7 +177,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 
 // End is part of the ParserConsumer interface and receives the end of archive notification.
 func (demux *Demultiplexer) End() error {
-	log.Logvf(log.DebugHigh, "demux End")
+	log.Logvf(log.Trace, false, "demux End")
 	var err error
 	if len(demux.outs) != 0 {
 		openNss := []string{}
@@ -227,7 +227,7 @@ func (demux *Demultiplexer) Open(ns string, out DemuxOut) {
 	// or while the demutiplexer is inside of the NamespaceChan NamespaceErrorChan conversation
 	// I think that we don't need to lock outs, but I suspect that if the implementation changes
 	// we may need to lock when outs is accessed
-	log.Logvf(log.DebugHigh, "demux Open")
+	log.Logvf(log.Trace, false, "demux Open")
 	if demux.outs == nil {
 		demux.outs = make(map[string]DemuxOut)
 		demux.lengths = make(map[string]int64)

--- a/vendor/github.com/mongodb/mongo-tools-common/archive/multiplexer.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/archive/multiplexer.go
@@ -74,7 +74,7 @@ func (mux *Multiplexer) Run() {
 		EOF := !notEOF
 		if index == 0 { //Control index
 			if EOF {
-				log.Logvf(log.DebugLow, "Mux finish")
+				log.Logvf(log.Trace, false, "Mux finish")
 				mux.Out.Close()
 				if completionErr != nil {
 					mux.Completed <- completionErr
@@ -91,7 +91,7 @@ func (mux *Multiplexer) Run() {
 				mux.Completed <- fmt.Errorf("non MuxIn received on Control chan") // one for the MuxIn.Open
 				return
 			}
-			log.Logvf(log.DebugLow, "Mux open namespace %v", muxIn.Intent.Namespace())
+			log.Logvf(log.Trace, false, "Mux open namespace %v", muxIn.Intent.Namespace())
 			mux.selectCases = append(mux.selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectRecv,
 				Chan: reflect.ValueOf(muxIn.writeChan),
@@ -114,7 +114,7 @@ func (mux *Multiplexer) Run() {
 					mux.Out = &nopCloseNopWriter{}
 					completionErr = err
 				}
-				log.Logvf(log.DebugLow, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
+				log.Logvf(log.Trace, false, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
 				mux.currentNamespace = ""
 				mux.selectCases = append(mux.selectCases[:index], mux.selectCases[index+1:]...)
 				mux.ins = append(mux.ins[:index], mux.ins[index+1:]...)
@@ -249,7 +249,7 @@ func (muxIn *MuxIn) Pos() int64 {
 // formatEOF to occur.
 func (muxIn *MuxIn) Close() error {
 	// the mux side of this gets closed in the mux when it gets an eof on the read
-	log.Logvf(log.DebugHigh, "MuxIn close %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, false, "MuxIn close %v", muxIn.Intent.Namespace())
 	if bufferWrites {
 		muxIn.writeChan <- muxIn.buf
 		length := <-muxIn.writeLenChan
@@ -270,7 +270,7 @@ func (muxIn *MuxIn) Close() error {
 // Open is implemented in Mux.open, but in short, it creates chans and a select case
 // and adds the SelectCase and the MuxIn in to the Multiplexer.
 func (muxIn *MuxIn) Open() error {
-	log.Logvf(log.DebugHigh, "MuxIn open %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, false, "MuxIn open %v", muxIn.Intent.Namespace())
 	muxIn.writeChan = make(chan []byte)
 	muxIn.writeLenChan = make(chan int)
 	muxIn.writeCloseFinishedChan = make(chan struct{})

--- a/vendor/github.com/mongodb/mongo-tools-common/archive/prelude.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/archive/prelude.go
@@ -135,7 +135,7 @@ func (prelude *Prelude) AddMetadata(cm *CollectionMetadata) {
 		prelude.DBS = append(prelude.DBS, cm.Database)
 	}
 	prelude.NamespaceMetadatasByDB[cm.Database] = append(prelude.NamespaceMetadatasByDB[cm.Database], cm)
-	log.Logvf(log.Info, "archive prelude %v.%v", cm.Database, cm.Collection)
+	log.Logvf(log.Debug, false, "archive prelude %v.%v", cm.Database, cm.Collection)
 }
 
 // Write writes the archive header.

--- a/vendor/github.com/mongodb/mongo-tools-common/bsonutil/indexes.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/bsonutil/indexes.go
@@ -125,7 +125,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexKey)
-		log.Logvf(log.Always, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
+		log.Logvf(log.Info, false, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
 			originalJSONString, newJSONString, ns)
 	}
 }
@@ -146,7 +146,7 @@ func ConvertLegacyIndexOptions(indexOptions bson.M) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Always, "convertLegacyIndexes: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, false, "convertLegacyIndexes: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }
@@ -169,7 +169,7 @@ func ConvertLegacyIndexOptionsFromOp(indexOptions *bson.D) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Always, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, false, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }

--- a/vendor/github.com/mongodb/mongo-tools-common/db/db.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/db.go
@@ -478,10 +478,10 @@ func FilterError(stopOnError bool, err error) error {
 		// Just log the error but don't propagate it.
 		if bwe, ok := err.(mongo.BulkWriteException); ok {
 			for _, be := range bwe.WriteErrors {
-				log.Logvf(log.Always, continueThroughErrorFormat, be.Message)
+				log.Logvf(log.Error, false, continueThroughErrorFormat, be.Message)
 			}
 		} else {
-			log.Logvf(log.Always, continueThroughErrorFormat, err)
+			log.Logvf(log.Error, false, continueThroughErrorFormat, err)
 		}
 		return nil
 	}
@@ -508,7 +508,7 @@ func CanIgnoreError(err error) bool {
 		}
 
 		if mongoErr.WriteConcernError != nil {
-			log.Logvf(log.Always, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
+			log.Logvf(log.Error, false, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
 			return false
 		}
 		return true

--- a/vendor/github.com/mongodb/mongo-tools-common/db/namespaces.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/namespaces.go
@@ -44,7 +44,7 @@ func (ci *CollectionInfo) GetUUID() string {
 				return hex.EncodeToString(x.Data)
 			}
 		default:
-			log.Logvf(log.DebugHigh, "unknown UUID BSON type '%T'", v)
+			log.Logvf(log.Trace, false, "unknown UUID BSON type '%T'", v)
 		}
 	}
 	return ""

--- a/vendor/github.com/mongodb/mongo-tools-common/db/write_concern.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/db/write_concern.go
@@ -34,7 +34,7 @@ func NewMongoWriteConcern(writeConcern string, cs *connstring.ConnString) (wc *w
 	// Log whatever write concern was generated
 	defer func() {
 		if wc != nil {
-			log.Logvf(log.Info, "using write concern: %v", wc)
+			log.Logvf(log.Debug, false, "using write concern: %v", wc)
 		}
 	}()
 

--- a/vendor/github.com/mongodb/mongo-tools-common/intents/intent.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/intents/intent.go
@@ -298,7 +298,7 @@ func (mgr *Manager) putNormalIntentWithNamespace(ns string, intent *Intent) {
 // Put inserts an intent into the manager with the same source namespace as
 // its destinations.
 func (mgr *Manager) Put(intent *Intent) {
-	log.Logvf(log.DebugLow, "enqueued collection '%v'", intent.Namespace())
+	log.Logvf(log.Trace, false, "enqueued collection '%v'", intent.Namespace())
 	mgr.PutWithNamespace(intent.Namespace(), intent)
 }
 
@@ -467,13 +467,13 @@ func (mgr *Manager) AuthVersion() *Intent {
 func (mgr *Manager) Finalize(pType PriorityType) {
 	switch pType {
 	case Legacy:
-		log.Logv(log.DebugHigh, "finalizing intent manager with legacy prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with legacy prioritizer")
 		mgr.prioritizer = newLegacyPrioritizer(mgr.intentsByDiscoveryOrder)
 	case LongestTaskFirst:
-		log.Logv(log.DebugHigh, "finalizing intent manager with longest task first prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with longest task first prioritizer")
 		mgr.prioritizer = newLongestTaskFirstPrioritizer(mgr.intentsByDiscoveryOrder)
 	case MultiDatabaseLTF:
-		log.Logv(log.DebugHigh, "finalizing intent manager with multi-database longest task first prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with multi-database longest task first prioritizer")
 		mgr.prioritizer = newMultiDatabaseLTFPrioritizer(mgr.intentsByDiscoveryOrder)
 	default:
 		panic("cannot initialize IntentPrioritizer with unknown type")

--- a/vendor/github.com/mongodb/mongo-tools-common/json/scanner.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/json/scanner.go
@@ -650,7 +650,7 @@ func quoteChar(c int) string {
 	}
 
 	// use quoted string with different quotation marks
-	s := strconv.Quote(string(c))
+	s := strconv.Quote(string(rune(c)))
 	return "'" + s[1:len(s)-1] + "'"
 }
 

--- a/vendor/github.com/mongodb/mongo-tools-common/log/tool_logger.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/log/tool_logger.go
@@ -18,17 +18,17 @@ import (
 // Tool Logger verbosity constants
 const (
 	Error = iota
-	Warn
-	Info
 	Debug
 	Trace
+	Warn
+	Info
 )
 
 const (
 	ToolTimeFormat = "2006-01-02T15:04:05.000-0700"
 )
 
-var errAbbreviations = []string{"ERR", "WRN", "INF", "DEB", "TRC"}
+var errAbbreviations = []string{"ERR", "DEB", "TRC", "WRN", "INF"}
 
 //// Tool Logger Definition
 
@@ -70,7 +70,11 @@ func (tl *ToolLogger) Logvf(minVerb int, printLogType bool, format string, a ...
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
 
-	if minVerb <= tl.verbosity {
+	logLevel := minVerb
+	if minVerb == Error || minVerb == Info || minVerb == Warn {
+		logLevel = 0
+	}
+	if logLevel <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
 		if printLogType {
@@ -86,7 +90,11 @@ func (tl *ToolLogger) Logv(minVerb int, printLogType bool, msg string) {
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
 
-	if minVerb <= tl.verbosity {
+	logLevel := minVerb
+	if minVerb == Error || minVerb == Info || minVerb == Warn {
+		logLevel = 0
+	}
+	if logLevel <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
 		if printLogType {

--- a/vendor/github.com/mongodb/mongo-tools-common/options/options.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/options/options.go
@@ -240,7 +240,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 		} else if val == "" {
 			opts.VLevel = opts.VLevel + 1 // Increment for every occurrence of flag
 		} else {
-			log.Logvf(log.Always, "Invalid verbosity value given")
+			log.Logvf(log.Error, false, "Invalid verbosity value given")
 			os.Exit(-1)
 		}
 	}
@@ -287,7 +287,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 	if opts.MaxProcs <= 0 {
 		opts.MaxProcs = runtime.NumCPU()
 	}
-	log.Logvf(log.Info, "Setting num cpus to %v", opts.MaxProcs)
+	log.Logvf(log.Debug, false, "Setting num cpus to %v", opts.MaxProcs)
 	runtime.GOMAXPROCS(opts.MaxProcs)
 	return opts
 }
@@ -392,7 +392,7 @@ func (opts *ToolOptions) EnabledToolOptions() EnabledOptions {
 // The unknown options are determined by the driver.
 func (uri *URI) LogUnsupportedOptions() {
 	for key := range uri.ConnString.UnknownOptions {
-		log.Logvf(log.Always, unknownOptionsWarningFormat, key)
+		log.Logvf(log.Warn, false, unknownOptionsWarningFormat, key)
 	}
 }
 
@@ -432,7 +432,7 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 	}
 
 	if opts.SSLAllowInvalidCert || opts.SSLAllowInvalidHost {
-		log.Logvf(log.Always, deprecationWarningSSLAllow)
+		log.Logvf(log.Warn, false, deprecationWarningSSLAllow)
 	}
 
 	if opts.parsePositionalArgsAsURI {

--- a/vendor/github.com/mongodb/mongo-tools-common/password/password.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/password/password.go
@@ -32,11 +32,11 @@ func Prompt() (string, error) {
 	var pass string
 	var err error
 	if IsTerminal() {
-		log.Logv(log.DebugLow, "standard input is a terminal; reading password from terminal")
+		log.Logv(log.Trace, false, "standard input is a terminal; reading password from terminal")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassInteractively()
 	} else {
-		log.Logv(log.Always, "reading password from standard input")
+		log.Logv(log.Info, false, "reading password from standard input")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassNonInteractively(os.Stdin)
 	}

--- a/vendor/github.com/mongodb/mongo-tools-common/set_goenv.sh
+++ b/vendor/github.com/mongodb/mongo-tools-common/set_goenv.sh
@@ -11,11 +11,14 @@ set_goenv() {
     UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
     case $UNAME_S in
         CYGWIN*)
-            PREF_GOROOT="c:/golang/go1.11"
-            PREF_PATH="/cygdrive/c/golang/go1.11/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
+            PREF_GOROOT="c:/golang/go1.15"
+            PREF_PATH="/cygdrive/c/golang/go1.15/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
+            if [[ $GOCACHE != C:* ]]; then
+                export GOCACHE="C:$GOCACHE"
+            fi
         ;;
         *)
-            PREF_GOROOT="/opt/golang/go1.11"
+            PREF_GOROOT="/opt/golang/go1.15"
             # XXX might not need mongodbtoolchain anymore
             PREF_PATH="$PREF_GOROOT/bin:/opt/mongodbtoolchain/v3/bin/:$PATH"
         ;;

--- a/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
+++ b/vendor/github.com/mongodb/mongo-tools-common/signals/signals.go
@@ -37,7 +37,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	noopChan := make(chan os.Signal)
 	signal.Notify(noopChan, syscall.SIGPIPE)
 
-	log.Logv(log.DebugLow, "will listen for SIGTERM, SIGINT, and SIGKILL")
+	log.Logv(log.Trace, false, "will listen for SIGTERM, SIGINT, and SIGKILL")
 	sigChan := make(chan os.Signal, 2)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
 	defer signal.Stop(sigChan)
@@ -45,7 +45,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 		select {
 		case sig := <-sigChan:
 			// first signal use finalizer to terminate cleanly
-			log.Logvf(log.Always, "signal '%s' received; attempting to shut down", sig)
+			log.Logvf(log.Info, false, "signal '%s' received; attempting to shut down", sig)
 			finalizer()
 		case <-finishedChan:
 			return
@@ -54,7 +54,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	select {
 	case sig := <-sigChan:
 		// second signal exits immediately
-		log.Logvf(log.Always, "signal '%s' received; forcefully terminating", sig)
+		log.Logvf(log.Info, false, "signal '%s' received; forcefully terminating", sig)
 		os.Exit(util.ExitFailure)
 	case <-finishedChan:
 		return


### PR DESCRIPTION
Since we shouldn't introduce changes to logging output in minor releases, I've created a new parameter for `func (tl *ToolLogger) Logvf` and `func (tl *ToolLogger) Logv` called `printLogType` to toggle the changes to logging output. When enabled, the log type will be printed; for now, `printLogType: false` for every tools log. I've created [TOOLS-2742](https://jira.mongodb.org/browse/TOOLS-2742) to remove this parameter and automatically print the log type in the next major release.

Changes to the log types:
- `log.Always` -> `log.Error` or `log.Info` or `log.Warn`
- `log.Info` -> `log.Debug`
- `log.DebugLow` and `log.DebugHigh` -> `log.Trace`