### PR TITLE
TOOLS-2687 Support a release feed with all historical releases

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -973,6 +973,14 @@ functions:
         content_type: application/json
         bucket: mciuploads
         permissions: public-read
+  
+  "generate full JSON feed":
+    - command: shell.exec
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        script: |
+          ${_set_shell_env}
+          go run release/release.go generate-full-json
 
   "upload release packages to linux repos":
     - command: shell.exec
@@ -1280,6 +1288,12 @@ tasks:
     - func: "fetch source"
     - command: expansions.update
     - func: "upload release json feed to s3"
+
+- name: generate-full-json
+  commands:
+    - func: "fetch source"
+    - command: expansions.update
+    - func: "generate full JSON feed"
 
 - name: integration-3.4
   commands:
@@ -2012,6 +2026,14 @@ buildvariants:
   - amazon1-2018-test
   tasks:
   - name: release-json
+
+
+- name: full-json
+  display_name: 'Generate Full JSON'
+  run_on:
+  - amazon1-2018-large
+  tasks:
+  - name: generate-full-json
 
 #######################################
 #     Amazon x86_64 Buildvariants     #

--- a/release/aws/aws.go
+++ b/release/aws/aws.go
@@ -44,6 +44,8 @@ func initializeClient() error {
 	return nil
 }
 
