### PR TITLE
TOOLS-3056: Add RHEL9 x86 to Tools

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2526,6 +2526,32 @@ buildvariants:
   - name: "push"
     run_on: rhel80-small
 
+- name: rhel90
+  display_name: RHEL 9.0
+  run_on:
+  - rhel90-small
+  expansions:
+    <<: [ *mongod_ssl_startup_args, *mongo_ssl_startup_args, *mongod_tls_startup_args, *mongo_tls_startup_args ]
+    mongo_os: "rhel90"
+    mongo_edition: "enterprise"
+    smoke_use_ssl: --use-ssl
+    resmoke_use_ssl: _ssl
+    smoke_use_tls: --use-tls
+    resmoke_use_tls: _tls
+    edition: enterprise
+    run_kinit: true
+    resmoke_args: --jobs 4
+  tasks:
+  - name: "unit"
+#  - name: ".6.0"
+#  - name: ".latest"
+  - name: ".kerberos"
+  - name: "dist"
+  - name: "sign"
+    run_on: rhel80-small
+  - name: "push"
+    run_on: rhel80-small
+
 #######################################
 #     SUSE x86_64 Buildvariants       #
 #######################################

--- a/etc/repo-config.yml
+++ b/etc/repo-config.yml
@@ -122,6 +122,22 @@ repos:
       - yum/redhat/8/mongodb-org
       - yum/redhat/8Server/mongodb-org
 
+  - name: rhel83
+    type: rpm
+    edition: org
+    bucket: repo.mongodb.org
+    repos:
+      - yum/redhat/8/mongodb-org
+      - yum/redhat/8Server/mongodb-org
+
+  - name: rhel90
+    type: rpm
+    edition: org
+    bucket: repo.mongodb.org
+    repos:
+      - yum/redhat/9/mongodb-org
+      - yum/redhat/9Server/mongodb-org
+
   - name: amazon
     type: rpm
     edition: org
@@ -368,6 +384,14 @@ repos:
     repos:
       - yum/redhat/8/mongodb-enterprise
       - yum/redhat/8Server/mongodb-enterprise
+
+  - name: rhel90
+    type: rpm
+    edition: enterprise
+    bucket: repo.mongodb.com
+    repos:
+      - yum/redhat/9/mongodb-enterprise
+      - yum/redhat/9Server/mongodb-enterprise
 
   - name: amazon
     type: rpm

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -280,6 +280,14 @@ var platforms = []Platform{
 		BuildTags: defaultBuildTags,
 	},
 	{
+		Name:      "rhel90",
+		Arch:      ArchX86_64,
+		OS:        OSLinux,
+		Pkg:       PkgRPM,
+		Repos:     []string{RepoOrg, RepoEnterprise},
+		BuildTags: defaultBuildTags,
+	},
+	{
 		Name:      "suse12",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,


### PR DESCRIPTION
This PR adds RHEL 9.0 x86 ~_and_ ARM~ to tools. ~Similar to the ubuntu 22.04 support I did earlier, I combined TOOLS-3054 and 3056 into one PR since they are similar.~

Update: the evergreen RHEL9 ARM distro does not have Go installed, so that ticket (3054) is blocked. I am keeping this PR open since it can still cover the work for 3056.