### PR TITLE
TOOLS-3110 Fix windows tests

### DIFF
--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -108,6 +108,11 @@ class Main:
                 exe += ".exe"
             os.rename(os.path.join(extracted[0], exe), os.path.join("bin", exe))
 
+        if platform.system() == "Windows":
+            dlls = glob.glob(os.path.join(self.dir, "mongodb-*", "bin", "*.dll"))
+            for dll in dlls:
+                os.rename(dll, os.path.join("bin", os.path.basename(dll)))
+
         os.remove(local)
         shutil.rmtree(extracted[0])
 

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -111,6 +111,7 @@ class Main:
         if platform.system() == "Windows":
             dlls = glob.glob(os.path.join(self.dir, "mongodb-*", "bin", "*.dll"))
             for dll in dlls:
+                log(dll)
                 os.rename(dll, os.path.join("bin", os.path.basename(dll)))
 
         os.remove(local)

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -109,7 +109,7 @@ class Main:
                 exe += ".exe"
             os.rename(os.path.join(extracted[0], exe), os.path.join("bin", exe))
 
-        if platform.system() == "Windows":
+        if platform.system() == "Windows" and not shell_only:
             dlls = glob.glob(os.path.join(self.dir, "mongodb-*", "bin", "*.dll"))
             for dll in dlls:
                 log(dll)

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -109,6 +109,7 @@ class Main:
                 exe += ".exe"
             os.rename(os.path.join(extracted[0], exe), os.path.join("bin", exe))
 
+        # Copy dlls on Windows, but don't copy for the shell since we don't want to copy the dlls twice.
         if platform.system() == "Windows" and not shell_only:
             dlls = glob.glob(os.path.join(self.dir, "mongodb-*", "bin", "*.dll"))
             for dll in dlls:

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -104,7 +104,6 @@ class Main:
             wanted = ["mongo", "mongos", "mongod"]
 
         for exe in wanted:
-            log(exe)
             if platform.system() == "Windows":
                 exe += ".exe"
             os.rename(os.path.join(extracted[0], exe), os.path.join("bin", exe))
@@ -113,7 +112,6 @@ class Main:
         if platform.system() == "Windows" and not shell_only:
             dlls = glob.glob(os.path.join(self.dir, "mongodb-*", "bin", "*.dll"))
             for dll in dlls:
-                log(dll)
                 os.rename(dll, os.path.join("bin", os.path.basename(dll)))
 
         os.remove(local)

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -104,6 +104,7 @@ class Main:
             wanted = ["mongo", "mongos", "mongod"]
 
         for exe in wanted:
+            log(exe)
             if platform.system() == "Windows":
                 exe += ".exe"
             os.rename(os.path.join(extracted[0], exe), os.path.join("bin", exe))


### PR DESCRIPTION
`download_mongod_and_shell.py` copies dlls to `bin` on Windows. 

Evg: https://spruce.mongodb.com/version/62d5a134850e6108ac50aac0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC