### PR TITLE
TOOLS-704: Remove system.indexes collection dumping from mongodump

### DIFF
--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -334,11 +334,6 @@ func (dump *MongoDump) Dump() (err error) {
 		}
 	}
 
-	err = dump.DumpSystemIndexes()
-	if err != nil {
-		return fmt.Errorf("error dumping system indexes: %v", err)
-	}
-
 	if !dump.SkipUsersAndRoles {
 		if dump.ToolOptions.DB == "admin" || dump.ToolOptions.DB == "" {
 			err = dump.DumpUsersAndRoles()
@@ -820,18 +815,6 @@ func (dump *MongoDump) DumpUsersAndRoles() error {
 		}
 	}
 
-	return nil
-}
-
-// DumpSystemIndexes dumps all of the system.indexes
-func (dump *MongoDump) DumpSystemIndexes() error {
-	buffer := dump.getResettableOutputBuffer()
-	for _, dbName := range dump.manager.SystemIndexDBs() {
-		err := dump.DumpIntent(dump.manager.SystemIndexes(dbName), buffer)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -335,16 +335,14 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 			delete(intent.Options, "pipeline")
 		}
 		//Set the MetadataFile path.
-		if !intent.IsSystemIndexes() {
-			if dump.OutputOptions.Archive != "" {
-				intent.MetadataFile = &archive.MetadataFile{
-					Intent: intent,
-					Buffer: &bytes.Buffer{},
-				}
-			} else {
-				path := nameGz(dump.OutputOptions.Gzip, dump.outputPath(dbName, ci.Name)+".metadata.json")
-				intent.MetadataFile = &realMetadataFile{path: path, intent: intent}
+		if dump.OutputOptions.Archive != "" {
+			intent.MetadataFile = &archive.MetadataFile{
+				Intent: intent,
+				Buffer: &bytes.Buffer{},
 			}
+		} else {
+			path := nameGz(dump.OutputOptions.Gzip, dump.outputPath(dbName, ci.Name)+".metadata.json")
+			intent.MetadataFile = &realMetadataFile{path: path, intent: intent}
 		}
 	}
 


### PR DESCRIPTION
All of the tests passed after removing `system.indexes` dumping.