### PR TITLE
TOOLS-3130: Add 6.0 to list of linux repos we release to

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -776,6 +776,7 @@ pre:
           export AWS_SECRET_ACCESS_KEY='${release_aws_secret}'
           export NOTARY_TOKEN_4_4='${signing_auth_token_server_4_4}'
           export NOTARY_TOKEN_5_0='${signing_auth_token_server_5_0}'
+          export NOTARY_TOKEN_6_0='${signing_auth_token_server_6_0}'
           export BARQUE_USERNAME='${evg_user}'
           export BARQUE_API_KEY='${barque_api_key}'
           export TOOLS_TESTING_AUTH_USERNAME='${auth_username}'

--- a/release/release.go
+++ b/release/release.go
@@ -1123,6 +1123,7 @@ type LinuxRepo struct {
 var linuxRepoVersionsStable = []LinuxRepo{
 	{"4.4", "4.4.0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")}, // any 4.4 stable release version will send the package to the "4.4" repo
 	{"5.0", "5.0.0", "server-5.0", os.Getenv("NOTARY_TOKEN_5_0")}, // any 5.0 stable release version will send the package to the "5.0" repo
+	{"6.0", "6.0.0", "server-6.0", os.Getenv("NOTARY_TOKEN_6_0")}, // any 6.0 stable release version will send the package to the "6.0" repo
 }
 
 var linuxRepoVersionsUnstable = []LinuxRepo{


### PR DESCRIPTION
~WIP~

~This PR adds 6.0 to the list of linux repos we release to. The only remaining step is adding the new variable to the mongo-tools evergreen project. I will update this PR with reviewers and relevant evergreen tasks when that is completed.~

This PR adds 6.0 to the list of linux repos we release to.