### PR TITLE
TOOLS-2963 Move prompting for password to earlier in options processing

### DIFF
--- a/common/db/db.go
+++ b/common/db/db.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/password"
 	"github.com/youmark/pkcs8"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -119,15 +118,6 @@ func (sp *SessionProvider) DB(name string) *mongo.Database {
 
 // NewSessionProvider constructs a session provider, including a connected client.
 func NewSessionProvider(opts options.ToolOptions) (*SessionProvider, error) {
-	// finalize auth options, filling in missing passwords
-	if opts.Auth.ShouldAskForPassword() {
-		pass, err := password.Prompt()
-		if err != nil {
-			return nil, fmt.Errorf("error reading password: %v", err)
-		}
-		opts.Auth.Password = pass
-	}
-
 	client, err := configureClient(opts)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring the connector: %v", err)

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -21,6 +21,7 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/mongodb/mongo-tools/common/failpoint"
 	"github.com/mongodb/mongo-tools/common/log"
+	"github.com/mongodb/mongo-tools/common/password"
 	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -654,6 +655,16 @@ func (opts *ToolOptions) NormalizeOptionsAndURI() error {
 	if err != nil {
 		return err
 	}
+
+	// finalize auth options, filling in missing passwords
+	if opts.Auth.ShouldAskForPassword() {
+		pass, err := password.Prompt()
+		if err != nil {
+			return fmt.Errorf("error reading password: %v", err)
+		}
+		opts.Auth.Password = pass
+	}
+
 	err = opts.ConnString.Validate()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, we didn't prompt for a password until we attempted to establish a
database connection. But before we did that we would call
`connstring.ConnString.Validate`, which would return an error if the user for
the connection was set but no password was provided.

This commit moves the prompt for the password to just before the call to
`Validate`, so we should never end up complaining about a missing password
before having a chance to prompt the user.

I tested this by hand with a few different patterns:

$> go run ./mongotop/main/ -u user --authenticationMechanism 'PLAIN'
$> go run ./mongotop/main/ -u user --password="" --authenticationMechanism 'PLAIN'
$> go run ./mongotop/main/ -u user --password=""

I tried this with a few different tools, including mongodump, mongorestore,
and mongotop.