### PR TITLE
TOOLS-2775: Disallow multi-file get with --local

### DIFF
--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -214,6 +214,10 @@ func (mf *MongoFiles) handleGet() (err error) {
 		return err
 	}
 
+	if len(files) > 1 && mf.StorageOptions.LocalFileName != "" {
+		return fmt.Errorf("cannot get multiple files with --local specified")
+	}
+
 	for _, file := range files {
 		if err = mf.writeGFSFileToLocal(file); err != nil {
 			return err


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2775

With two sample files in GridFS:
```
$ mongofiles --db testDB list
2021-01-07T14:38:21.865-0500	connected to: mongodb://localhost/
sample-file-1.txt	0
sample-file-2.txt	0
```

Before change:
```
$ mongofiles --db testDB get_regex "sample*" --local sample-file.txt
2021-01-07T14:47:57.620-0500	connected to: mongodb://localhost/
2021-01-07T14:47:57.625-0500	finished writing to sample-file.txt
2021-01-07T14:47:57.625-0500	finished writing to sample-file.txt
```
^ `sample-file.txt` gets written twice

After change:
```
$ mongofiles --db testDB get_regex "sample*" --local sample-file.txt
2021-01-07T14:55:56.891-0500	connected to: mongodb://localhost/
2021-01-07T14:55:56.891-0500	Failed: cannot get multiple files with --local specified
```

I don't think a test is that necessary here, but lmk if you think otherwise.