### PR TITLE
TOOLS-2796 Fix mongotop_sharded.js test

### DIFF
--- a/test/qa-tests/jstests/top/mongotop_sharded.js
+++ b/test/qa-tests/jstests/top/mongotop_sharded.js
@@ -13,6 +13,7 @@ var testName = 'mongotop_sharded';
     jsTest.log('shell output: ' + shellOutput);
     shellOutput.split('\n').slice(1).forEach(function(line) {
       // check the displayed error message
+      jsTest.log('line: ' + line);
       assert.neq(line.match(expectedError), null, 'unexpected error message');
     });
   };

--- a/test/qa-tests/jstests/top/mongotop_sharded.js
+++ b/test/qa-tests/jstests/top/mongotop_sharded.js
@@ -8,14 +8,8 @@ var testName = 'mongotop_sharded';
 
   var expectedError = 'cannot run mongotop against a mongos';
   var verifyOutput = function(getOutput) {
+    jsTest.log('shell output: ' + getOutput);
     assert.strContains.soon(expectedError, getOutput, 'error message must appear at least once');
-    var shellOutput = getOutput();
-    jsTest.log('shell output: ' + shellOutput);
-    shellOutput.split('\n').slice(1).forEach(function(line) {
-      // check the displayed error message
-      jsTest.log('line: ' + line);
-      assert.neq(line.match(expectedError), null, 'unexpected error message');
-    });
   };
 
   var runTests = function(topology, passthrough) {


### PR DESCRIPTION
It looks like the test was checking that only the error message was printed. When we added some warning messages, they got printed too and the test started failing. The test now doesn't care if anything else is printed.