### PR TITLE
TOOLS-3179: update enterprise repo config

### DIFF
--- a/etc/repo-config.yml
+++ b/etc/repo-config.yml
@@ -380,7 +380,7 @@ repos:
   - name: rhel83
     type: rpm
     edition: enterprise
-    bucket: repo.mongodb.org
+    bucket: repo.mongodb.com
     repos:
       - yum/redhat/8/mongodb-enterprise
       - yum/redhat/8Server/mongodb-enterprise


### PR DESCRIPTION
This commit fixes a typo in the RHEL 83 enterprise repo configuration to point to the enterprise address at repo.mongodb.com instead of the community address, repo.mongodb.org.