### PR TITLE
TOOLS-2926 remove dev/test repos from stable releases

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1121,14 +1121,13 @@ type LinuxRepo struct {
 }
 
 var linuxRepoVersionsStable = []LinuxRepo{
-	{"development", "4.0.0-15-gabcde123", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")}, // any non-rc pre-release version will send the package to the "development" repo
-	{"testing", "4.0.0-rc0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")},              // any rc version will send the package to the "testing" repo
-	{"4.4", "4.4.0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")},                      // any 4.4 stable release version will send the package to the "4.4" repo
-	{"5.0", "5.0.0", "server-5.0", os.Getenv("NOTARY_TOKEN_5_0")},                      // any 5.0 stable release version will send the package to the "5.0" repo
+	{"4.4", "4.4.0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")}, // any 4.4 stable release version will send the package to the "4.4" repo
+	{"5.0", "5.0.0", "server-5.0", os.Getenv("NOTARY_TOKEN_5_0")}, // any 5.0 stable release version will send the package to the "5.0" repo
 }
 
 var linuxRepoVersionsUnstable = []LinuxRepo{
 	{"development", "4.0.0-15-gabcde123", "", ""}, // any non-rc pre-release version will send the package to the "development" repo
+	{"testing", "4.0.0-rc0", "", ""},              // any rc version will send the package to the "testing" repo
 }
 
 // findArgIndex is the helper function to locate index of provided arg value from an array of arg list


### PR DESCRIPTION
I'm a bit confused about when we should be pushing to the testing repos. The comment seems to imply that we should only be publishing rc versions... but we aren't doing any filtering of versions. Does barque filter out requests based on version strings?