### PR TITLE
TOOLS-2747 Get task lists from current build/version only

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1118,6 +1118,7 @@ pre:
           GOROOT=""; set_goenv
           export EVG_IS_PATCH='${is_patch}'
           export EVG_BUILD_ID='${build_id}'
+          export EVG_VERSION='${version_id}'
           export EVG_VARIANT='${build_variant}'
           if [ '${_platform}' != '' ]; then
             export EVG_VARIANT='${_platform}'

--- a/release/env/env.go
+++ b/release/env/env.go
@@ -38,3 +38,9 @@ func EvgBuildID() (string, error) {
 func EvgVariant() (string, error) {
 	return mustGet("EVG_VARIANT")
 }
+
+// EvgVersionID returns the current evergreen version,
+// based on the value of an env variable set by the evg project file.
+func EvgVersionID() (string, error) {
+	return mustGet("EVG_VERSION")
+}

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -99,24 +99,6 @@ func GetArtifactsForTask(id string) ([]Artifact, error) {
 	return task.Artifacts, nil
 }
 
-// GetTasksForRevision gets all the evergreen tasks associated with a
-// git revision. This also includes tasks from patches that were based
-// on the provided revision.
-func GetTasksForRevision(rev string) ([]Task, error) {
-	res, err := get("/projects/mongo-tools/revisions/" + rev + "/tasks?limit=100000")
-	if err != nil {
-		return nil, err
-	}
-
-	tasks := []Task{}
-	bodyDecoder := json.NewDecoder(res.Body)
-	err = bodyDecoder.Decode(&tasks)
-	if err != nil {
-		return nil, err
-	}
-	return tasks, nil
-}
-
 // GetTasksForVersion gets all the evergreen tasks associated with a version.
 func GetTasksForVersion(version string) ([]Task, error) {
 	res, err := get("/versions/" + version)

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -26,6 +26,16 @@ type Task struct {
 	DisplayName string `json:"display_name"`
 }
 
+type BuildDetail struct {
+	BuildVariant string `json:"build_variant"`
+	BuildID      string `json:"build_id"`
+}
+
+// We only decode build_variants_status since that's all we care about
+type EvgVersion struct {
+	BuildVariantStatus []BuildDetail `json:"build_variants_status"`
+}
+
 // IsPatch indicates whether the task is part of a patchbuild (as
 // opposed to a task from the waterfall).
 func (t Task) IsPatch() bool {
@@ -94,6 +104,47 @@ func GetArtifactsForTask(id string) ([]Artifact, error) {
 // on the provided revision.
 func GetTasksForRevision(rev string) ([]Task, error) {
 	res, err := get("/projects/mongo-tools/revisions/" + rev + "/tasks?limit=100000")
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := []Task{}
+	bodyDecoder := json.NewDecoder(res.Body)
+	err = bodyDecoder.Decode(&tasks)
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+// GetTasksForVersion gets all the evergreen tasks associated with a version.
+func GetTasksForVersion(version string) ([]Task, error) {
+	res, err := get("/versions/" + version)
+	if err != nil {
+		return nil, err
+	}
+
+	var evgVersion EvgVersion
+	bodyDecoder := json.NewDecoder(res.Body)
+	err = bodyDecoder.Decode(evgVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := []Task{}
+	for _, buildDetail := range evgVersion.BuildVariantStatus {
+		buildTasks, err := GetTasksForBuild(buildDetail.BuildID)
+		if err != nil {
+			return nil, err
+		}
+		append(tasks, buildTasks...)
+	}
+	return tasks, nil
+}
+
+// GetTasksForBuild gets all the evergreen tasks associated with a build.
+func GetTasksForBuild(build string) ([]Task, error) {
+	res, err := get("/builds/" + build + "/tasks?limit=100000")
 	if err != nil {
 		return nil, err
 	}

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -119,7 +119,7 @@ func GetTasksForVersion(version string) ([]Task, error) {
 		if err != nil {
 			return nil, err
 		}
-		append(tasks, buildTasks...)
+		tasks = append(tasks, buildTasks...)
 	}
 	return tasks, nil
 }

--- a/release/release.go
+++ b/release/release.go
@@ -883,7 +883,8 @@ func uploadReleaseJSON(v version.Version) {
 		return
 	}
 
-	tasks, err := evergreen.GetTasksForRevision(v.Commit)
+	versionID := EvgVersionID()
+	tasks, err := evergreen.GetTasksForVersion(versionID)
 	check(err, "get evergreen tasks")
 
 	signTasks := []evergreen.Task{}
@@ -991,16 +992,13 @@ func uploadRelease(v version.Version) {
 	pf, err := platform.GetFromEnv()
 	check(err, "get platform")
 
-	tasks, err := evergreen.GetTasksForRevision(v.Commit)
+	buildID := EvgBuildID()
+	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
 	signTasks := []evergreen.Task{}
 	for _, task := range tasks {
 		if task.IsPatch() || task.DisplayName != "sign" {
-			continue
-		}
-
-		if pf.Variant() != task.Variant {
 			continue
 		}
 
@@ -1092,16 +1090,13 @@ func linuxRelease(v version.Version) {
 		return
 	}
 
-	tasks, err := evergreen.GetTasksForRevision(v.Commit)
+	buildID := EvgBuildID()
+	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
 	distTasks := []evergreen.Task{}
 	for _, task := range tasks {
 		if task.IsPatch() || task.DisplayName != "dist" {
-			continue
-		}
-
-		if pf.Variant() != task.Variant {
 			continue
 		}
 

--- a/release/release.go
+++ b/release/release.go
@@ -883,7 +883,7 @@ func uploadReleaseJSON(v version.Version) {
 		return
 	}
 
-	versionID := EvgVersionID()
+	versionID := version.EvgVersionID()
 	tasks, err := evergreen.GetTasksForVersion(versionID)
 	check(err, "get evergreen tasks")
 
@@ -992,7 +992,7 @@ func uploadRelease(v version.Version) {
 	pf, err := platform.GetFromEnv()
 	check(err, "get platform")
 
-	buildID := EvgBuildID()
+	buildID := version.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
@@ -1090,7 +1090,7 @@ func linuxRelease(v version.Version) {
 		return
 	}
 
-	buildID := EvgBuildID()
+	buildID := version.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 

--- a/release/release.go
+++ b/release/release.go
@@ -883,7 +883,7 @@ func uploadReleaseJSON(v version.Version) {
 		return
 	}
 
-	versionID := evergreen.EvgVersionID()
+	versionID := env.EvgVersionID()
 	tasks, err := evergreen.GetTasksForVersion(versionID)
 	check(err, "get evergreen tasks")
 
@@ -992,7 +992,7 @@ func uploadRelease(v version.Version) {
 	pf, err := platform.GetFromEnv()
 	check(err, "get platform")
 
-	buildID := evergreen.EvgBuildID()
+	buildID := env.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
@@ -1090,7 +1090,7 @@ func linuxRelease(v version.Version) {
 		return
 	}
 
-	buildID := evergreen.EvgBuildID()
+	buildID := env.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 

--- a/release/release.go
+++ b/release/release.go
@@ -883,7 +883,7 @@ func uploadReleaseJSON(v version.Version) {
 		return
 	}
 
-	versionID := version.EvgVersionID()
+	versionID := evergreen.EvgVersionID()
 	tasks, err := evergreen.GetTasksForVersion(versionID)
 	check(err, "get evergreen tasks")
 
@@ -992,7 +992,7 @@ func uploadRelease(v version.Version) {
 	pf, err := platform.GetFromEnv()
 	check(err, "get platform")
 
-	buildID := version.EvgBuildID()
+	buildID := evergreen.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
@@ -1090,7 +1090,7 @@ func linuxRelease(v version.Version) {
 		return
 	}
 
-	buildID := version.EvgBuildID()
+	buildID := evergreen.EvgBuildID()
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 

--- a/release/release.go
+++ b/release/release.go
@@ -883,7 +883,8 @@ func uploadReleaseJSON(v version.Version) {
 		return
 	}
 
-	versionID := env.EvgVersionID()
+	versionID, err := env.EvgVersionID()
+	check(err, "get evergreen version ID")
 	tasks, err := evergreen.GetTasksForVersion(versionID)
 	check(err, "get evergreen tasks")
 
@@ -992,7 +993,8 @@ func uploadRelease(v version.Version) {
 	pf, err := platform.GetFromEnv()
 	check(err, "get platform")
 
-	buildID := env.EvgBuildID()
+	buildID, err := env.EvgBuildID()
+	check(err, "get evergreen build ID")
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
@@ -1090,7 +1092,8 @@ func linuxRelease(v version.Version) {
 		return
 	}
 
-	buildID := env.EvgBuildID()
+	buildID, err := env.EvgBuildID()
+	check(err, "get evergreen build ID")
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 


### PR DESCRIPTION
We needed to retrieve a single sign or dist task to push the releases. But GetTasksForRevision would get the tasks for both the commit and the git tag. This will PR ensure that we only get the tasks for the git tag.