+// GetClient returns the global AWS client.
+// It initializes the AWS client if it hasn't already been initialized.
 func GetClient() (*AWS, error) {
 	if awsClient == nil {
 		err := initializeClient()
@@ -54,6 +56,8 @@ func GetClient() (*AWS, error) {
 	return awsClient, nil
 }
 
+// UploadFile will upload a file from the filesystem to the bucket and
+// path specified. The uploaded file keeps its filename.
 func (a *AWS) UploadFile(bucket, objPath, filename string) error {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -63,6 +67,7 @@ func (a *AWS) UploadFile(bucket, objPath, filename string) error {
 	return a.UploadBytes(bucket, objPath, filename, file)
 }
 
+// UploadBytes uploads data from a reader to the bucket, path, and filename specified.
 func (a *AWS) UploadBytes(bucket, objPath, filename string, reader io.Reader) error {
 	key := path.Join(objPath, filename)
 
@@ -80,6 +85,7 @@ func (a *AWS) UploadBytes(bucket, objPath, filename string, reader io.Reader) er
 	return nil
 }
 
+// DownloadFile downloads filename from bucket and
 func (a *AWS) DownloadFile(bucket, filename string) ([]byte, error) {
 	downloader := s3manager.NewDownloader(a.session)
 
@@ -98,6 +104,9 @@ func (a *AWS) DownloadFile(bucket, filename string) ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// GenerateFullReleaseFeedFromObjects will download all release artifacts from
+// the tools s3 bucket, caluclate their md5, sha1, and sha256 digests, and create
+// a download.JSONFeed object representing every artifact for every tools version.
 func (a *AWS) GenerateFullReleaseFeedFromObjects() (*download.JSONFeed, error) {
 	svc := s3.New(a.session)
 	downloader := s3manager.NewDownloader(a.session)

--- a/release/aws/aws.go
+++ b/release/aws/aws.go
@@ -1,13 +1,23 @@
 package aws
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"hash"
+	"io"
+	"log"
 	"os"
 	"path"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/mongodb/mongo-tools/release/download"
 )
 
 var awsClient *AWS
@@ -45,22 +55,196 @@ func GetClient() (*AWS, error) {
 }
 
 func (a *AWS) UploadFile(bucket, objPath, filename string) error {
-	key := path.Join(objPath, filename)
 	file, err := os.Open(filename)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
 
+	return a.UploadBytes(bucket, objPath, filename, file)
+}
+
+func (a *AWS) UploadBytes(bucket, objPath, filename string, reader io.Reader) error {
+	key := path.Join(objPath, filename)
+
 	uploader := s3manager.NewUploader(a.session)
-	_, err = uploader.Upload(&s3manager.UploadInput{
+	_, err := uploader.Upload(&s3manager.UploadInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 		ACL:    aws.String("public-read"),
-		Body:   file,
+		Body:   reader,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to upload: %w", err)
 	}
 
 	return nil
+}
+
+func (a *AWS) DownloadFile(bucket, filename string) ([]byte, error) {
+	downloader := s3manager.NewDownloader(a.session)
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(filename),
+	}
+
+	buff := &aws.WriteAtBuffer{}
+
+	_, err := downloader.Download(buff, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return buff.Bytes(), nil
+}
+
+func (a *AWS) GenerateFullReleaseFeedFromObjects() (*download.JSONFeed, error) {
+	svc := s3.New(a.session)
+	downloader := s3manager.NewDownloader(a.session)
+	// It is vital that we set the downloader Concurrency to 1 so that
+	// HashWriterAt can safely convert WriteAt calls to Write calls.
+	// This is necessary because hash.Hash is a Writer, but not a WriterAt.
+	downloader.Concurrency = 1
+
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String("downloads.mongodb.org"),
+		Prefix: aws.String("tools/db/"),
+	}
+
+	feed := &download.JSONFeed{}
+
+	handlePage := func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+		for _, obj := range page.Contents {
+			fmt.Printf("\nWorking on object: %v\n", *obj.Key)
+
+			artifactMetadata := extractArtifactMetadata(feed, obj)
+			if artifactMetadata == nil {
+				fmt.Printf("Could not match regex for filename, skipping...\n")
+				continue
+			}
+
+			fmt.Printf("platform: %v, arch: %v, version: %v, ext: %v\n",
+				artifactMetadata.Platform,
+				artifactMetadata.Arch,
+				artifactMetadata.Version,
+				artifactMetadata.Ext)
+
+			hashes := downloadAndGenerateHashes(downloader, *obj.Key)
+
+			addDownloadToFeed(feed, artifactMetadata, hashes)
+		}
+
+		return *page.IsTruncated
+	}
+
+	err := svc.ListObjectsV2Pages(input, handlePage)
+	if err != nil {
+		return nil, err
+	}
+
+	feed.Sort()
+
+	return feed, nil
+}
+
+func newHashWriterAt() HashWriterAt {
+	md5HashWriter := md5.New()
+	sha1HashWriter := sha1.New()
+	sha256HashWriter := sha256.New()
+
+	return HashWriterAt{
+		MD5:    md5HashWriter,
+		SHA1:   sha1HashWriter,
+		SHA256: sha256HashWriter,
+		w:      io.MultiWriter(sha256HashWriter, sha1HashWriter, md5HashWriter),
+	}
+}
+
+// HashWriterAt is used to calculate md5, sha1, and sha256 hashes in parallel.
+// w is a MulitWriter that writes to all the Hash interfaces.
+type HashWriterAt struct {
+	MD5    hash.Hash
+	SHA1   hash.Hash
+	SHA256 hash.Hash
+	w      io.Writer
+}
+
+// WriteAt fakes the io.WriterAt interface because s3manager.Downloarder.Download()
+// expects an io.WriterAt. Since we set the concurrency of the downloader to 1,
+// we can safely convert WriteAt calls to Write calls by ignoring the offset.
+func (fw HashWriterAt) WriteAt(p []byte, offset int64) (n int, err error) {
+	return fw.w.Write(p)
+}
+
+// ArtifactMetadata is a container to easily pass around some metadata extracted
+// from s3 object filenames.
+type ArtifactMetadata struct {
+	Name     string
+	Version  string
+	Platform string
+	Arch     string
+	Ext      string
+}
+
+func extractArtifactMetadata(feed *download.JSONFeed, obj *s3.Object) *ArtifactMetadata {
+	name := *obj.Key
+
+	artifactParts := regexp.MustCompile(`^tools\/db\/mongodb-database-tools-(.*)-(.*)-([0-9]+\.[0-9]+\.[0-9]+-?.*)\.(zip|tgz|deb|rpm|msi)$`)
+	parts := artifactParts.FindStringSubmatch(name)
+
+	if parts == nil {
+		return nil
+	}
+
+	return &ArtifactMetadata{
+		Name:     name,
+		Platform: parts[1],
+		Arch:     parts[2],
+		Version:  parts[3],
+		Ext:      parts[4],
+	}
+}
+
+// downloadAndGenerateHashes will exit if the download fails
+func downloadAndGenerateHashes(downloader *s3manager.Downloader, name string) HashWriterAt {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String("downloads.mongodb.org"),
+		Key:    aws.String(name),
+	}
+	hashWriter := newHashWriterAt()
+
+	_, err := downloader.Download(hashWriter, input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return hashWriter
+}
+
+func addDownloadToFeed(feed *download.JSONFeed, am *ArtifactMetadata, hashes HashWriterAt) {
+	md5Hash := hex.EncodeToString(hashes.MD5.Sum(nil))
+	sha1Hash := hex.EncodeToString(hashes.SHA1.Sum(nil))
+	sha256Hash := hex.EncodeToString(hashes.SHA256.Sum(nil))
+
+	fmt.Printf("MD5: %v\nSHA1: %v\nSHA256: %v\n", md5Hash, sha1Hash, sha256Hash)
+
+	dl := feed.FindOrCreateDownload(am.Version, am.Platform, am.Arch)
+
+	if am.Ext == "zip" || am.Ext == "tgz" {
+		dl.Archive = download.ToolsArchive{
+			URL:    fmt.Sprintf("https://fastdl.mongodb.org/%s", am.Name),
+			Md5:    md5Hash,
+			Sha1:   sha1Hash,
+			Sha256: sha256Hash,
+		}
+	} else {
+		dl.Package = &download.ToolsPackage{
+			URL:    fmt.Sprintf("https://fastdl.mongodb.org/%s", am.Name),
+			Md5:    md5Hash,
+			Sha1:   sha1Hash,
+			Sha256: sha256Hash,
+		}
+	}
+
+	fmt.Printf("Added %s info to feed\n", am.Name)
 }

--- a/release/download/download.go
+++ b/release/download/download.go
@@ -1,5 +1,12 @@
 package download
 
+import (
+	"log"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
 // JSONFeed represents the structure of the JSON
 // document consumed by the MongoDB downloads center.
 // An abbreviated version of the document might look like:
@@ -30,12 +37,12 @@ package download
 //   ]
 // }
 type JSONFeed struct {
-	Versions []ToolsVersion `json:"versions"`
+	Versions []*ToolsVersion `json:"versions"`
 }
 
 type ToolsVersion struct {
-	Version   string          `json:"version"`
-	Downloads []ToolsDownload `json:"downloads"`
+	Version   string           `json:"version"`
+	Downloads []*ToolsDownload `json:"downloads"`
 }
 
 type ToolsDownload struct {
@@ -53,4 +60,82 @@ type ToolsArtifact struct {
 	Md5    string `json:"md5"`
 	Sha1   string `json:"sha1"`
 	Sha256 string `json:"sha256"`
+}
+
+func (f *JSONFeed) findOrCreateVersion(version string) *ToolsVersion {
+	for _, v := range f.Versions {
+		if v.Version == version {
+			return v
+		}
+	}
+
+	v := &ToolsVersion{Version: version}
+	f.Versions = append(f.Versions, v)
+	return v
+}
+
+func (f *JSONFeed) FindOrCreateDownload(version, platform, arch string) *ToolsDownload {
+	v := f.findOrCreateVersion(version)
+
+	for _, dl := range v.Downloads {
+		if dl.Name == platform && dl.Arch == arch {
+			return dl
+		}
+	}
+
+	dl := &ToolsDownload{
+		Name: platform,
+		Arch: arch,
+	}
+	v.Downloads = append(v.Downloads, dl)
+	return dl
+}
+
+func (f *JSONFeed) Sort() {
+	for _, v := range f.Versions {
+		sort.Slice(v.Downloads, func(i, j int) bool {
+			if v.Downloads[i].Name == v.Downloads[j].Name {
+				return v.Downloads[i].Arch < v.Downloads[j].Arch
+			}
+			return v.Downloads[i].Name < v.Downloads[j].Name
+		})
+	}
+	sort.Slice(f.Versions, func(i, j int) bool {
+		return compareVersions(f.Versions[i].Version, f.Versions[j].Version)
+	})
+}
+
+func compareVersions(v1, v2 string) bool {
+	versionParts := regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9]+)-?(.*)$`)
+	v1Parts := versionParts.FindStringSubmatch(v1)[1:]
+	v2Parts := versionParts.FindStringSubmatch(v2)[1:]
+
+	for i := range v1Parts {
+		if v1Parts[i] != v2Parts[i] {
+			if i == 3 {
+				if v1Parts[i] == "" {
+					return false
+				}
+				if v2Parts[i] == "" {
+					return true
+				}
+				return v1Parts[i] < v2Parts[i]
+			}
+
+			v1Part, err := strconv.Atoi(v1Parts[i])
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			v2Part, err := strconv.Atoi(v2Parts[i])
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			return v1Part < v2Part
+		}
+	}
+
+	// They're the same so just return true
+	return true
 }

--- a/release/download/download.go
+++ b/release/download/download.go
@@ -74,6 +74,9 @@ func (f *JSONFeed) findOrCreateVersion(version string) *ToolsVersion {
 	return v
 }
 
+// FindOrCreateDownload will find the ToolsDownload in f that matches the version, platform, and arch.
+// If the ToolsDownload  does not exist, it will be added to f. If the parent ToolsVersion doesn't exist
+// either, that will also be created.
 func (f *JSONFeed) FindOrCreateDownload(version, platform, arch string) *ToolsDownload {
 	v := f.findOrCreateVersion(version)
 
@@ -91,6 +94,8 @@ func (f *JSONFeed) FindOrCreateDownload(version, platform, arch string) *ToolsDo
 	return dl
 }
 
+// Sort will sort f.Versions by semver version. Version preference for the suffix of pre-release
+// versions are alphabetical. Within each version, Downloads are sorted by OS name and architecture.
 func (f *JSONFeed) Sort() {
 	for _, v := range f.Versions {
 		sort.Slice(v.Downloads, func(i, j int) bool {
@@ -105,6 +110,7 @@ func (f *JSONFeed) Sort() {
 	})
 }
 
+// compareVersions compares two semver version strings. version suffixes are compared alphabetiaclly.
 func compareVersions(v1, v2 string) bool {
 	versionParts := regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9]+)-?(.*)$`)
 	v1Parts := versionParts.FindStringSubmatch(v1)[1:]

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -31,7 +31,8 @@ type BuildDetail struct {
 	BuildID      string `json:"build_id"`
 }
 
-// We only decode build_variants_status since that's all we care about
+// EvgVersion is a container for the /versions/<id> endpoint response.
+// We only decode build_variants_status since that's all we care about.
 type EvgVersion struct {
 	BuildVariantStatus []BuildDetail `json:"build_variants_status"`
 }

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -140,47 +140,6 @@ func GetTasksForBuild(build string) ([]Task, error) {
 	return tasks, nil
 }
 
-// GetTasksForVersion gets all the evergreen tasks associated with a version.
-func GetTasksForVersion(version string) ([]Task, error) {
-	res, err := get("/versions/" + version)
-	if err != nil {
-		return nil, err
-	}
-
-	var evgVersion EvgVersion
-	bodyDecoder := json.NewDecoder(res.Body)
-	err = bodyDecoder.Decode(evgVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	tasks := []Task{}
-	for _, buildDetail := range evgVersion.BuildVariantStatus {
-		buildTasks, err := GetTasksForBuild(buildDetail.BuildID)
-		if err != nil {
-			return nil, err
-		}
-		append(tasks, buildTasks...)
-	}
-	return tasks, nil
-}
-
-// GetTasksForBuild gets all the evergreen tasks associated with a build.
-func GetTasksForBuild(build string) ([]Task, error) {
-	res, err := get("/builds/" + build + "/tasks?limit=100000")
-	if err != nil {
-		return nil, err
-	}
-
-	tasks := []Task{}
-	bodyDecoder := json.NewDecoder(res.Body)
-	err = bodyDecoder.Decode(&tasks)
-	if err != nil {
-		return nil, err
-	}
-	return tasks, nil
-}
-
 func get(relPath string) (*http.Response, error) {
 	uri, err := url.Parse(EVG_API_BASE_URI + relPath)
 	if err != nil {

--- a/release/evergreen/evergreen.go
+++ b/release/evergreen/evergreen.go
@@ -140,6 +140,47 @@ func GetTasksForBuild(build string) ([]Task, error) {
 	return tasks, nil
 }
 
+// GetTasksForVersion gets all the evergreen tasks associated with a version.
+func GetTasksForVersion(version string) ([]Task, error) {
+	res, err := get("/versions/" + version)
+	if err != nil {
+		return nil, err
+	}
+
+	var evgVersion EvgVersion
+	bodyDecoder := json.NewDecoder(res.Body)
+	err = bodyDecoder.Decode(evgVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := []Task{}
+	for _, buildDetail := range evgVersion.BuildVariantStatus {
+		buildTasks, err := GetTasksForBuild(buildDetail.BuildID)
+		if err != nil {
+			return nil, err
+		}
+		append(tasks, buildTasks...)
+	}
+	return tasks, nil
+}
+
+// GetTasksForBuild gets all the evergreen tasks associated with a build.
+func GetTasksForBuild(build string) ([]Task, error) {
+	res, err := get("/builds/" + build + "/tasks?limit=100000")
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := []Task{}
+	bodyDecoder := json.NewDecoder(res.Body)
+	err = bodyDecoder.Decode(&tasks)
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
 func get(relPath string) (*http.Response, error) {
 	uri, err := url.Parse(EVG_API_BASE_URI + relPath)
 	if err != nil {

--- a/release/release.go
+++ b/release/release.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"crypto/md5"
 	"crypto/sha1"
@@ -92,6 +93,8 @@ func main() {
 		uploadRelease(v)
 	case "upload-json":
 		uploadReleaseJSON(v)
+	case "generate-full-json":
+		generateFullReleaseJSON()
 	case "linux-release":
 		linuxRelease(v)
 	default:
@@ -872,6 +875,16 @@ func buildZip() {
 	}
 }
 
+func generateFullReleaseJSON() {
+	awsClient, err := aws.GetClient()
+	check(err, "get aws client")
+
+	feed, err := awsClient.GenerateFullReleaseFeedFromObjects()
+	check(err, "generate full release feed from s3 objects")
+
+	uploadFeedFile("full.json", feed, awsClient)
+}
+
 func uploadReleaseJSON(v version.Version) {
 	if env.EvgIsPatch() {
 		log.Println("current build is a patch; not uploading release JSON feed")
@@ -910,7 +923,7 @@ func uploadReleaseJSON(v version.Version) {
 	check(err, "get aws client")
 
 	// Accumulate all downloaded artifacts from sign tasks for JSON feed.
-	var dls []download.ToolsDownload
+	var dls []*download.ToolsDownload
 
 	for _, task := range signTasks {
 		pf, ok := platform.GetByVariant(task.Variant)
@@ -962,26 +975,39 @@ func uploadReleaseJSON(v version.Version) {
 			}
 		}
 
-		dls = append(dls, dl)
+		dls = append(dls, &dl)
 	}
 
-	// We only have one version for now, so we can just append one
-	// ToolsVersion to the JSON feed and upload immediately.
+	// Download the current full.json
+	buff, err := awsClient.DownloadFile("downloads.mongodb.org", "tools/db/full.json")
+	check(err, "download full.json")
+
+	var fullFeed download.JSONFeed
+
+	err = json.Unmarshal(buff, &fullFeed)
+	check(err, "unmarshal full.json into download.JSONFeed")
+
+	// Append the new version to full.json and upload
+	fullFeed.Versions = append(fullFeed.Versions, &download.ToolsVersion{Version: v.StringWithoutPre(), Downloads: dls})
+	uploadFeedFile("full.json", &fullFeed, awsClient)
+
+	// Upload only the most recent version to release.json
 	var feed download.JSONFeed
-	feed.Versions = append(feed.Versions, download.ToolsVersion{Version: v.StringWithoutPre(), Downloads: dls})
+	feed.Versions = append(feed.Versions, &download.ToolsVersion{Version: v.StringWithoutPre(), Downloads: dls})
 
-	feedFilename := "release.json"
-	feedFile, err := os.Create(feedFilename)
-	check(err, "create release.json")
-	defer feedFile.Close()
+	uploadFeedFile("release.json", &feed, awsClient)
+}
 
-	jsonEncoder := json.NewEncoder(feedFile)
+func uploadFeedFile(filename string, feed *download.JSONFeed, awsClient *aws.AWS) {
+	var feedBuffer bytes.Buffer
+
+	jsonEncoder := json.NewEncoder(&feedBuffer)
 	jsonEncoder.SetIndent("", "  ")
-	err = jsonEncoder.Encode(feed)
+	err := jsonEncoder.Encode(*feed)
 	check(err, "encode json feed")
 
-	log.Printf("uploading download feed to https://s3.amazonaws.com/downloads.mongodb.org/tools/db/%s\n", feedFilename)
-	awsClient.UploadFile("downloads.mongodb.org", "/tools/db", feedFilename)
+	log.Printf("uploading download feed to https://s3.amazonaws.com/downloads.mongodb.org/tools/db/%s\n", filename)
+	awsClient.UploadBytes("downloads.mongodb.org", "/tools/db", filename, &feedBuffer)
 }
 
 func uploadRelease(v version.Version) {


### PR DESCRIPTION
In order to create a download page for all historical releases of the tools, we need a JSON feed that contains information on all release artifacts. The current `release.json` only contains the latest release.

This PR adds logic for generating a release feed that contains all releases. The feed is uploaded it to the S3 bucket as `full.json`. Generating the feed from scratch will download each artifact and calculate the required hashes. New releases will update the `full.json` without having to calculate the hashes for previous versions.

See the generated `full.json` here: https://fastdl.mongodb.org/tools/db/full.json