### PR TITLE
TOOLS-2849 fix resharding tests

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1801,9 +1801,10 @@ func TestFailDuringResharding(t *testing.T) {
 				case <-done:
 					return
 				default:
-					time.Sleep(2 * time.Second)
 					session.Database("config").CreateCollection(ctx, "reshardingOperations")
+					time.Sleep(1 * time.Second)
 					session.Database("config").Collection("reshardingOperations").Drop(ctx)
+					time.Sleep(1 * time.Second)
 				}
 			}()
 
@@ -1824,9 +1825,10 @@ func TestFailDuringResharding(t *testing.T) {
 				case <-done:
 					return
 				default:
-					time.Sleep(2 * time.Second)
 					session.Database("config").CreateCollection(ctx, "localReshardingOperations.donor")
+					time.Sleep(1 * time.Second)
 					session.Database("config").Collection("localReshardingOperations.donor").Drop(ctx)
+					time.Sleep(1 * time.Second)
 				}
 			}()
 
@@ -1847,9 +1849,10 @@ func TestFailDuringResharding(t *testing.T) {
 				case <-done:
 					return
 				default:
-					time.Sleep(2 * time.Second)
 					session.Database("config").CreateCollection(ctx, "localReshardingOperations.recipient")
+					time.Sleep(1 * time.Second)
 					session.Database("config").Collection("localReshardingOperations.recipient").Drop(ctx)
+					time.Sleep(1 * time.Second)
 				}
 			}()
 

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1740,16 +1740,26 @@ func TestTimeseriesCollections(t *testing.T) {
 func TestFailDuringResharding(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	if err != nil {
+		t.Errorf("could not get session provider: %v", err)
+	}
+
+	session, err := sessionProvider.GetSession()
 	if err != nil {
 		t.Errorf("could not get session: %v", err)
 	}
+
 	fcv := testutil.GetFCV(session)
 	if cmp, err := testutil.CompareFCV(fcv, "4.9"); err != nil || cmp < 0 {
 		t.Skip("Requires server with FCV 4.9 or later")
 	}
 
 	ctx := context.Background()
+
+	if ok, _ := sessionProvider.IsReplicaSet(); !ok {
+		t.SkipNow()
+	}
 
 	Convey("With a MongoDump instance", t, func() {
 		err := setUpMongoDumpTestData()


### PR DESCRIPTION
The resharding tests were failing on standalones because they require a replica set to test the oplog. These tests now skip standalones.

The test was also flaking on replica sets due to the timing between creating and dropping the collections in the test. I have modified the timing and it looks like it no longer flakes.

Evergreen patch: https://spruce.mongodb.com/version/60e4d55fe3c3312642105c74/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 