### PR TITLE
TOOLS-2824: Add static analysis task that runs `evergreen validate`

### DIFF
--- a/build.go
+++ b/build.go
@@ -17,6 +17,7 @@ func init() {
 
 	// Static Analysis
 	taskRegistry.Declare("sa:modtidy").Description("runs go mod tidy").Do(buildscript.SAModTidy)
+	taskRegistry.Declare("sa:evgvalidate").Description("runs evergreen validate").Do(buildscript.SAEvergreenValidate)
 
 	// Testing
 	taskRegistry.Declare("test:unit").Description("runs all unit tests").OptionalArgs("pkgs").Do(buildscript.TestUnit)

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -57,7 +57,7 @@ func SAEvergreenValidate(ctx *task.Context) error {
 		return fmt.Errorf("error from `evergreen validate`: %s: %w", output, err)
 	}
 
-	// TODO: change this if-block in TOOLS-...
+	// TODO: change this if-block in TOOLS-2840.
 	// This check ignores any YAML warnings related to duplicate keys in YAML maps.
 	// See ticket for more details.
 	if strings.HasSuffix(output, "is valid with warnings") {

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/craiggwilson/goke/pkg/sh"
 	"github.com/craiggwilson/goke/task"
@@ -44,6 +45,29 @@ func SAModTidy(ctx *task.Context) error {
 		_ = ioutil.WriteFile("go.mod", origGoMod, 0600)
 		_ = ioutil.WriteFile("go.sum", origGoSum, 0600)
 		return errors.New("go.mod and/or go.sum needs changes: run `go mod tidy` and commit the changes")
+	}
+
+	return nil
+}
+
+// SAEvergreenValidate runs `evergreen validate` on common.yml and ensures the file is valid.
+func SAEvergreenValidate(ctx *task.Context) error {
+	output, err := sh.RunOutput(ctx, "evergreen", "validate", "--file", "common.yml")
+	if err != nil {
+		return fmt.Errorf("error from `evergreen validate`: %s: %w", output, err)
+	}
+
+	// TODO: change this if-block in TOOLS-...
+	// This check ignores any YAML warnings related to duplicate keys in YAML maps.
+	// See ticket for more details.
+	if strings.HasSuffix(output, "is valid with warnings") {
+		for _, line := range strings.Split(output, "\n") {
+			if !(strings.HasSuffix(line, "unmarshal errors:") ||
+				strings.HasSuffix(line, "already set in map") ||
+				strings.HasSuffix(line, "is valid with warnings")) {
+				return fmt.Errorf("error from `evergreen validate`: %s", output)
+			}
+		}
 	}
 
 	return nil

--- a/common.yml
+++ b/common.yml
@@ -7,9 +7,9 @@ command_type: system
 # run the same task in the previous revision if the current task fails
 stepback: true
 
-mongo_tools_variables:
+variables:
 
-## List of tests to run on each buildvariant
+  # List of tests to run on each buildvariant
   mongo_tools_task_lists:
     mac_task_list: &macos_tasks
       - name: dist
@@ -279,7 +279,7 @@ mongo_tools_variables:
       - name: native-cert-ssl-current
 
 
-## Common mongodb arguments
+  # Common mongodb arguments
   mongod_arguments:
     default: &mongod_default_startup_args
       mongod_args: ""
@@ -343,6 +343,7 @@ functions:
       working_dir: src/github.com/mongodb/mongo-tools
       script: |
         ${_set_shell_env}
+        PATH=$PATH:$HOME
         go run build.go -v ${target}
 
   "download mongod":
@@ -1441,6 +1442,13 @@ tasks:
       vars:
         target: sa:modtidy
 
+- name: evergreen-validate
+  commands:
+    - func: "fetch source"
+    - func: "run make target"
+      vars:
+        target: sa:evgvalidate
+
 - name: format-go
   commands:
     - func: "fetch source"
@@ -1675,6 +1683,7 @@ buildvariants:
   - name: lint-go
   - name: lint-js
   - name: mod-tidy
+  - name: evergreen-validate
   - name: vet
 
 #######################################


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2824

Evergreen patch with task: https://evergreen.mongodb.com/version/606f6d6cd6d80a5fbdd77f56

This adds a task for `evergreen validate` in the buildscript and updates our Static Analysis buildvariant with it. Also adding some sample output of different scenarios below.

Everything succeeds:
```
$ go run build.go -v sa:evgvalidate
START  | sa:evgvalidate
       | exec: '.../bin/evergreen validate --file common.yml'
FINISH | sa:evgvalidate in 971.621181ms
---------------
Completed in 971.889045ms
```

Breaking the syntax:
```
$ go run build.go -v sa:evgvalidate
START  | sa:evgvalidate
       | exec: '.../bin/evergreen validate --file common.yml'
FAIL   | sa:evgvalidate in 807.488006ms
       | error from `evergreen validate`: ERROR: load project error(s): error unmarshalling into parser project: yaml: line 282: did not find expected key
       | common.yml is an invalid configuration: exit status 1
task(s) [sa:evgvalidate] failed
exit status 2
```

Misspelling a distro name:
```
$ go run build.go -v sa:evgvalidate
START  | sa:evgvalidate
       | exec: '.../bin/evergreen validate --file common.yml'
FAIL   | sa:evgvalidate in 863.701372ms
       | error from `evergreen validate`: WARNING: yaml: unmarshal errors:
       |   line 302: key "mongod_port" already set in map
       |   line 294: key "mongod_port" already set in map
       |   line 305: key "mongod_port" already set in map
       | WARNING: buildvariant 'suse12' in project '' references a nonexistent distro 'susie12-sp5-small'.
       | common.yml is valid with warnings
task(s) [sa:evgvalidate] failed
exit status 2
```
^ for the last one, I'll make a comment below about `key "mongod_port" already set in map`