### PR TITLE
TOOLS-2805: Add mod tidy static analysis check for Go modules

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,8 +12,13 @@ import (
 var taskRegistry = task.NewRegistry(task.WithAutoNamespaces(true))
 
 func init() {
+	// Build
+	taskRegistry.Declare("build").Description("build the tools").OptionalArgs("tools").Do(buildscript.BuildTools)
+
+	// Static Analysis
 	taskRegistry.Declare("sa:modtidy").Description("runs go mod tidy").Do(buildscript.SAModTidy)
-	taskRegistry.Declare("build").Description("build the tools").DependsOn("sa:modtidy").OptionalArgs("tools").Do(buildscript.BuildTools)
+
+	// Testing
 	taskRegistry.Declare("test:unit").Description("runs unit tests").OptionalArgs("tools").Do(buildscript.TestUnit)
 	taskRegistry.Declare("test:integration").Description("runs integration tests").OptionalArgs("tools", "ssl", "auth", "kerberos", "topology").Do(buildscript.TestIntegration)
 	taskRegistry.Declare("test:kerberos").Description("runs kerberos tests").Do(buildscript.TestKerberos)

--- a/build.go
+++ b/build.go
@@ -12,7 +12,8 @@ import (
 var taskRegistry = task.NewRegistry(task.WithAutoNamespaces(true))
 
 func init() {
-	taskRegistry.Declare("build").Description("build the tools").OptionalArgs("tools").Do(buildscript.BuildTools)
+	taskRegistry.Declare("sa:modtidy").Description("runs go mod tidy").Do(buildscript.SAModTidy)
+	taskRegistry.Declare("build").Description("build the tools").DependsOn("sa:modtidy").OptionalArgs("tools").Do(buildscript.BuildTools)
 	taskRegistry.Declare("test:unit").Description("runs unit tests").OptionalArgs("tools").Do(buildscript.TestUnit)
 	taskRegistry.Declare("test:integration").Description("runs integration tests").OptionalArgs("tools", "ssl", "auth", "kerberos", "topology").Do(buildscript.TestIntegration)
 	taskRegistry.Declare("test:kerberos").Description("runs kerberos tests").Do(buildscript.TestKerberos)

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -2,10 +2,8 @@ package buildscript
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,45 +23,6 @@ var toolNames = []string{
 	"mongoimport", "mongoexport",
 	"mongostat", "mongotop",
 	"mongofiles",
-}
-
-// SAModTidy runs go mod tidy and ensure no changes were made.
-// Copied from mongohouse: https://github.com/10gen/mongohouse/blob/333308814f96a0909c8125f71af7748b263e3263/buildscript/sa.go#L72
-func SAModTidy(ctx *task.Context) error {
-	// Save original contents in case they get modified. When
-	// https://github.com/golang/go/issues/27005 is done, we
-	// shouldn't need this anymore.
-	origGoMod, err := ioutil.ReadFile("go.mod")
-	if err != nil {
-		return fmt.Errorf("error reading go.mod: %w", err)
-	}
-	origGoSum, err := ioutil.ReadFile("go.sum")
-	if err != nil {
-		return fmt.Errorf("error reading go.sum: %w", err)
-	}
-
-	err = sh.Run(ctx, "go", "mod", "tidy")
-	if err != nil {
-		return err
-	}
-
-	newGoMod, err := ioutil.ReadFile("go.mod")
-	if err != nil {
-		return fmt.Errorf("error reading go.mod: %w", err)
-	}
-	newGoSum, err := ioutil.ReadFile("go.sum")
-	if err != nil {
-		return fmt.Errorf("error reading go.sum: %w", err)
-	}
-
-	if !bytes.Equal(origGoMod, newGoMod) || !bytes.Equal(origGoSum, newGoSum) {
-		// Restore originals, ignoring errors since they need tidying anyway.
-		_ = ioutil.WriteFile("go.mod", origGoMod, 0600)
-		_ = ioutil.WriteFile("go.sum", origGoSum, 0600)
-		return errors.New("go.mod and/or go.sum needs changes: run `go mod tidy` and commit the changes")
-	}
-
-	return nil
 }
 
 // BuildTools is an Executor that builds the tools.

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -2,8 +2,10 @@ package buildscript
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,6 +25,45 @@ var toolNames = []string{
 	"mongoimport", "mongoexport",
 	"mongostat", "mongotop",
 	"mongofiles",
+}
+
+// SAModTidy runs go mod tidy and ensure no changes were made.
+// Copied from mongohouse: https://github.com/10gen/mongohouse/blob/333308814f96a0909c8125f71af7748b263e3263/buildscript/sa.go#L72
+func SAModTidy(ctx *task.Context) error {
+	// Save original contents in case they get modified. When
+	// https://github.com/golang/go/issues/27005 is done, we
+	// shouldn't need this anymore.
+	origGoMod, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		return fmt.Errorf("error reading go.mod: %w", err)
+	}
+	origGoSum, err := ioutil.ReadFile("go.sum")
+	if err != nil {
+		return fmt.Errorf("error reading go.sum: %w", err)
+	}
+
+	err = sh.Run(ctx, "go", "mod", "tidy")
+	if err != nil {
+		return err
+	}
+
+	newGoMod, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		return fmt.Errorf("error reading go.mod: %w", err)
+	}
+	newGoSum, err := ioutil.ReadFile("go.sum")
+	if err != nil {
+		return fmt.Errorf("error reading go.sum: %w", err)
+	}
+
+	if !bytes.Equal(origGoMod, newGoMod) || !bytes.Equal(origGoSum, newGoSum) {
+		// Restore originals, ignoring errors since they need tidying anyway.
+		_ = ioutil.WriteFile("go.mod", origGoMod, 0600)
+		_ = ioutil.WriteFile("go.sum", origGoSum, 0600)
+		return errors.New("go.mod and/or go.sum needs changes: run `go mod tidy` and commit the changes")
+	}
+
+	return nil
 }
 
 // BuildTools is an Executor that builds the tools.

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -1,0 +1,50 @@
+package buildscript
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/craiggwilson/goke/pkg/sh"
+	"github.com/craiggwilson/goke/task"
+)
+
+// SAModTidy runs go mod tidy and ensure no changes were made.
+// Copied from mongohouse: https://github.com/10gen/mongohouse/blob/333308814f96a0909c8125f71af7748b263e3263/buildscript/sa.go#L72
+func SAModTidy(ctx *task.Context) error {
+	// Save original contents in case they get modified. When
+	// https://github.com/golang/go/issues/27005 is done, we
+	// shouldn't need this anymore.
+	origGoMod, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		return fmt.Errorf("error reading go.mod: %w", err)
+	}
+	origGoSum, err := ioutil.ReadFile("go.sum")
+	if err != nil {
+		return fmt.Errorf("error reading go.sum: %w", err)
+	}
+
+	err = sh.Run(ctx, "go", "mod", "tidy")
+	if err != nil {
+		return err
+	}
+
+	newGoMod, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		return fmt.Errorf("error reading go.mod: %w", err)
+	}
+	newGoSum, err := ioutil.ReadFile("go.sum")
+	if err != nil {
+		return fmt.Errorf("error reading go.sum: %w", err)
+	}
+
+	if !bytes.Equal(origGoMod, newGoMod) || !bytes.Equal(origGoSum, newGoSum) {
+		// Restore originals, ignoring errors since they need tidying anyway.
+		_ = ioutil.WriteFile("go.mod", origGoMod, 0600)
+		_ = ioutil.WriteFile("go.sum", origGoSum, 0600)
+		return errors.New("go.mod and/or go.sum needs changes: run `go mod tidy` and commit the changes")
+	}
+
+	return nil
+}

--- a/common.yml
+++ b/common.yml
@@ -1319,6 +1319,13 @@ tasks:
       vars:
         test_path: "test/legacy42"
 
+- name: mod-tidy
+  commands:
+    - func: "fetch source"
+    - func: "run make target"
+      vars:
+        target: sa:modtidy
+
 - name: format-go
   commands:
     - func: "fetch source"
@@ -1552,6 +1559,7 @@ buildvariants:
   - name: format-go
   - name: lint-go
   - name: lint-js
+  - name: mod-tidy
   - name: vet
 
 #######################################


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2805

This adds mongohouse's `go mod tidy` check to the tools. Building should now look like:
```
$ ./make build

START  | sa:modtidy
       | exec: '/usr/local/bin/go mod tidy'
FINISH | sa:modtidy in 123.32094ms
START  | build
       | rm: bin/bsondump
       | exec: '/usr/local/bin/go run release/release.go get-version'
       | exec: '/usr/bin/git rev-parse HEAD'
       ...
```