### PR TITLE
TOOLS-2807: Add common integration and srv tests

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ func init() {
 	taskRegistry.Declare("test:unit").Description("runs all unit tests").OptionalArgs("pkgs").Do(buildscript.TestUnit)
 	taskRegistry.Declare("test:integration").Description("runs all integration tests").OptionalArgs("pkgs", "ssl", "auth", "kerberos", "topology").Do(buildscript.TestIntegration)
 	taskRegistry.Declare("test:kerberos").Description("runs all kerberos tests").Do(buildscript.TestKerberos)
-	taskRegistry.Declare("test:srv").Description("runs all kerberos tests").Do(buildscript.TestSRV)
+	taskRegistry.Declare("test:srv").Description("runs all srv tests").Do(buildscript.TestSRV)
 }
 
 func main() {

--- a/build.go
+++ b/build.go
@@ -22,6 +22,7 @@ func init() {
 	taskRegistry.Declare("test:unit").Description("runs all unit tests").OptionalArgs("pkgs").Do(buildscript.TestUnit)
 	taskRegistry.Declare("test:integration").Description("runs all integration tests").OptionalArgs("pkgs", "ssl", "auth", "kerberos", "topology").Do(buildscript.TestIntegration)
 	taskRegistry.Declare("test:kerberos").Description("runs all kerberos tests").Do(buildscript.TestKerberos)
+	taskRegistry.Declare("test:srv").Description("runs all kerberos tests").Do(buildscript.TestSRV)
 }
 
 func main() {

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -51,11 +51,11 @@ func TestKerberos(ctx *task.Context) error {
 
 // TestIntegration is an Executor that runs all integration tests for the provided packages.
 func TestIntegration(ctx *task.Context) error {
-	err := runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
-	if err != nil {
-		return err
-	}
+	return runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
+}
 
+// TestSRV is an Executor that runs the SRV connection string test for package `common`.
+func TestSRV(ctx *task.Context) error {
 	return runTests(ctx, []string{"common"}, testtype.SRVConnectionStringTestType)
 }
 

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -54,9 +54,9 @@ func TestIntegration(ctx *task.Context) error {
 	return runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
 }
 
-// TestSRV is an Executor that runs the SRV connection string test for package `common`.
+// TestSRV is an Executor that runs all SRV tests for the provided packages.
 func TestSRV(ctx *task.Context) error {
-	return runTests(ctx, []string{"common"}, testtype.SRVConnectionStringTestType)
+	return runTests(ctx, selectedPkgs(ctx), testtype.SRVConnectionStringTestType)
 }
 
 // buildToolBinary builds the tool with the specified name, putting

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -51,18 +51,12 @@ func TestKerberos(ctx *task.Context) error {
 
 // TestIntegration is an Executor that runs all integration tests for the provided packages.
 func TestIntegration(ctx *task.Context) error {
-	// TODO: Replace func body with following line in TOOLS-2807.
-	// return runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
-
-	// Don't run integration tests in /common yet.
-	pkgs := selectedPkgs(ctx)
-	for i := range pkgs {
-		if pkgs[i] == "common" {
-			pkgs = append(pkgs[:i], pkgs[i+1:]...)
-			break
-		}
+	err := runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
+	if err != nil {
+		return err
 	}
-	return runTests(ctx, pkgs, testtype.IntegrationTestType)
+
+	return runTests(ctx, []string{"common"}, testtype.SRVConnectionStringTestType)
 }
 
 // buildToolBinary builds the tool with the specified name, putting

--- a/common.yml
+++ b/common.yml
@@ -1059,7 +1059,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-3.4-mmapv1
   commands:
@@ -1077,7 +1077,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-3.6
   commands:
@@ -1093,7 +1093,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-3.6-mmapv1
   commands:
@@ -1111,7 +1111,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.0
   commands:
@@ -1127,7 +1127,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.0-auth
   commands:
@@ -1149,7 +1149,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true -auth=true
+        target: test:integration test:srv -ssl=true -auth=true
 
 - name: integration-4.0-cluster
   commands:
@@ -1166,7 +1166,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.0-mmapv1
   commands:
@@ -1184,7 +1184,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.2
   commands:
@@ -1200,7 +1200,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.2-auth
   commands:
@@ -1222,7 +1222,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true -auth=true
+        target: test:integration test:srv -ssl=true -auth=true
 
 - name: integration-4.4
   commands:
@@ -1242,7 +1242,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true
+        target: test:integration test:srv -ssl=true
 
 - name: integration-4.4-auth
   commands:
@@ -1270,7 +1270,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true -auth=true
+        target: test:integration test:srv -ssl=true -auth=true
 
 - name: integration-4.4-cluster
   commands:
@@ -1287,7 +1287,7 @@ tasks:
         target: build
     - func: "run make target"
       vars:
-        target: test:integration -ssl=true -topology=replSet
+        target: test:integration test:srv -ssl=true -topology=replSet
 
 - name: kerberos
   commands:

--- a/common.yml
+++ b/common.yml
@@ -939,6 +939,8 @@ pre:
           export TOOLS_TESTING_AUTH_USERNAME='${auth_username}'
           export TOOLS_TESTING_AUTH_PASSWORD='${auth_password}'
           export MONGODB_KERBEROS_PASSWORD='${kerberos_password}'
+          export ATLAS_URI=${atlas_srv_uri}
+          export TOOLS_TESTING_PKCS8_PASSWORD=${pkcs8_password}
           set -o xtrace
           set -o verbose
           set -o errexit


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2807

This enables integration tests for `common`, including one options test with test type `SRVConnectionStringTestType`.

I think there's already sufficient platform coverage in mongo-tools for integration tests and that we don't need to sift through mtc's setup, but I can take a closer look if you think otherwise.