### PR TITLE
TOOLS-2937 Set loadbalanced option in db.configureClient()

### DIFF
--- a/common/db/db.go
+++ b/common/db/db.go
@@ -355,6 +355,10 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 		clientopt.SetMinPoolSize(cs.MinPoolSize)
 	}
 
+	if cs.LoadBalancedSet {
+		clientopt.SetLoadBalanced(cs.LoadBalanced)
+	}
+
 	if cs.ReadConcernLevel != "" {
 		rc := readconcern.New(readconcern.Level(cs.ReadConcernLevel))
 		clientopt.SetReadConcern(rc)

--- a/common/db/db.go
+++ b/common/db/db.go
@@ -305,7 +305,9 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 	if opts.Connection.ServerSelectionTimeout > 0 {
 		clientopt.SetServerSelectionTimeout(time.Duration(opts.Connection.ServerSelectionTimeout) * time.Second)
 	}
-	clientopt.SetReplicaSet(opts.ReplicaSetName)
+	if opts.ReplicaSetName != "" {
+		clientopt.SetReplicaSet(opts.ReplicaSetName)
+	}
 
 	clientopt.SetAppName(opts.AppName)
 	if opts.Direct && len(clientopt.Hosts) == 1 {

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -755,6 +755,10 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 			opts.Host = opts.Host[:len(opts.Host)-1]
 		}
 
+		if len(cs.Hosts) > 1 && cs.LoadBalanced {
+			return fmt.Errorf("loadBalanced cannot be set to true if multiple hosts are specified")
+		}
+
 		if opts.Connection.ServerSelectionTimeout != 0 && cs.ServerSelectionTimeoutSet {
 			if (time.Duration(opts.Connection.ServerSelectionTimeout) * time.Millisecond) != cs.ServerSelectionTimeout {
 				return ConflictingArgsErrorFormat("serverSelectionTimeout", strconv.Itoa(int(cs.ServerSelectionTimeout/time.Millisecond)), strconv.Itoa(opts.Connection.ServerSelectionTimeout), "--serverSelectionTimeout")

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -889,8 +889,9 @@ func TestOptionsParsing(t *testing.T) {
 			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI", ShouldSucceed},
 
 			// Loadbalanced
-			{"", "mongodb://foo?loadbalanced=true&replicaSet=foo", ShouldFail},
-			{"", "mongodb://foo?loadbalanced=true&direct=true", ShouldFail},
+			{"", "mongodb://foo,bar/?loadbalanced=true", ShouldFail},
+			{"", "mongodb://foo/?loadbalanced=true&replicaSet=foo", ShouldFail},
+			{"", "mongodb://foo/?loadbalanced=true&connect=direct", ShouldFail},
 		}
 
 		// Each entry is expanded into 4 test cases with createTestCases()

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -516,6 +516,28 @@ func TestParseAndSetOptions(t *testing.T) {
 				ShouldError: false,
 			},
 			{
+				Name: "Direct is false when loadbalanced == true",
+				CS: connstring.ConnString{
+					LoadBalanced:    true,
+					LoadBalancedSet: true,
+				},
+				OptsIn: New("", "", "", "", true, enabledURIOnly),
+				OptsExpected: &ToolOptions{
+					General:        &General{},
+					Verbosity:      &Verbosity{},
+					Connection:     &Connection{},
+					URI:            &URI{},
+					SSL:            &SSL{},
+					Auth:           &Auth{},
+					Namespace:      &Namespace{},
+					Kerberos:       &Kerberos{},
+					enabledOptions: EnabledOptions{URI: true},
+					ReplicaSetName: "",
+					Direct:         false,
+				},
+				ShouldError: false,
+			},
+			{
 				Name: "Don't fail when uri and options set",
 				CS: connstring.ConnString{
 					Hosts: []string{"host"},
@@ -865,6 +887,10 @@ func TestOptionsParsing(t *testing.T) {
 			{"", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:foo", ShouldSucceed},
 			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:bar", ShouldFail},
 			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI", ShouldSucceed},
+
+			// Loadbalanced
+			{"", "mongodb://foo?loadbalanced=true&replicaSet=foo", ShouldFail},
+			{"", "mongodb://foo?loadbalanced=true&direct=true", ShouldFail},
 		}
 
 		// Each entry is expanded into 4 test cases with createTestCases()


### PR DESCRIPTION
When `loadBalanced` is set, we need to make sure we don't set `direct` or `replicaSet`. We were doing that by default in some situations.

We also now error if a user sets `loadBalanced` with `direct` or `replicaSet` in the URI.

I tested this manually on serverless and it looks good!