### PR TITLE
TOOLS-3062: Add Amazon Linux 2022 x86 to Tools

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2303,12 +2303,6 @@ buildvariants:
     resmoke_args: --jobs 4
   tasks:
   - name: "unit"
-  - name: ".3.6"
-  - name: ".4.0"
-  - name: ".4.2"
-  - name: ".4.4"
-  - name: ".5.0"
-  - name: ".5.3"
 #  - name: ".6.0"
 #  - name: ".latest"
   - name: ".kerberos"

--- a/common.yml
+++ b/common.yml
@@ -2286,6 +2286,38 @@ buildvariants:
   - name: "push"
     run_on: rhel80-small
 
+- name: amazon2022
+  display_name: Amazon Linux 2022
+  run_on:
+  - amazon2022-small
+  expansions:
+    <<: [ *mongod_ssl_startup_args, *mongo_ssl_startup_args, *mongod_tls_startup_args, *mongo_tls_startup_args ]
+    mongo_os: "amazon2022"
+    mongo_edition: "enterprise"
+    smoke_use_ssl: --use-ssl
+    resmoke_use_ssl: _ssl
+    smoke_use_tls: --use-tls
+    resmoke_use_tls: _tls
+    edition: enterprise
+    run_kinit: true
+    resmoke_args: --jobs 4
+  tasks:
+  - name: "unit"
+  - name: ".3.6"
+  - name: ".4.0"
+  - name: ".4.2"
+  - name: ".4.4"
+  - name: ".5.0"
+  - name: ".5.3"
+#  - name: ".6.0"
+#  - name: ".latest"
+  - name: ".kerberos"
+  - name: "dist"
+  - name: "sign"
+    run_on: rhel80-small
+  - name: "push"
+    run_on: rhel80-small
+
 #######################################
 #     Debian x86_64 Buildvariants     #
 #######################################

--- a/etc/repo-config.yml
+++ b/etc/repo-config.yml
@@ -144,6 +144,13 @@ repos:
     repos:
       - yum/amazon/2/mongodb-org
 
+  - name: amazon2022
+    type: rpm
+    edition: org
+    bucket: repo.mongodb.org
+    repos:
+      - yum/amazon/2022/mongodb-org
+
   - name: suse11
     type: rpm
     edition: org
@@ -369,6 +376,13 @@ repos:
     bucket: repo.mongodb.com
     repos:
       - yum/amazon/2/mongodb-enterprise
+
+  - name: amazon2022
+    type: rpm
+    edition: enterprise
+    bucket: repo.mongodb.com
+    repos:
+      - yum/amazon/2022/mongodb-enterprise
 
   - name: suse11
     type: rpm

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -186,6 +186,14 @@ var platforms = []Platform{
 		BuildTags: defaultBuildTags,
 	},
 	{
+		Name:      "amazon2022",
+		Arch:      ArchX86_64,
+		OS:        OSLinux,
+		Pkg:       PkgRPM,
+		Repos:     []string{RepoOrg, RepoEnterprise},
+		BuildTags: defaultBuildTags,
+	},
+	{
 		Name:      "debian81",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,


### PR DESCRIPTION
This PR adds Amazon Linux 2022 x86 to Tools. I followed [these instructions](https://github.com/mongodb/mongo-tools/blob/master/PLATFORMSUPPORT.md) (and the examples of existing amazon linux platforms) to add this one.