### PR TITLE
TOOLS-2913 Prompt for SSL key password when key is encrypted

### DIFF
--- a/common/db/db.go
+++ b/common/db/db.go
@@ -450,7 +450,7 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 		}
 
 		var x509Subject string
-		var keyPasswd string
+		keyPasswd := opts.SSL.SSLPEMKeyPassword
 		var err error
 		if cs.SSLClientCertificateKeyPasswordSet && cs.SSLClientCertificateKeyPassword != nil {
 			keyPasswd = cs.SSLClientCertificateKeyPassword()

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -689,7 +689,7 @@ func (opts *ToolOptions) NormalizeOptionsAndURI() error {
 
 	// finalize auth options, filling in missing passwords
 	if opts.Auth.ShouldAskForPassword() {
-		pass, err := password.Prompt()
+		pass, err := password.Prompt("mongo user")
 		if err != nil {
 			return fmt.Errorf("error reading password: %v", err)
 		}
@@ -701,7 +701,7 @@ func (opts *ToolOptions) NormalizeOptionsAndURI() error {
 		return fmt.Errorf("error determining whether client cert needs password: %v", err)
 	}
 	if shouldAskForSSLPassword {
-		pass, err := password.Prompt()
+		pass, err := password.Prompt("client certificate")
 		if err != nil {
 			return fmt.Errorf("error reading password: %v", err)
 		}

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -9,6 +9,7 @@
 package options
 
 import (
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -384,6 +385,36 @@ func (auth *Auth) ShouldAskForPassword() bool {
 		!(auth.Mechanism == "MONGODB-X509" || auth.Mechanism == "GSSAPI")
 }
 
+// ShouldAskForPassword returns true if the user specifies a ssl pem key file
+// flag but no password for that file, and the key file has any encrypted
+// blocks.
+func (ssl *SSL) ShouldAskForPassword() (bool, error) {
+	if ssl.SSLPEMKeyFile == "" || ssl.SSLPEMKeyPassword != "" {
+		return false, nil
+	}
+	return ssl.pemKeyFileHasEncryptedKey()
+}
+
+func (ssl *SSL) pemKeyFileHasEncryptedKey() (bool, error) {
+	b, err := ioutil.ReadFile(ssl.SSLPEMKeyFile)
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		var v *pem.Block
+		v, b = pem.Decode(b)
+		if v == nil {
+			break
+		}
+		if v.Type == "ENCRYPTED PRIVATE KEY" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func NewURI(unparsed string) (*URI, error) {
 	cs, err := connstring.Parse(unparsed)
 	if err != nil {
@@ -663,6 +694,18 @@ func (opts *ToolOptions) NormalizeOptionsAndURI() error {
 			return fmt.Errorf("error reading password: %v", err)
 		}
 		opts.Auth.Password = pass
+	}
+
+	shouldAskForSSLPassword, err := opts.SSL.ShouldAskForPassword()
+	if err != nil {
+		return fmt.Errorf("error determining whether client cert needs password: %v", err)
+	}
+	if shouldAskForSSLPassword {
+		pass, err := password.Prompt()
+		if err != nil {
+			return fmt.Errorf("error reading password: %v", err)
+		}
+		opts.SSL.SSLPEMKeyPassword = pass
 	}
 
 	err = opts.ConnString.Validate()

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -148,14 +148,14 @@ func TestVerbosityFlag(t *testing.T) {
 }
 
 type uriTester struct {
-	Name                 string
-	CS                   connstring.ConnString
-	OptsIn               *ToolOptions
-	OptsExpected         *ToolOptions
-	WithSSL              bool
-	WithGSSAPI           bool
-	ShouldError          bool
-	ShouldAskForPassword bool
+	Name                     string
+	CS                       connstring.ConnString
+	OptsIn                   *ToolOptions
+	OptsExpected             *ToolOptions
+	WithSSL                  bool
+	WithGSSAPI               bool
+	ShouldError              bool
+	AuthShouldAskForPassword bool
 }
 
 func TestParseAndSetOptions(t *testing.T) {
@@ -430,7 +430,7 @@ func TestParseAndSetOptions(t *testing.T) {
 				ShouldError: false,
 			},
 			{
-				Name: "should ask for password",
+				Name: "should ask for user password",
 				CS: connstring.ConnString{
 					AuthMechanism: "MONGODB-X509",
 					AuthSource:    "",
@@ -462,8 +462,8 @@ func TestParseAndSetOptions(t *testing.T) {
 					Kerberos:       &Kerberos{},
 					enabledOptions: EnabledOptions{Connection: true, URI: true},
 				},
-				ShouldError:          false,
-				ShouldAskForPassword: true,
+				ShouldError:              false,
+				AuthShouldAskForPassword: true,
 			},
 			{
 				Name: "single connect sets 'Direct'",
@@ -640,7 +640,7 @@ func TestParseAndSetOptions(t *testing.T) {
 				So(testCase.OptsIn.Kerberos.Service, ShouldResemble, testCase.OptsExpected.Kerberos.Service)
 				So(testCase.OptsIn.Kerberos.ServiceHost, ShouldResemble, testCase.OptsExpected.Kerberos.ServiceHost)
 				So(testCase.OptsIn.RetryWrites, ShouldResemble, testCase.OptsExpected.RetryWrites)
-				So(testCase.OptsIn.Auth.ShouldAskForPassword(), ShouldEqual, testCase.OptsIn.ShouldAskForPassword())
+				So(testCase.OptsIn.Auth.ShouldAskForPassword(), ShouldEqual, testCase.OptsExpected.Auth.ShouldAskForPassword())
 			}
 		})
 	})
@@ -940,8 +940,8 @@ func TestOptionsParsing(t *testing.T) {
 			{"--sslCAFile", "sslCertificateAuthorityFile", "foo", "bar"},
 			{"--sslCAFile", "tlsCAFile", "foo", "bar"},
 
-			{"--sslPEMKeyFile", "sslClientCertificateKeyFile", "foo", "bar"},
-			{"--sslPEMKeyFile", "tlsCertificateKeyFile", "foo", "bar"},
+			{"--sslPEMKeyFile", "sslClientCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
+			{"--sslPEMKeyFile", "tlsCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
 
 			{"--sslPEMKeyPassword", "sslClientCertificateKeyPassword", "foo", "bar"},
 			{"--sslPEMKeyPassword", "tlsCertificateKeyFilePassword", "foo", "bar"},

--- a/common/password/password.go
+++ b/common/password/password.go
@@ -28,16 +28,16 @@ const (
 
 // Prompt displays a prompt asking for the password and returns the
 // password the user enters as a string.
-func Prompt() (string, error) {
+func Prompt(what string) (string, error) {
 	var pass string
 	var err error
 	if IsTerminal() {
 		log.Logv(log.DebugLow, "standard input is a terminal; reading password from terminal")
-		fmt.Fprintf(os.Stderr, "Enter password:")
+		fmt.Fprintf(os.Stderr, "Enter password for %s:", what)
 		pass, err = readPassInteractively()
 	} else {
 		log.Logv(log.Always, "reading password from standard input")
-		fmt.Fprintf(os.Stderr, "Enter password:")
+		fmt.Fprintf(os.Stderr, "Enter password for %s:", what)
 		pass, err = readPassNonInteractively(os.Stdin)
 	}
 	if err != nil {

--- a/mongostat/main/mongostat.go
+++ b/mongostat/main/mongostat.go
@@ -113,7 +113,7 @@ func main() {
 	// we have to check this here, otherwise the user will be prompted
 	// for a password for each discovered node
 	if opts.Auth.ShouldAskForPassword() {
-		pass, err := password.Prompt()
+		pass, err := password.Prompt("mongo user")
 		if err != nil {
 			log.Logvf(log.Always, "Failed: %v", err)
 			os.Exit(util.ExitFailure)


### PR DESCRIPTION
I tested this by hand by running the following command:

    go run ./mongodump/main/ --ssl --sslPEMKeyFile=./common/db/testdata/test-client-pkcs8-encrypted.pem

This prompted me for the password.