### PR TITLE
TOOLS-2584: Restoring single BSON file should use db set in URI

### DIFF
--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -426,7 +426,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				// holds the users for a database that was dumped with --dumpDbUsersAndRoles enabled).
 				// If these special files manage to be included in a dump directory during a full
 				// (multi-db) restore, we should ignore them.
-				if restore.NSOptions.DB == "" && strings.HasPrefix(collection, "$") {
+				if restore.ToolOptions.Namespace.DB == "" && strings.HasPrefix(collection, "$") {
 					log.Logvf(log.DebugLow, "not restoring special collection %v.%v", db, collection)
 					skip = true
 				}
@@ -644,7 +644,7 @@ func hasMetadataFiles(files []archive.DirLike) bool {
 func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 	// we know we have been given a non-directory, so we should handle it
 	// like a bson file and infer as much as we can
-	if restore.NSOptions.Collection == "" {
+	if restore.ToolOptions.Namespace.Collection == "" {
 		// if the user did not set -c, get the collection name from the bson file
 		newCollectionName, fileType, err := restore.getInfoFromFile(path)
 		if err != nil {
@@ -654,10 +654,10 @@ func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 		if fileType != BSONFileType {
 			return fmt.Errorf("file %v does not have .bson extension", path)
 		}
-		restore.NSOptions.Collection = newCollectionName
-		log.Logvf(log.DebugLow, "inferred collection '%v' from file", restore.NSOptions.Collection)
+		restore.ToolOptions.Namespace.Collection = newCollectionName
+		log.Logvf(log.DebugLow, "inferred collection '%v' from file", restore.ToolOptions.Namespace.Collection)
 	}
-	if restore.NSOptions.DB == "" {
+	if restore.ToolOptions.Namespace.DB == "" {
 		// if the user did not set -d, use the directory containing the target
 		// file as the db name (as it would be in a dump directory). If
 		// we cannot determine the directory name, use "test"
@@ -665,8 +665,8 @@ func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 		if dirForFile == "." || dirForFile == ".." {
 			dirForFile = "test"
 		}
-		restore.NSOptions.DB = dirForFile
-		log.Logvf(log.DebugLow, "inferred db '%v' from the file's directory", restore.NSOptions.DB)
+		restore.ToolOptions.Namespace.DB = dirForFile
+		log.Logvf(log.DebugLow, "inferred db '%v' from the file's directory", restore.ToolOptions.Namespace.DB)
 	}
 	return nil
 }

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -426,7 +426,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				// holds the users for a database that was dumped with --dumpDbUsersAndRoles enabled).
 				// If these special files manage to be included in a dump directory during a full
 				// (multi-db) restore, we should ignore them.
-				if restore.ToolOptions.Namespace.DB == "" && strings.HasPrefix(collection, "$") {
+				if restore.ToolOptions.Namespace != nil && restore.ToolOptions.Namespace.DB == "" && strings.HasPrefix(collection, "$") {
 					log.Logvf(log.DebugLow, "not restoring special collection %v.%v", db, collection)
 					skip = true
 				}

--- a/mongorestore/filepath_test.go
+++ b/mongorestore/filepath_test.go
@@ -321,8 +321,8 @@ func TestHandlingBSON(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("the proper DB and Coll should be inferred", func() {
-				So(mr.NSOptions.DB, ShouldEqual, "db1")
-				So(mr.NSOptions.Collection, ShouldEqual, "c2")
+				So(mr.ToolOptions.Namespace.DB, ShouldEqual, "db1")
+				So(mr.ToolOptions.Namespace.Collection, ShouldEqual, "c2")
 			})
 		})
 
@@ -331,27 +331,27 @@ func TestHandlingBSON(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("the proper DB and Coll should be inferred", func() {
-				So(mr.NSOptions.DB, ShouldEqual, "db1")
-				So(mr.NSOptions.Collection, ShouldEqual, longCollectionName)
+				So(mr.ToolOptions.Namespace.DB, ShouldEqual, "db1")
+				So(mr.ToolOptions.Namespace.Collection, ShouldEqual, longCollectionName)
 			})
 		})
 
 		Convey("but pre-existing settings should not be overwritten", func() {
-			mr.NSOptions.DB = "a"
+			mr.ToolOptions.Namespace.DB = "a"
 
 			Convey("either collection settings", func() {
-				mr.NSOptions.Collection = "b"
+				mr.ToolOptions.Namespace.Collection = "b"
 				err := mr.handleBSONInsteadOfDirectory("testdata/testdirs/db1/c1.bson")
 				So(err, ShouldBeNil)
-				So(mr.NSOptions.DB, ShouldEqual, "a")
-				So(mr.NSOptions.Collection, ShouldEqual, "b")
+				So(mr.ToolOptions.Namespace.DB, ShouldEqual, "a")
+				So(mr.ToolOptions.Namespace.Collection, ShouldEqual, "b")
 			})
 
 			Convey("or db settings", func() {
 				err := mr.handleBSONInsteadOfDirectory("testdata/testdirs/db1/c1.bson")
 				So(err, ShouldBeNil)
-				So(mr.NSOptions.DB, ShouldEqual, "a")
-				So(mr.NSOptions.Collection, ShouldEqual, "c1")
+				So(mr.ToolOptions.Namespace.DB, ShouldEqual, "a")
+				So(mr.ToolOptions.Namespace.Collection, ShouldEqual, "c1")
 			})
 		})
 	})

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -265,7 +265,7 @@ func (restore *MongoRestore) CreateCollection(intent *intents.Intent, options bs
 func (restore *MongoRestore) UpdateAutoIndexId(options bson.D) {
 	if restore.serverVersion.GTE(db.Version{4, 0, 0}) {
 		for i, elem := range options {
-			if elem.Key == "autoIndexId" && elem.Value == false && restore.NSOptions.DB != "local" {
+			if elem.Key == "autoIndexId" && elem.Value == false && restore.ToolOptions.Namespace.DB != "local" {
 				options[i].Value = true
 				log.Logvf(log.Always, "{autoIndexId: false} is not allowed in server versions >= 4.0. Changing to {autoIndexId: true}.")
 			}
@@ -500,7 +500,7 @@ func (restore *MongoRestore) GetDumpAuthVersion() (int, error) {
 			// If we are using --restoreDbUsersAndRoles, we cannot guarantee an
 			// $admin.system.version collection from a 2.6 server,
 			// so we can assume up to version 3.
-			log.Logvf(log.Always, "no system.version bson file found in '%v' database dump", restore.NSOptions.DB)
+			log.Logvf(log.Always, "no system.version bson file found in '%v' database dump", restore.ToolOptions.Namespace.DB)
 			log.Logv(log.Always, "warning: assuming users and roles collections are of auth version 3")
 			log.Logv(log.Always, "if users are from an earlier version of MongoDB, they may not restore properly")
 			return 3, nil
@@ -606,8 +606,8 @@ func (restore *MongoRestore) ShouldRestoreUsersAndRoles() bool {
 	// is doing a full restore), then we check if users or roles BSON files
 	// actually exist in the dump dir. If they do, return true.
 	if restore.InputOptions.RestoreDBUsersAndRoles ||
-		restore.NSOptions.DB == "" ||
-		restore.NSOptions.DB == "admin" {
+		restore.ToolOptions.Namespace.DB == "" ||
+		restore.ToolOptions.Namespace.DB == "admin" {
 		if restore.manager.Users() != nil || restore.manager.Roles() != nil {
 			return true
 		}

--- a/mongorestore/metadata_test.go
+++ b/mongorestore/metadata_test.go
@@ -137,9 +137,10 @@ func TestGetDumpAuthVersion(t *testing.T) {
 				InputOptions: &InputOptions{
 					RestoreDBUsersAndRoles: true,
 				},
-				ToolOptions: &commonOpts.ToolOptions{},
-				NSOptions: &NSOptions{
-					DB: "TestDB",
+				ToolOptions: &commonOpts.ToolOptions{
+					Namespace: &commonOpts.Namespace{
+						DB: "TestDB",
+					},
 				},
 			}
 

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -174,8 +174,8 @@ func TestMongorestore(t *testing.T) {
 			bsonFile, err := os.Open("testdata/testdirs/db1/c1.bson")
 			So(err, ShouldBeNil)
 
-			restore.NSOptions.Collection = "c1"
-			restore.NSOptions.DB = "db1"
+			restore.ToolOptions.Namespace.Collection = "c1"
+			restore.ToolOptions.Namespace.DB = "db1"
 			restore.InputReader = bsonFile
 			restore.TargetDirectory = "-"
 
@@ -395,8 +395,8 @@ func TestMongorestoreLongCollectionName(t *testing.T) {
 			longBsonFile, err := os.Open("testdata/longcollectionname/db1/" + longBsonName)
 			So(err, ShouldBeNil)
 
-			restore.NSOptions.Collection = longCollectionName
-			restore.NSOptions.DB = "db1"
+			restore.ToolOptions.Namespace.Collection = longCollectionName
+			restore.ToolOptions.Namespace.DB = "db1"
 			restore.InputReader = longBsonFile
 			restore.TargetDirectory = "-"
 			result := restore.Restore()

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -128,8 +128,6 @@ const (
 
 // NSOptions defines the set of options for configuring involved namespaces
 type NSOptions struct {
-	DB                         string   `short:"d" long:"db" value-name:"<database-name>" description:"database to use when restoring from a BSON file"`
-	Collection                 string   `short:"c" long:"collection" value-name:"<collection-name>" description:"collection to use when restoring from a BSON file"`
 	ExcludedCollections        []string `long:"excludeCollection" value-name:"<collection-name>" description:"DEPRECATED; collection to skip over during restore (may be specified multiple times to exclude additional collections)"`
 	ExcludedCollectionPrefixes []string `long:"excludeCollectionsWithPrefix" value-name:"<collection-prefix>" description:"DEPRECATED; collections to skip over during restore that have the given prefix (may be specified multiple times to exclude additional prefixes)"`
 	NSExclude                  []string `long:"nsExclude" value-name:"<namespace-pattern>" description:"exclude matching namespaces"`
@@ -166,12 +164,6 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 			"provide only one polling interval in seconds and only one MongoDB connection string. " +
 			"Connection strings must begin with mongodb:// or mongodb+srv:// schemes",
 		)
-	}
-
-	// Allow the db connector to fall back onto the current database when no
-	// auth database is given.
-	if opts.DB == "" {
-		opts.Namespace = &options.Namespace{DB: nsOpts.DB, Collection: nsOpts.Collection}
 	}
 
 	log.SetVerbosity(opts.Verbosity)

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -146,7 +146,7 @@ func (*NSOptions) Name() string {
 // ParseOptions reads the command line arguments and converts them into options used to configure a MongoRestore instance
 func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, error) {
 	opts := options.New("mongorestore", versionStr, gitCommit, Usage, true,
-		options.EnabledOptions{Auth: true, Connection: true, URI: true})
+		options.EnabledOptions{Auth: true, Connection: true, Namespace: true, URI: true})
 	nsOpts := &NSOptions{}
 	opts.AddOptions(nsOpts)
 
@@ -169,8 +169,10 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 	}
 
 	// Allow the db connector to fall back onto the current database when no
-	// auth database is given; the standard -d/-c options go into nsOpts now
-	opts.Namespace = &options.Namespace{DB: nsOpts.DB}
+	// auth database is given.
+	if opts.DB == "" {
+		opts.Namespace = &options.Namespace{DB: nsOpts.DB, Collection: nsOpts.Collection}
+	}
 
 	log.SetVerbosity(opts.Verbosity)
 

--- a/mongorestore/options_test.go
+++ b/mongorestore/options_test.go
@@ -60,6 +60,19 @@ func TestWriteConcernOptionParsing(t *testing.T) {
 	})
 }
 
+func TestURIParsing(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	Convey("Testing parsing from URI", t, func() {
+		args := []string{
+			"--uri", "mongodb://localhost:27017/test",
+		}
+		opts, err := ParseOptions(args, "", "")
+
+		So(err, ShouldBeNil)
+		So(opts.ToolOptions.DB, ShouldEqual, "test")
+	})
+}
+
 type PositionalArgumentTestCase struct {
 	InputArgs    []string
 	ExpectedOpts Options


### PR DESCRIPTION
I changed all usages of `NSOptions.{DB, Collection}` to `ToolOptions.Namespace.{DB, Collection}`, and added a test to `mongorestore/options_test.go`