### PR TITLE
MGOMIRROR-469: Fix verbosity bug when calling ParseArgs multiple times

### DIFF
--- a/common/failpoint/failpoint.go
+++ b/common/failpoint/failpoint.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build failpoints
 // +build failpoints
 
 // Package failpoint implements triggers for custom debugging behavoir

--- a/common/failpoint/failpoint_disabled.go
+++ b/common/failpoint/failpoint_disabled.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build !failpoints
 // +build !failpoints
 
 package failpoint

--- a/common/failpoint/failpoint_test.go
+++ b/common/failpoint/failpoint_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build failpoints
 // +build failpoints
 
 package failpoint

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -446,7 +446,7 @@ func (opts *ToolOptions) AddToExtraOptionsRegistry(extraOpts ExtraOptions) {
 	opts.URI.extraOptionsRegistry = append(opts.URI.extraOptionsRegistry, extraOpts)
 }
 
-func (opts *ToolOptions) CallParser(args []string) ([]string, error) {
+func (opts *ToolOptions) CallArgParser(args []string) ([]string, error) {
 	args, err := opts.parser.ParseArgs(args)
 	if err != nil {
 		return []string{}, err
@@ -470,7 +470,7 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 		return []string{}, err
 	}
 
-	args, err := opts.CallParser(args)
+	args, err := opts.CallArgParser(args)
 	if err != nil {
 		return []string{}, err
 	}
@@ -516,7 +516,7 @@ func LogSensitiveOptionWarnings(args []string) {
 
 	// Create temporary options for parsing command line args.
 	tempOpts := New("", "", "", "", true, EnabledOptions{Auth: true, Connection: true, URI: true})
-	extraArgs, err := tempOpts.CallParser(args)
+	extraArgs, err := tempOpts.CallArgParser(args)
 	if err != nil {
 		return
 	}
@@ -553,7 +553,7 @@ func LogSensitiveOptionWarnings(args []string) {
 // This also applies to --destinationPassword for mongomirror only.
 func (opts *ToolOptions) ParseConfigFile(args []string) error {
 	// Get config file path from the arguments, if specified.
-	_, err := opts.CallParser(args)
+	_, err := opts.CallArgParser(args)
 	if err != nil {
 		return err
 	}

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -457,7 +457,7 @@ func (opts *ToolOptions) CallArgParser(args []string) ([]string, error) {
 		opts.VerbosityParsed = true
 	}
 
-	return args, err
+	return args, nil
 }
 
 // ParseArgs parses a potential config file followed by the command line args, overriding

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -121,9 +121,10 @@ type General struct {
 
 // Struct holding verbosity-related options
 type Verbosity struct {
-	SetVerbosity func(string) `short:"v" long:"verbose" value-name:"<level>" description:"more detailed log output (include multiple times for more verbosity, e.g. -vvvvv, or specify a numeric value, e.g. --verbose=N)" optional:"true" optional-value:""`
-	Quiet        bool         `long:"quiet" description:"hide all log output"`
-	VLevel       int          `no-flag:"true"`
+	SetVerbosity    func(string) `short:"v" long:"verbose" value-name:"<level>" description:"more detailed log output (include multiple times for more verbosity, e.g. -vvvvv, or specify a numeric value, e.g. --verbose=N)" optional:"true" optional-value:""`
+	Quiet           bool         `long:"quiet" description:"hide all log output"`
+	VLevel          int          `no-flag:"true"`
+	VerbosityParsed bool         `no-flag:"true"`
 }
 
 func (v Verbosity) Level() int {
@@ -235,6 +236,12 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 
 	// Called when -v or --verbose is parsed
 	opts.SetVerbosity = func(val string) {
+		// Reset verbosity level when we call ParseArgs again and see the verbosity flag
+		if opts.VLevel != 0 && opts.VerbosityParsed {
+			opts.VerbosityParsed = false
+			opts.VLevel = 0
+		}
+
 		if i, err := strconv.Atoi(val); err == nil {
 			opts.VLevel = opts.VLevel + i // -v=N or --verbose=N
 		} else if matched, _ := regexp.MatchString(`^v+$`, val); matched {
@@ -439,6 +446,20 @@ func (opts *ToolOptions) AddToExtraOptionsRegistry(extraOpts ExtraOptions) {
 	opts.URI.extraOptionsRegistry = append(opts.URI.extraOptionsRegistry, extraOpts)
 }
 
+func (opts *ToolOptions) CallParser(args []string) ([]string, error) {
+	args, err := opts.parser.ParseArgs(args)
+	if err != nil {
+		return []string{}, err
+	}
+
+	// Set VerbosityParsed flag to make sure we reset verbosity level when we call ParseArgs again
+	if opts.Verbosity.VLevel != 0 && !opts.VerbosityParsed {
+		opts.VerbosityParsed = true
+	}
+
+	return args, err
+}
+
 // ParseArgs parses a potential config file followed by the command line args, overriding
 // any values in the config file. Returns any extra args not accounted for by parsing,
 // as well as an error if the parsing returns an error.
@@ -449,7 +470,7 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 		return []string{}, err
 	}
 
-	args, err := opts.parser.ParseArgs(args)
+	args, err := opts.CallParser(args)
 	if err != nil {
 		return []string{}, err
 	}
@@ -495,7 +516,7 @@ func LogSensitiveOptionWarnings(args []string) {
 
 	// Create temporary options for parsing command line args.
 	tempOpts := New("", "", "", "", true, EnabledOptions{Auth: true, Connection: true, URI: true})
-	extraArgs, err := tempOpts.parser.ParseArgs(args)
+	extraArgs, err := tempOpts.CallParser(args)
 	if err != nil {
 		return
 	}
@@ -532,7 +553,7 @@ func LogSensitiveOptionWarnings(args []string) {
 // This also applies to --destinationPassword for mongomirror only.
 func (opts *ToolOptions) ParseConfigFile(args []string) error {
 	// Get config file path from the arguments, if specified.
-	_, err := opts.parser.ParseArgs(args)
+	_, err := opts.CallParser(args)
 	if err != nil {
 		return err
 	}

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -453,7 +453,7 @@ func (opts *ToolOptions) CallArgParser(args []string) ([]string, error) {
 	}
 
 	// Set VerbosityParsed flag to make sure we reset verbosity level when we call ParseArgs again
-	if opts.Verbosity.VLevel != 0 && !opts.VerbosityParsed {
+	if opts.VLevel != 0 && !opts.VerbosityParsed {
 		opts.VerbosityParsed = true
 	}
 

--- a/common/options/options_fp.go
+++ b/common/options/options_fp.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build failpoints
 // +build failpoints
 
 package options

--- a/common/options/options_fp_disabled.go
+++ b/common/options/options_fp_disabled.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build !failpoints
 // +build !failpoints
 
 package options

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -78,69 +78,69 @@ func TestVerbosityFlag(t *testing.T) {
 		So(optPtr.parser, ShouldNotBeNil)
 
 		Convey("no verbosity flags, Level should be 0", func() {
-			_, err := optPtr.CallParser([]string{})
+			_, err := optPtr.CallArgParser([]string{})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 0)
 		})
 
 		Convey("one short verbosity flag, Level should be 1", func() {
-			_, err := optPtr.CallParser([]string{"-v"})
+			_, err := optPtr.CallArgParser([]string{"-v"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 1)
 		})
 
 		Convey("three short verbosity flags (consecutive), Level should be 3", func() {
-			_, err := optPtr.CallParser([]string{"-vvv"})
+			_, err := optPtr.CallArgParser([]string{"-vvv"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("three short verbosity flags (dispersed), Level should be 3", func() {
-			_, err := optPtr.CallParser([]string{"-v", "-v", "-v"})
+			_, err := optPtr.CallArgParser([]string{"-v", "-v", "-v"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("short verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.CallParser([]string{"-v=3"})
+			_, err := optPtr.CallArgParser([]string{"-v=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("consecutive short flags with assignment, only assignment holds", func() {
-			_, err := optPtr.CallParser([]string{"-vv=3"})
+			_, err := optPtr.CallArgParser([]string{"-vv=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("one long verbose flag, Level should be 1", func() {
-			_, err := optPtr.CallParser([]string{"--verbose"})
+			_, err := optPtr.CallArgParser([]string{"--verbose"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 1)
 		})
 
 		Convey("three long verbosity flags, Level should be 3", func() {
-			_, err := optPtr.CallParser([]string{"--verbose", "--verbose", "--verbose"})
+			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose", "--verbose"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("long verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.CallParser([]string{"--verbose=3"})
+			_, err := optPtr.CallArgParser([]string{"--verbose=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("mixed assignment and bare flag, total is sum", func() {
-			_, err := optPtr.CallParser([]string{"--verbose", "--verbose=3"})
+			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 4)
 		})
 
-		Convey("run CallParser multiple times, level should be correct", func() {
-			_, err := optPtr.CallParser([]string{"--verbose", "--verbose=3"})
+		Convey("run CallArgParser multiple times, level should be correct", func() {
+			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
 			So(err, ShouldBeNil)
-			_, err = optPtr.CallParser([]string{"--verbose", "--verbose=3"})
+			_, err = optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 4)
 		})
@@ -1007,7 +1007,7 @@ func TestHiddenOptionsDefaults(t *testing.T) {
 	Convey("With a ToolOptions parsed", t, func() {
 		enabled := EnabledOptions{Connection: true}
 		opts := New("", "", "", "", true, enabled)
-		_, err := opts.CallParser([]string{})
+		_, err := opts.CallArgParser([]string{})
 		So(err, ShouldBeNil)
 		Convey("hidden options should have expected values", func() {
 			So(opts.MaxProcs, ShouldEqual, runtime.NumCPU())

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -78,61 +78,69 @@ func TestVerbosityFlag(t *testing.T) {
 		So(optPtr.parser, ShouldNotBeNil)
 
 		Convey("no verbosity flags, Level should be 0", func() {
-			_, err := optPtr.parser.ParseArgs([]string{})
+			_, err := optPtr.CallParser([]string{})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 0)
 		})
 
 		Convey("one short verbosity flag, Level should be 1", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"-v"})
+			_, err := optPtr.CallParser([]string{"-v"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 1)
 		})
 
 		Convey("three short verbosity flags (consecutive), Level should be 3", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"-vvv"})
+			_, err := optPtr.CallParser([]string{"-vvv"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("three short verbosity flags (dispersed), Level should be 3", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"-v", "-v", "-v"})
+			_, err := optPtr.CallParser([]string{"-v", "-v", "-v"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("short verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"-v=3"})
+			_, err := optPtr.CallParser([]string{"-v=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("consecutive short flags with assignment, only assignment holds", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"-vv=3"})
+			_, err := optPtr.CallParser([]string{"-vv=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("one long verbose flag, Level should be 1", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"--verbose"})
+			_, err := optPtr.CallParser([]string{"--verbose"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 1)
 		})
 
 		Convey("three long verbosity flags, Level should be 3", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"--verbose", "--verbose", "--verbose"})
+			_, err := optPtr.CallParser([]string{"--verbose", "--verbose", "--verbose"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("long verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"--verbose=3"})
+			_, err := optPtr.CallParser([]string{"--verbose=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 3)
 		})
 
 		Convey("mixed assignment and bare flag, total is sum", func() {
-			_, err := optPtr.parser.ParseArgs([]string{"--verbose", "--verbose=3"})
+			_, err := optPtr.CallParser([]string{"--verbose", "--verbose=3"})
+			So(err, ShouldBeNil)
+			So(optPtr.Level(), ShouldEqual, 4)
+		})
+
+		Convey("run CallParser multiple times, level should be correct", func() {
+			_, err := optPtr.CallParser([]string{"--verbose", "--verbose=3"})
+			So(err, ShouldBeNil)
+			_, err = optPtr.CallParser([]string{"--verbose", "--verbose=3"})
 			So(err, ShouldBeNil)
 			So(optPtr.Level(), ShouldEqual, 4)
 		})
@@ -999,7 +1007,7 @@ func TestHiddenOptionsDefaults(t *testing.T) {
 	Convey("With a ToolOptions parsed", t, func() {
 		enabled := EnabledOptions{Connection: true}
 		opts := New("", "", "", "", true, enabled)
-		_, err := opts.parser.ParseArgs([]string{})
+		_, err := opts.CallParser([]string{})
 		So(err, ShouldBeNil)
 		Convey("hidden options should have expected values", func() {
 			So(opts.MaxProcs, ShouldEqual, runtime.NumCPU())

--- a/common/password/pass_util.go
+++ b/common/password/pass_util.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build !solaris
 // +build !solaris
 
 package password

--- a/common/progress/progress_bar_test.go
+++ b/common/progress/progress_bar_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build !race
 // +build !race
 
 // Disable race detector since these tests are inherently racy

--- a/linter.go
+++ b/linter.go
@@ -1,3 +1,4 @@
+//go:build linter
 // +build linter
 
 package main

--- a/mongostat/stat_consumer/interactive_line_formatter.go
+++ b/mongostat/stat_consumer/interactive_line_formatter.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build !solaris
 // +build !solaris
 
 package stat_consumer


### PR DESCRIPTION
Currently we have a bug in the verbose flag parsing. The `SetVerbosity` function adds up the verbosity level every time when it's called. The reason for such logic is we wanna support command line flag such as 
`-v -v -v`(verbose level =3) or `-v --verbose=3`(verbose level =4)

However, this imposes a bug when `parseArgs`get called multiple times, we will multiple the verbose levels in the case. Currently `parseArgs` is get called both in `func (opts *ToolOptions) ParseArgs` and `ParseConfigFile`. 

There is no perfect solution for this bug right now because we cannot differentiate when `SetVerbosity` was called by a single `parseArgs` for a second time or by different `parseArgs` callers. So I made a little hacky fix.

I created a function `CallArgParser` to wrap `parseArgs` around. This function makes sure we reset the verbosity level every time when calling `parseArgs`, and the reset will only happen if the current  `parseArgs` detects verbosity flags that exist. We should not call `opts.parser.ParseArgs` directly as well. 