### PR TITLE
TOOLS-2938: Re-add Ubuntu 16.04 PowerPC platform

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2322,6 +2322,35 @@ buildvariants:
   - name: "push"
     run_on: rhel80-small
 
+# MongoDB 4.0
+- name: ubuntu1604-ppc64le
+  display_name: ZAP PPC64LE Ubuntu 16.04
+  run_on:
+  - ubuntu1604-power8
+  stepback: false
+  batchtime: 10080 # weekly
+  expansions:
+    <<: *mongod_ssl_startup_args
+    <<: *mongo_ssl_startup_args
+    <<: *mongod_tls_startup_args
+    <<: *mongo_tls_startup_args
+    mongo_os: "ubuntu1604"
+    mongo_edition: "enterprise"
+    mongo_arch: "ppc64le"
+    resmoke_use_ssl: _ssl
+    resmoke_args: -j 4
+    excludes: requires_mmap_available,requires_large_ram,requires_mongo_24,requires_mongo_26,requires_mongo_30
+    edition: enterprise
+    run_kinit: true
+  tasks:
+  - name: "unit"
+  - name: ".4.0"
+  - name: "dist"
+  - name: "sign"
+    run_on: rhel80-small
+  - name: "push"
+    run_on: rhel80-small
+
 # MongoDB 4.2+
 - name: ubuntu1804-ppc64le
   display_name: ZAP PPC64LE Ubuntu 18.04

--- a/common.yml
+++ b/common.yml
@@ -2344,7 +2344,7 @@ buildvariants:
     run_kinit: true
   tasks:
   - name: "unit"
-  - name: ".4.0"
+  - name: ".4.0 !.mmap"
   - name: "dist"
   - name: "sign"
     run_on: rhel80-small

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -334,6 +334,14 @@ var platforms = []Platform{
 		BuildTags: []string{"ssl", "sasl", "gssapi", "failpoints"},
 	},
 	{
+		Name:      "ubuntu1604",
+		Arch:      ArchPpc64le,
+		OS:        OSLinux,
+		Pkg:       PkgDeb,
+		Repos:     []string{RepoOrg, RepoEnterprise},
+		BuildTags: []string{"ssl", "sasl", "gssapi", "failpoints"},
+	},
+	{
 		Name:      "ubuntu1804",
 		Arch:      ArchPpc64le,
 		OS:        OSLinux,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2938

Evergreen patch for added platform: https://spruce.mongodb.com/version/610955d70305b90f583aee5e/tasks

Only thing is that the `integration-4.0-mmapv1` task is failing [here](https://evergreen.mongodb.com/task_log_raw/mongo_tools_ubuntu1604_ppc64le_integration_4.0_mmapv1_patch_d727fdbbdda025b60ceac191df3219cbea96ffe7_610955d70305b90f583aee5e_21_08_03_14_42_49/0?type=T#L213) with the error:
```
Cannot start server with an unknown storage engine: mmapv1, terminating
```

I noticed the same issue on the RHEL 7.1 PPC64LE platform [here](https://evergreen.mongodb.com/task_log_raw/mongo_tools_rhel71_ppc64le_integration_4.0_mmapv1_d727fdbbdda025b60ceac191df3219cbea96ffe7_21_07_30_13_33_44/0?type=T#L202), but not on a non-PPC platforms like SUSE 12 [here](https://evergreen.mongodb.com/task_log_raw/mongo_tools_suse12_integration_4.0_mmapv1_d727fdbbdda025b60ceac191df3219cbea96ffe7_21_07_30_13_33_44/0?type=T#L204).

The only obvious difference I'm noticing is the build environments from the server logs:
```
build environment:
    distmod: ubuntu1604
    distarch: ppc64le
    target_arch: ppc64le
```
vs.
```
build environment:
    distmod: suse12
    distarch: x86_64
    target_arch: x86_64
```

Seems like something that might be outside our control.