### PR TITLE
Add allow disk use option for mongoexport

### DIFF
--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -308,6 +308,10 @@ func (exp *MongoExport) getCursor() (*mongo.Cursor, error) {
 		findOpts.SetSort(sortD)
 	}
 
+	if exp.InputOpts != nil && exp.InputOpts.AllowDiskUse {
+		findOpts.SetAllowDiskUse(true)
+	}
+
 	query := bson.D{}
 	if exp.InputOpts != nil && exp.InputOpts.HasQuery() {
 		var err error

--- a/mongoexport/options.go
+++ b/mongoexport/options.go
@@ -69,6 +69,7 @@ type InputOptions struct {
 	Limit          int64  `long:"limit" value-name:"<count>" description:"limit the number of documents to export"`
 	Sort           string `long:"sort" value-name:"<json>" description:"sort order, as a JSON string, e.g. '{x:1}'"`
 	AssertExists   bool   `long:"assertExists" description:"if specified, export fails if the collection does not exist"`
+	AllowDiskUse   bool   `long:"allowDiskUse" description:"if specified, the server can write temporary data to disk while executing the find operation"`
 }
 
 // Name returns a human-readable group name for input options.


### PR DESCRIPTION
The memory usage is huge when exporting large collections or sorting on fields without index, so I've added the option to allow disk usage while exporting.