### PR TITLE
TOOLS-3058 + TOOLS-3060: Add Ubuntu 22.04 x86 and ARM to Tools

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2716,9 +2716,6 @@ buildvariants:
     resmoke_args: --jobs 4
   tasks:
   - name: "unit"
-  - name: ".4.4"
-  - name: ".5.0"
-  - name: ".5.3"
 #  - name: ".6.0"
 #  - name: ".latest"
   - name: ".kerberos"
@@ -2892,9 +2889,6 @@ buildvariants:
     USE_SSL: "true"
   tasks:
   - name: "unit"
-  - name: ".4.4"
-  - name: ".5.0"
-  - name: ".5.3"
 #  - name: ".6.0"
 #  - name: ".latest"
   - name: ".kerberos"

--- a/common.yml
+++ b/common.yml
@@ -2872,6 +2872,38 @@ buildvariants:
   - name: "push"
     run_on: rhel80-small
 
+- name: ubuntu2204-arm64
+  display_name: ZAP ARM64 Ubuntu 22.04
+  run_on:
+    - ubuntu2204-arm64-small
+  stepback: false
+  expansions:
+    <<: [ *mongod_ssl_startup_args, *mongo_ssl_startup_args, *mongod_tls_startup_args, *mongo_tls_startup_args ]
+    mongo_os: "ubuntu2204"
+    mongo_edition: "enterprise"
+    mongo_arch: "aarch64"
+    smoke_use_ssl: --use-ssl
+    resmoke_use_ssl: _ssl
+    smoke_use_tls: --use-tls
+    resmoke_use_tls: _tls
+    excludes: requires_mmap_available,requires_large_ram,requires_mongo_24,requires_mongo_26,requires_mongo_30
+    resmoke_args: -j 2
+    edition: "enterprise"
+    USE_SSL: "true"
+  tasks:
+  - name: "unit"
+  - name: ".4.4"
+  - name: ".5.0"
+  - name: ".5.3"
+#  - name: ".6.0"
+#  - name: ".latest"
+  - name: ".kerberos"
+  - name: "dist"
+  - name: "sign"
+    run_on: rhel80-small
+  - name: "push"
+    run_on: rhel80-small
+
 - name: amazon2-arm64
   display_name: Amazon Linux ARM v2
   run_on:

--- a/common.yml
+++ b/common.yml
@@ -2699,6 +2699,35 @@ buildvariants:
   - name: "push"
     run_on: rhel80-small
 
+- name: ubuntu2204
+  display_name: Ubuntu 22.04
+  run_on:
+  - ubuntu2204-small
+  expansions:
+    <<: [ *mongod_ssl_startup_args, *mongo_ssl_startup_args, *mongod_tls_startup_args, *mongo_tls_startup_args ]
+    mongo_os: "ubuntu2204"
+    mongo_edition: "enterprise"
+    smoke_use_ssl: --use-ssl
+    resmoke_use_ssl: _ssl
+    smoke_use_tls: --use-tls
+    resmoke_use_tls: _tls
+    edition: enterprise
+    run_kinit: true
+    resmoke_args: --jobs 4
+  tasks:
+  - name: "unit"
+  - name: ".4.4"
+  - name: ".5.0"
+  - name: ".5.3"
+#  - name: ".6.0"
+#  - name: ".latest"
+  - name: ".kerberos"
+  - name: "dist"
+  - name: "sign"
+    run_on: rhel80-small
+  - name: "push"
+    run_on: rhel80-small
+
 #######################################
 #        Windows Buildvariants        #
 #######################################

--- a/etc/repo-config.yml
+++ b/etc/repo-config.yml
@@ -285,6 +285,18 @@ repos:
     repos:
       - apt/ubuntu/dists/focal/mongodb-org
 
+  - name: ubuntu2204
+    type: deb
+    code_name: "jammy"
+    edition: org
+    bucket: repo.mongodb.org
+    component: multiverse
+    architectures:
+      - amd64
+      - i386
+    repos:
+      - apt/ubuntu/dists/jammy/mongodb-org
+
 ####################
 #
 # Enterprise Repos:
@@ -521,3 +533,15 @@ repos:
       - i386
     repos:
       - apt/ubuntu/dists/focal/mongodb-enterprise
+
+  - name: ubuntu2204
+    type: deb
+    code_name: "jammy"
+    edition: enterprise
+    bucket: repo.mongodb.com
+    component: multiverse
+    architectures:
+      - amd64
+      - i386
+    repos:
+      - apt/ubuntu/dists/jammy/mongodb-enterprise

--- a/etc/repo-config.yml
+++ b/etc/repo-config.yml
@@ -294,6 +294,7 @@ repos:
     architectures:
       - amd64
       - i386
+      - arm64
     repos:
       - apt/ubuntu/dists/jammy/mongodb-org
 
@@ -543,5 +544,6 @@ repos:
     architectures:
       - amd64
       - i386
+      - arm64
     repos:
       - apt/ubuntu/dists/jammy/mongodb-enterprise

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -361,6 +361,14 @@ var platforms = []Platform{
 	},
 	{
 		Name:      "ubuntu2204",
+		Arch:      ArchArm64,
+		OS:        OSLinux,
+		Pkg:       PkgDeb,
+		Repos:     []string{RepoOrg, RepoEnterprise},
+		BuildTags: []string{"ssl", "failpoints"},
+	},
+	{
+		Name:      "ubuntu2204",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,
 		Pkg:       PkgDeb,

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -360,6 +360,14 @@ var platforms = []Platform{
 		BuildTags: defaultBuildTags,
 	},
 	{
+		Name:      "ubuntu2204",
+		Arch:      ArchX86_64,
+		OS:        OSLinux,
+		Pkg:       PkgDeb,
+		Repos:     []string{RepoOrg, RepoEnterprise},
+		BuildTags: defaultBuildTags,
+	},
+	{
 		Name:      "windows",
 		Arch:      ArchX86_64,
 		OS:        OSWindows,


### PR DESCRIPTION
This PR adds Ubuntu 22.04 x86 _and_ ARM to tools. I combined TOOLS-3058 and 3060 into one PR since they are similar. I followed [these instructions](https://github.com/mongodb/mongo-tools/blob/master/PLATFORMSUPPORT.md) (and the examples of existing ubuntu platforms) to add these two.