### PR TITLE
TOOLS-2952 Filter config collections in dump/restore

### DIFF
--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -151,7 +151,13 @@ func shouldSkipSystemNamespace(dbName, collName string) bool {
 			return true
 		}
 	case "config":
-		if collName == "transactions" || collName == "system.sessions" || collName == "transaction_coordinators" || collName == "system.indexBuilds" {
+		if collName == "transactions" ||
+			collName == "system.sessions" ||
+			collName == "transaction_coordinators" ||
+			collName == "system.indexBuilds" ||
+			collName == "image_collection" ||
+			collName == "mongos" ||
+			strings.HasPrefix(collName, "cache.") {
 			return true
 		}
 	default:

--- a/mongodump/prepare_test.go
+++ b/mongodump/prepare_test.go
@@ -91,6 +91,46 @@ func TestShouldSkipSystemNamespace(t *testing.T) {
 			coll:   "test",
 			output: false,
 		},
+		{
+			db:     "config",
+			coll:   "transactions",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "system.sessions",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "transaction_coordinators",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "system.indexBuilds",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "image_collection",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "mongos",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "cache.foo",
+			output: true,
+		},
+		{
+			db:     "config",
+			coll:   "foo",
+			output: false,
+		},
 	}
 
 	for _, testVals := range tests {

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -61,7 +61,13 @@ var errorTimestampBeforeLimit = fmt.Errorf("timestamp before limit")
 
 // shouldIgnoreNamespace returns true if the given namespace should be ignored during applyOps.
 func shouldIgnoreNamespace(ns string) bool {
-	if strings.HasPrefix(ns, "config.cache.") || ns == "config.system.sessions" || ns == "config.system.indexBuilds" {
+	if strings.HasPrefix(ns, "config.cache.") ||
+		ns == "config.transactions" ||
+		ns == "config.transaction_coordinators" ||
+		ns == "config.image_collection" ||
+		ns == "config.mongos" ||
+		ns == "config.system.sessions" ||
+		ns == "config.system.indexBuilds" {
 		log.Logv(log.Always, "skipping applying the "+ns+" namespace in applyOps")
 		return true
 	}

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -627,6 +627,22 @@ func TestShouldIgnoreNamespacee(t *testing.T) {
 			output: true,
 		},
 		{
+			ns:     "config.transactions",
+			output: true,
+		},
+		{
+			ns:     "config.transaction_coordinators",
+			output: true,
+		},
+		{
+			ns:     "config.image_collection",
+			output: true,
+		},
+		{
+			ns:     "config.mongos",
+			output: true,
+		},
+		{
 			ns:     "test.system.js",
 			output: false,
 		},


### PR DESCRIPTION
I ended up not running `shouldSkipSystemNamespace()` in `oplogDocumentValidator()` since that would skip all system collections (e.g. `db.system.views`, `admin.system.users`). That would be a behavior change requiring a major version bump. So the config collections are just filtered on the mongorestore side. Likewise I did not merge `shouldSkipSystemNamespace()` and `shouldIgnoreNamespace()` into one function in common.

This fixes a problem with restoring config collections that definitely should not be restored. We should open a ticket to investigate options for filtering the entire config and admin collections.