### PR TITLE
TOOLS-3194 mongorestore cannot recover collection containing "\n"

### DIFF
--- a/mongorestore/ns/ns.go
+++ b/mongorestore/ns/ns.go
@@ -149,7 +149,7 @@ func processReplacement(from, to string) (re *regexp.Regexp, replacer string, er
 		matcher += string(c)
 		from = from[width:]
 	}
-	matcher = fmt.Sprintf("^%s$", matcher)
+	matcher = fmt.Sprintf("(?s)^%s$", matcher)
 	// The regexp we generated should always compile (it's not the user's fault)
 	re = regexp.MustCompile(matcher)
 

--- a/mongorestore/ns/ns_test.go
+++ b/mongorestore/ns/ns_test.go
@@ -128,6 +128,12 @@ func TestMatcher(t *testing.T) {
 			So(m.Has("restaurants.cafés"), ShouldBeTrue)
 			So(m.Has("ÿœp.tāx"), ShouldBeTrue)
 		})
+		Convey("'*'", func() {
+			m, err := NewMatcher([]string{"*"})
+			So(m, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(m.Has("test.\n"), ShouldBeTrue)
+		})
 	})
 	Convey("with invalid matcher", t, func() {
 		Convey("'$.user$'", func() {


### PR DESCRIPTION
use \s mod fix regexMatch failed

![image](https://user-images.githubusercontent.com/24381592/190308003-3bce1231-c7e9-4a06-b15e-25e5a6f7ac11.png)
