### PR TITLE
TOOLS-2774: Raise default import/restore buffer size from 1000 to 100,000

### DIFF
--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -255,9 +255,8 @@ func (imp *MongoImport) validateSettings(args []string) error {
 	log.Logvf(log.DebugLow, "using %v decoding workers", imp.IngestOptions.NumDecodingWorkers)
 	log.Logvf(log.DebugLow, "using %v insert workers", imp.IngestOptions.NumInsertionWorkers)
 
-	// get the number of documents per batch
-	if imp.IngestOptions.BulkBufferSize <= 0 || imp.IngestOptions.BulkBufferSize > 1000 {
-		imp.IngestOptions.BulkBufferSize = 1000
+	if imp.IngestOptions.BulkBufferSize <= 0 || imp.IngestOptions.BulkBufferSize > 100000 {
+		imp.IngestOptions.BulkBufferSize = 100000
 	}
 
 	// ensure we have a valid string to use for the collection

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -1285,7 +1285,7 @@ func TestHiddenOptionsDefaults(t *testing.T) {
 			imp.ToolOptions.Collection = "col"
 			So(imp.validateSettings([]string{}), ShouldBeNil)
 			So(imp.IngestOptions.NumDecodingWorkers, ShouldEqual, runtime.NumCPU())
-			So(imp.IngestOptions.BulkBufferSize, ShouldEqual, 1000)
+			So(imp.IngestOptions.BulkBufferSize, ShouldEqual, 100000)
 		})
 	})
 }

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -101,7 +101,7 @@ type IngestOptions struct {
 	// Specifies the number of threads to use in processing data read from the input source
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
-	BulkBufferSize int `long:"batchSize" default:"1000" hidden:"true"`
+	BulkBufferSize int `long:"batchSize" default:"100000" hidden:"true"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -294,6 +294,10 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 		restore.OutputOptions.NumInsertionWorkers = 1
 	}
 
+	if restore.OutputOptions.BulkBufferSize <= 0 || restore.OutputOptions.BulkBufferSize > 100000 {
+		restore.OutputOptions.BulkBufferSize = 100000
+	}
+
 	if restore.OutputOptions.PreserveUUID {
 		if !restore.OutputOptions.Drop {
 			return fmt.Errorf("cannot specify --preserveUUID without --drop")

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -105,7 +105,7 @@ type OutputOptions struct {
 	PreserveUUID             bool   `long:"preserveUUID" description:"preserve original collection UUIDs (off by default, requires drop)"`
 	TempUsersColl            string `long:"tempUsersColl" default:"tempusers" hidden:"true"`
 	TempRolesColl            string `long:"tempRolesColl" default:"temproles" hidden:"true"`
-	BulkBufferSize           int    `long:"batchSize" default:"1000" hidden:"true"`
+	BulkBufferSize           int    `long:"batchSize" default:"100000" hidden:"true"`
 	FixDottedHashedIndexes   bool   `long:"fixDottedHashIndex" description:"when enabled, all the hashed indexes on dotted fields will be created as single field ascending indexes on the destination"`
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2774

This bumps up the `BulkBufferSize` to match what the server supports for versions 3.6+