### PR TITLE
TOOLS-2767: Windows 64 dist task fails

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -562,7 +562,7 @@ func buildMSI() {
 		return
 	}
 
-	// The msi msiUpgradeCode must be updated when the minor version changes.
+	// The msi msiUpgradeCode must be updated when the major version changes.
 	msiUpgradeCode := "effc2f80-8f82-413f-a3ba-4a96f3d2883a"
 
 	binariesPath := filepath.Join("..", "bin")

--- a/release/release.go
+++ b/release/release.go
@@ -637,7 +637,7 @@ func buildMSI() {
 
 	for _, name := range binaries {
 		err := os.Link(
-			filepath.Join(binariesPath, name),
+			filepath.Join(binariesPath, name+".exe"),
 			name+".exe",
 		)
 		check(err, "link binary files into "+msiBuildDir)


### PR DESCRIPTION
The macos 10.14 sign task is currently failing because Patrick changed his Apple password and forgot to change the corresponding evergreen variable -- should be fixed soon!