### PR TITLE
TOOLS-2875 Add batch byte limit to BufferedBulkInserter

### DIFF
--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -16,6 +16,7 @@ import (
 )
 
 // The default value of maxMessageSizeBytes
+// See: https://docs.mongodb.com/manual/reference/command/hello/#mongodb-data-hello.maxMessageSizeBytes
 const MAX_MESSAGE_SIZE_BYTES = 48000000
 
 // BufferedBulkInserter implements a bufio.Writer-like design for queuing up

--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -15,6 +15,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// The default value of maxMessageSizeBytes
+const MAX_MESSAGE_SIZE_BYTES = 48000000
+
 // BufferedBulkInserter implements a bufio.Writer-like design for queuing up
 // documents and inserting them in bulk when the given doc limit (or max
 // message size) is reached. Must be flushed at the end to ensure that all
@@ -24,6 +27,8 @@ type BufferedBulkInserter struct {
 	writeModels   []mongo.WriteModel
 	docLimit      int
 	docCount      int
+	byteCount     int
+	byteLimit     int
 	bulkWriteOpts *options.BulkWriteOptions
 	upsert        bool
 }
@@ -33,7 +38,11 @@ func newBufferedBulkInserter(collection *mongo.Collection, docLimit int, ordered
 		collection:    collection,
 		bulkWriteOpts: options.BulkWrite().SetOrdered(ordered),
 		docLimit:      docLimit,
-		writeModels:   make([]mongo.WriteModel, 0, docLimit),
+		// We set the byte limit to be slightly lower than maxMessageSizeBytes so it can fit in one OP_MSG.
+		// This may not always be perfect, e.g. we don't count update selectors in byte totals, but it should
+		// be good enough to keep memory consumption in check.
+		byteLimit:   MAX_MESSAGE_SIZE_BYTES - 100,
+		writeModels: make([]mongo.WriteModel, 0, docLimit),
 	}
 	return bb
 }
@@ -67,6 +76,7 @@ func (bb *BufferedBulkInserter) SetUpsert(upsert bool) *BufferedBulkInserter {
 func (bb *BufferedBulkInserter) resetBulk() {
 	bb.writeModels = bb.writeModels[:0]
 	bb.docCount = 0
+	bb.byteCount = 0
 }
 
 // Insert adds a document to the buffer for bulk insertion. If the buffer becomes full, the bulk write is performed, returning
@@ -83,18 +93,32 @@ func (bb *BufferedBulkInserter) Insert(doc interface{}) (*mongo.BulkWriteResult,
 // Update adds a document to the buffer for bulk update. If the buffer becomes full, the bulk write is performed, returning
 // any error that occurs.
 func (bb *BufferedBulkInserter) Update(selector, update bson.D) (*mongo.BulkWriteResult, error) {
-	return bb.addModel(mongo.NewUpdateOneModel().SetFilter(selector).SetUpdate(update).SetUpsert(bb.upsert))
+	rawBytes, err := bson.Marshal(update)
+	if err != nil {
+		return nil, err
+	}
+	bb.byteCount += len(rawBytes)
+
+	return bb.addModel(mongo.NewUpdateOneModel().SetFilter(selector).SetUpdate(rawBytes).SetUpsert(bb.upsert))
 }
 
 // Replace adds a document to the buffer for bulk replacement. If the buffer becomes full, the bulk write is performed, returning
 // any error that occurs.
 func (bb *BufferedBulkInserter) Replace(selector, replacement bson.D) (*mongo.BulkWriteResult, error) {
-	return bb.addModel(mongo.NewReplaceOneModel().SetFilter(selector).SetReplacement(replacement).SetUpsert(bb.upsert))
+	rawBytes, err := bson.Marshal(replacement)
+	if err != nil {
+		return nil, err
+	}
+	bb.byteCount += len(rawBytes)
+
+	return bb.addModel(mongo.NewReplaceOneModel().SetFilter(selector).SetReplacement(rawBytes).SetUpsert(bb.upsert))
 }
 
 // InsertRaw adds a document, represented as raw bson bytes, to the buffer for bulk insertion. If the buffer becomes full,
 // the bulk write is performed, returning any error that occurs.
 func (bb *BufferedBulkInserter) InsertRaw(rawBytes []byte) (*mongo.BulkWriteResult, error) {
+	bb.byteCount += len(rawBytes)
+
 	return bb.addModel(mongo.NewInsertOneModel().SetDocument(rawBytes))
 }
 
@@ -110,7 +134,7 @@ func (bb *BufferedBulkInserter) addModel(model mongo.WriteModel) (*mongo.BulkWri
 	bb.docCount++
 	bb.writeModels = append(bb.writeModels, model)
 
-	if bb.docCount >= bb.docLimit {
+	if bb.docCount >= bb.docLimit || bb.byteCount >= bb.byteLimit {
 		return bb.Flush()
 	}
 

--- a/common/db/buffered_bulk_test.go
+++ b/common/db/buffered_bulk_test.go
@@ -134,6 +134,22 @@ func TestBufferedBulkInserterInserts(t *testing.T) {
 			})
 		})
 
+		Convey("using a test collection and a byte limit of 1", func() {
+			testCol := session.Database("tools-test").Collection("bulk4")
+			bufBulk = NewUnorderedBufferedBulkInserter(testCol, 1000)
+			So(bufBulk, ShouldNotBeNil)
+			bufBulk.byteLimit = 1
+
+			Convey("inserting 10 documents into the BufferedBulkInserter", func() {
+				for i := 0; i < 10; i++ {
+					result, err := bufBulk.Insert(bson.D{{"foo", "bar"}})
+					So(err, ShouldBeNil)
+					So(result, ShouldNotBeNil)
+					So(result.InsertedCount, ShouldEqual, 1)
+				}
+			})
+		})
+
 		Reset(func() {
 			provider.DropDatabase("tools-test")
 			provider.Close()


### PR DESCRIPTION
Add the batch byte limit back. The byte limit does not take selectors into account so it won't be perfect for delete, update, and replace. But it should be good enough to keep memory usage in check in most cases.