### PR TITLE
TOOLS-2800: Fix rpmbuild failing on amazon linux 1

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -391,9 +391,13 @@ func buildRPM() {
 
 	outputFile := mdt + "-" + rpmVersion + "-" + rpmRelease + "." + pf.Arch + ".rpm"
 	outputPath := filepath.Join(home, "rpmbuild", "RPMS", outputFile)
-	// create the .deb file.
+
+	// ensure that the _topdir macro used by rpmbuild references a writeable location
+	topdirDefine := "_topdir " + filepath.Join(home, "rpmbuild")
+
+	// create the .rpm file.
 	log.Printf("running: rpmbuild -bb %s\n", specFile)
-	out, err := run("rpmbuild", "-bb", specFile)
+	out, err := run("rpmbuild", "--define", topdirDefine, "-bb", specFile)
 	check(err, "rpmbuild\n"+out)
 	// Copy to top level directory so we can upload it.
 	check(copyFile(


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2800
Evergreen with variants that build rpm's: https://evergreen.mongodb.com/version/6019d3fc3627e0294b148ea6

This fixes the failing dist task on `amazon1-2018-test` albeit in a kind of ad hoc way. I spent some time looking into what was going on by comparing it with `amazon2-test` which works okay. I found some weird behavior, so I think this is the best we can do for the moment.

On the surface, the dist task was failing because `rpmbuild` was trying to create `/usr/src/rpm` which you'd need root permissions for. It got this directory from the `%{_topdir}` macro (I verified this with `rpm --eval "%{_topdir}"` and saw that it's `/usr/src/rpm`). That was strange given that every online doc says `%{_topdir}` should default to `%{getenv:HOME}/rpmbuild`, which is what it was on `amazon2`.

I looked for where macros are defined and found that they're in the `/usr/lib/rpm` directory.  This is where the two hosts (`amazon1` and `amazon2`) diverged:

On `amazon2` it's defined in one place:
```
$ grep -r "topdir" /usr/lib/rpm/
/usr/lib/rpm/macros:%_topdir           %{getenv:HOME}/rpmbuild
```

But on `amazon1` it's defined in two places, with the former probably overwriting the latter:
```
$ grep -r "topdir" /usr/lib/rpm/
/usr/lib/rpm/amazon/macros:%_topdir    %{_usrsrc}/rpm
...
/usr/lib/rpm/macros:%_topdir           %{getenv:HOME}/rpmbuild
```

There's also this difference:
```
$PATH for amazon2 includes:    /usr/lib/rpm/redhat/macros
$PATH for amazon1 includes:    /usr/lib/rpm/amazon/macros
```

So it seems like `amazon1` has an additional platform-specific macros file that defines `%{_topdir}` as `%{_usrsrc}/rpm`. That could be a side effect of unrelated changes by the build team, but I'm not really sure. Either way, creating a `~/.rpmmacros` file with `%{_topdir}` defined as `%{getenv:HOME}/rpmbuild` is enough to fix the issue for now.

Side note -- I was hoping to just put this line at the top of our `mongodb-database-tools.spec` file:
```
%define _topdir %{getenv:HOME}/rpmbuild
```
Yet that gets ignored on `amazon1`. But weirdly if `~/.rpmmacros` defines `%{_topdir}` first, then defining it in the spec file has an effect. And it always has an effect on `amazon2` regardless of whether `~/.rpmmacros` defines it or not...