### PR TITLE
Fix bsonutil.IsEqual

### DIFF
--- a/common/bsonutil/bsonutil.go
+++ b/common/bsonutil/bsonutil.go
@@ -31,7 +31,7 @@ func IsEqual(left, right bson.D) (bool, error) {
 		return false, err
 	}
 
-	rightBytes, err := bson.Marshal(left)
+	rightBytes, err := bson.Marshal(right)
 	if err != nil {
 		return false, err
 	}

--- a/common/bsonutil/bsonutil_test.go
+++ b/common/bsonutil/bsonutil_test.go
@@ -2,7 +2,8 @@ package bsonutil
 
 import (
 	"github.com/mongodb/mongo-tools/common/testtype"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"testing"
@@ -11,24 +12,88 @@ import (
 func TestBson2Float64(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
+	assert := assert.New(t)
+
 	decimalVal, _ := primitive.ParseDecimal128("-1")
 	tests := []struct {
-		In        interface{}
-		Expected  float64
-		isSuccess bool
+		in          interface{}
+		expected    float64
+		isSuccess   bool
+		description string
 	}{
-		{int32(1), 1.0, true},
-		{int64(1), 1.0, true},
-		{1.0, 1.0, true},
-		{decimalVal, float64(-1), true},
-		{"invalid value", 0, false},
+		{int32(1), 1.0, true, "int32"},
+		{int64(1), 1.0, true, "int64"},
+		{1.0, 1.0, true, "float"},
+		{decimalVal, float64(-1), true, "decimal128"},
+		{"invalid value", 0, false, "invalid float value"},
 	}
 
-	Convey("Test numerical value conversion", t, func() {
-		for _, test := range tests {
-			result, ok := Bson2Float64(test.In)
-			So(ok, ShouldEqual, test.isSuccess)
-			So(result, ShouldEqual, test.Expected)
+	for _, test := range tests {
+		result, ok := Bson2Float64(test.in)
+		if test.isSuccess {
+			assert.True(ok, "%s converted to float64", test.description)
+		} else {
+			assert.False(ok, "%s did not convert to float64", test.description)
 		}
-	})
+		assert.Equal(test.expected, result, test.description)
+	}
+}
+
+// It'd be good to test the case where IsEqual returns an error, but it's not
+// clear if this can actually happen in practice. Internally, these errors can
+// only occur when the call to `bson.Marshal()` fails. But the type signature
+// for IsEqual means that we are always passing `bson.D` values to
+// `bson.Marshal()`, and I don't think those can cause marshalling errors.
+func TestIsEqual(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	assert := assert.New(t)
+
+	tests := []struct {
+		left        bson.D
+		right       bson.D
+		isEqual     bool
+		description string
+	}{
+		{
+			bson.D{{"hello", int64(42)}},
+			bson.D{{"hello", int64(42)}},
+			true,
+			"identical documents with int64 keys",
+		},
+		{
+			bson.D{{"hello", int64(42)}},
+			bson.D{{"hello", int32(42)}},
+			false,
+			"documents have same keys but values have different types",
+		},
+		{
+			bson.D{{"foo", "bar"}, {"baz", "buz"}},
+			bson.D{{"baz", "buz"}, {"foo", "bar"}},
+			false,
+			"document has same key/value pairs but in different order",
+		},
+		{
+			bson.D{{"hello", primitive.DateTime(42)}},
+			bson.D{{"hello", primitive.DateTime(42)}},
+			true,
+			"identical documents with datetime keys",
+		},
+		{
+			bson.D{{"hello", primitive.DateTime(42)}},
+			bson.D{{"hello", primitive.DateTime(999)}},
+			false,
+			"same key but different datetime value",
+		},
+	}
+	for _, test := range tests {
+		isEq, err := IsEqual(test.left, test.right)
+		if assert.NoError(err) {
+			if test.isEqual {
+				assert.True(isEq, test.description)
+			} else {
+				assert.False(isEq)
+			}
+		}
+	}
 }

--- a/common/idx/index_catalog_test.go
+++ b/common/idx/index_catalog_test.go
@@ -10,27 +10,27 @@ import (
 func TestDeleteIndexes(t *testing.T) {
 	require := require.New(t)
 
-	// t.Run("drop one index by name", func(t *testing.T) {
-	// 	i := newTestIndexCatalog(t)
+	t.Run("drop one index by name", func(t *testing.T) {
+		i := newTestIndexCatalog(t)
 
-	// 	dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", "foo_bar_field1_idx"}}
-	// 	i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
-	// 	require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
-	// 	require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
-	// 	require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
-	// 	require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
-	// })
+		dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", "foo_bar_field1_idx"}}
+		i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
+		require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+		require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+	})
 
-	// t.Run("drop one index by definition", func(t *testing.T) {
-	// 	i := newTestIndexCatalog(t)
+	t.Run("drop one index by definition", func(t *testing.T) {
+		i := newTestIndexCatalog(t)
 
-	// 	dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", bson.D{{"foo_bar_field1_idx", 1}}}}
-	// 	i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
-	// 	require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
-	// 	require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
-	// 	require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
-	// 	require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
-	// })
+		dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", bson.D{{"field1", 1}}}}
+		i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
+		require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+		require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+	})
 
 	t.Run("drop all indexes", func(t *testing.T) {
 		i := newTestIndexCatalog(t)

--- a/common/idx/index_catalog_test.go
+++ b/common/idx/index_catalog_test.go
@@ -1,0 +1,78 @@
+package idx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestDeleteIndexes(t *testing.T) {
+	require := require.New(t)
+
+	// t.Run("drop one index by name", func(t *testing.T) {
+	// 	i := newTestIndexCatalog(t)
+
+	// 	dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", "foo_bar_field1_idx"}}
+	// 	i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
+	// 	require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+	// 	require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+	// 	require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
+	// 	require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+	// })
+
+	// t.Run("drop one index by definition", func(t *testing.T) {
+	// 	i := newTestIndexCatalog(t)
+
+	// 	dropFooBarField1Cmd := bson.D{{"dropIndexes", "foo"}, {"index", bson.D{{"foo_bar_field1_idx", 1}}}}
+	// 	i.DeleteIndexes("foo", "bar", dropFooBarField1Cmd)
+	// 	require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+	// 	require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+	// 	require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
+	// 	require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+	// })
+
+	t.Run("drop all indexes", func(t *testing.T) {
+		i := newTestIndexCatalog(t)
+
+		dropStarCmd := bson.D{{"dropIndexes", "foo"}, {"index", "*"}}
+		i.DeleteIndexes("foo", "bar", dropStarCmd)
+		require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+		require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"), "foo_baz_idx index still exists")
+		require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+
+		i.DeleteIndexes("foo", "baz", dropStarCmd)
+		require.Nil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"), "dropped foo_bar_field1_idx index")
+		require.NotNil(i.GetIndex("foo", "bar", "_id_"), "bar._id_ index still exists")
+		require.Nil(i.GetIndex("foo", "baz", "foo_baz_idx"), "dropped foo_baz_idx index")
+		require.NotNil(i.GetIndex("foo", "baz", "_id_clustered_index"), "_id_clustered_index index still exists")
+	})
+}
+
+func newTestIndexCatalog(t *testing.T) *IndexCatalog {
+	require := require.New(t)
+
+	i := NewIndexCatalog()
+
+	fooBarIdDoc, err := NewIndexDocumentFromD(bson.D{{"key", bson.D{{"_id", 1}}}})
+	require.NoError(err, "no error creating index document for foo.bar._id index")
+
+	fooBarField1Doc, err := NewIndexDocumentFromD(bson.D{{"key", bson.D{{"field1", 1}}}})
+	require.NoError(err, "no error creating index document for foo.bar.field1 index")
+
+	fooBazIdDoc, err := NewIndexDocumentFromD(bson.D{{"key", bson.D{{"_id", 1}}}})
+	require.NoError(err, "no error creating index document for foo.baz._id index")
+
+	fooBazField2Doc, err := NewIndexDocumentFromD(bson.D{{"key", bson.D{{"field2", 1}}}})
+	require.NoError(err, "no error creating index document for foo.baz.field2 index")
+
+	i.addIndex("foo", "bar", "_id_", fooBarIdDoc)
+	i.addIndex("foo", "bar", "foo_bar_field1_idx", fooBarField1Doc)
+	i.addIndex("foo", "baz", "_id_clustered_index", fooBazIdDoc)
+	i.addIndex("foo", "baz", "foo_baz_idx", fooBazField2Doc)
+	require.NotNil(i.GetIndex("foo", "bar", "foo_bar_field1_idx"))
+	require.NotNil(i.GetIndex("foo", "baz", "foo_baz_idx"))
+
+	return i
+}


### PR DESCRIPTION
Previously it always returned true because of a bug that had it always compare the left value to itself instead of the right.

I also added tests for this function and converted the existing tests in bsonutil_test.go to testify.

This also adds some additional protection in `IndexCatalog.DeleteIndexes` to prevent dropping more than 1 index.