### PR TITLE
TOOLS-3185 Fix `TestMongorestoreTxns` failure with Server 6.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 
 !**/testdata/**
 
+/mongorestore/testdata/txntest/oplog.bson
+
 /temp*
 
 bin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ To run unit and integration tests:
 ```
 go test -v ./...
 ```
-If TOOLS_TESTING_UNIT is set to "true" in the environment, unit tests will run.
-If TOOLS_TESTING_INTEGRATION is set to "true" in the environment, integration tests will run.
+If TOOLS_TESTING_UNIT is set to a true value in the environment, unit tests will run.
+If TOOLS_TESTING_INTEGRATION is set to a true value in the environment, integration tests will run.
 
 Integration tests require a `mongod` (running on port 33333) while unit tests do not.
 

--- a/common.yml
+++ b/common.yml
@@ -165,24 +165,6 @@ functions:
         fi
         PATH=$PWD/bin:$PATH ./bin/mongod${extension}  --port ${mongod_port} $MONGOD_ARGS ${additional_args} --dbpath mongodb/db_files --setParameter=enableTestCommands=1 $storage_args
 
-  "start mongod cluster":
-    command: shell.exec
-    params:
-      working_dir: src/github.com/mongodb/mongo-tools
-      background: true
-      script: |
-        set -x
-        set -v
-        set -e
-        rm -rf mongodb/db_files mongodb/${logfile|run.log}
-        mkdir -p mongodb/db_files
-        MONGOD_ARGS="${mongod_args}"
-        if [ "${USE_TLS}" = "true" ]; then
-          MONGOD_ARGS="${mongod_args_tls}"
-        fi;
-        echo "Starting mongod cluster..."
-        PATH=$PWD/bin:$PATH ./bin/mongod${extension}  --port ${mongod_port} $MONGOD_ARGS ${additional_args} --dbpath mongodb/db_files --setParameter=enableTestCommands=1 --replSet repltester
-
   "wait for mongod to be ready":
     command: shell.exec
     params:
@@ -542,17 +524,6 @@ functions:
           set -e
           mkdir -p bin
 
-  "fetch ftdc":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src/github.com/mongodb/mongo-tools
-        script: |
-          set -x
-          set -v
-          set -e
-          GOPATH=$PWD go get github.com/10gen/ftdc-utils/cmd/ftdc
-
   "fetch golangci-lint":
     - command: shell.exec
       type: test
@@ -563,37 +534,6 @@ functions:
           set -v
           set -e
           curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.3
-
-  "create auth_user":
-    - command: shell.exec
-      params:
-        working_dir: src/github.com/mongodb/mongo-tools
-        script: |
-          set -x
-          set -v
-          set -e
-          ./bin/mongo --port ${mongod_port} admin --eval "db.createUser({user:\"authorizedUser\", pwd: \"authorizedPwd\", roles:[\"readWriteAnyDatabase\", \"clusterManager\"]});"
-
-  "create sharded_cluster":
-    - command: shell.exec
-      params:
-        working_dir: src/github.com/mongodb/mongo-tools
-        background: true
-        script: |
-          set -x
-          set -v
-          set -e
-          echo "starting sharded cluster"
-          mkdir -p /data/db/
-          PATH=./bin:$PATH ./bin/mongo --nodb --eval 'var d = new ShardingTest({shards:3, mongos:[{port:${mongod_port}}]}); while(true){sleep(1000)}'
-    - command: shell.exec
-      params:
-        working_dir: src/github.com/mongodb/mongo-tools
-        script: |
-          set -x
-          set -v
-          set -e
-          ./bin/mongo --nodb --eval 'var d; assert.soon(function(x){try{d = new Mongo("localhost:${mongod_port}"); return true} catch(e){return false}}, "timed out connection");d.setLogLevel(5, "write");'
 
   "create repl_set":
     - command: shell.exec

--- a/common/testtype/types.go
+++ b/common/testtype/types.go
@@ -46,7 +46,7 @@ const (
 
 func HasTestType(testType string) bool {
 	envVal := os.Getenv(testType)
-	return envVal == "true"
+	return envVal != ""
 }
 
 // Skip the test if the specified type is not being run.

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -24,7 +24,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const txnTestDataFile = "testdata/transactions.json"
+const txnTestDataFilePre61 = "testdata/transactions.json"
+const txnTestDataFile61Plus = "testdata/transactions-6.1.json"
 
 type txnTestDataMap map[string]*txnTestDataCase
 
@@ -41,7 +42,16 @@ func TestMongorestoreTxns(t *testing.T) {
 		t.Fatalf("No server available")
 	}
 
-	data, err := readTxnTestData(txnTestDataFile)
+	restore, err := getRestoreWithArgs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := txnTestDataFilePre61
+	if restore.serverVersion.GTE(db.Version{6, 1, 0}) {
+		file = txnTestDataFile61Plus
+	}
+	data, err := readTxnTestData(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// Test files with applyOps transaction entries for
+// MongoDB server versions <6.1 and >=6.1, respectively.
 const txnTestDataFilePre61 = "testdata/transactions.json"
 const txnTestDataFile61Plus = "testdata/transactions-6.1.json"
 

--- a/mongorestore/testdata/transactions-6.1.json
+++ b/mongorestore/testdata/transactions-6.1.json
@@ -1,0 +1,395 @@
+{
+    "not transaction": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"i","ns":"txntest.a","o":{"_id":0,"x":0},
+                "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}
+            }
+        ],
+        "ns": "txntest.a",
+        "postimage": [
+            {"_id":0,"x":0}
+        ]
+    },
+    "applyops not transaction": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.b","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.b","o":{"$v":2,"diff":{"u":{"x":1}}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ]
+                }
+            }
+        ],
+        "ns": "txntest.b",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "small, unprepared": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.c","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.c","o":{"$v":2,"diff":{"u":{"x":1}}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.c","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ]
+                },
+                "lsid":{"id":{"$binary":{"base64":"CK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            }
+        ],
+        "ns": "txntest.c",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "large, unprepared": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.d","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.d","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "count":6
+                },
+                "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            }
+        ],
+        "ns": "txntest.d",
+        "postimage": [
+            {"_id":0,"x":0},
+            {"_id":1,"x":1},
+            {"_id":2,"x":2},
+            {"_id":3,"x":3},
+            {"_id":4,"x":4},
+            {"_id":5,"x":5}
+        ]
+    },
+    "small, prepared, committed": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.e","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.e","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.e","o":{"$v":2,"diff":{"u":{"x":1}}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.e","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                            "commitTransaction":1,
+                            "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+                },
+                "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.e",
+        "postimage": [
+            {"_id":0,"x":1}
+        ]
+    },
+    "small, prepared, aborted": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.f","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.f","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.f","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.f","o":{"$v":2,"diff":{"u":{"x":1}}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.f","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{"abortTransaction":1 },
+                "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.f",
+        "postimage": []
+    },
+    "large, prepared, committed": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.g","o":{"_id":6,"x":6},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":7,"x":7},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":8,"x":8},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.g","o":{"_id":9,"x":9},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                            "commitTransaction":1,
+                            "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+                },
+                "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.g",
+        "postimage": [
+            {"_id":0,"x":0},
+            {"_id":1,"x":1},
+            {"_id":2,"x":2},
+            {"_id":3,"x":3},
+            {"_id":4,"x":4},
+            {"_id":5,"x":5},
+            {"_id":6,"x":6},
+            {"_id":7,"x":7},
+            {"_id":8,"x":8},
+            {"_id":9,"x":9}
+        ]
+    },
+    "large, prepared, aborted": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":5,"x":5},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.h","o":{"_id":6,"x":6},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":7,"x":7},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.h","o":{"_id":8,"x":8},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{"abortTransaction":1 },
+                "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+            }
+        ],
+        "ns": "txntest.h",
+        "postimage": []
+    },
+    "large, unprepared, incomplete": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.i","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"IK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            },
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.i","o":{"_id":2,"x":2},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":3,"x":3},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.i","o":{"_id":4,"x":4},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "partialTxn":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"IK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+            }
+        ],
+        "ns": "txntest.i",
+        "postimage": []
+    },
+    "small, prepared, incomplete": {
+        "ops": [
+            {
+                "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+                "op":"c","ns":"admin.$cmd",
+                "o":{
+                    "applyOps":[
+                        {"op":"i","ns":"txntest.j","o":{"_id":0,"x":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"i","ns":"txntest.j","o":{"_id":1,"x":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"u","ns":"txntest.j","o":{"$v":2,"diff":{"u":{"x":1}}},"o2":{"_id":0},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+                        {"op":"d","ns":"txntest.j","o":{"_id":1},
+                          "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+                    ],
+                    "prepare":true
+                },
+                "lsid":{"id":{"$binary":{"base64":"JK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+                "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+            }
+        ],
+        "ns": "txntest.j",
+        "postimage": []
+    }
+}

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -28,7 +28,7 @@ def main():
     )
     parser.add_argument(
         "--edition",
-        help="edition of MongoDB to use (e.g. 'targeted', 'enterprise'); defaults to 'base'",
+        help="edition of MongoDB to use, either 'community' or 'enterprise'; defaults to 'community'",
     )
     parser.add_argument(
         "--target",
@@ -121,7 +121,7 @@ class Main:
 class Wanted:
     def __init__(self, edition, version, target, arch):
         if not edition:
-            edition = "base"
+            edition = "community"
         if not arch:
             sys.exit("must specify --arch")
         if not target:
@@ -219,8 +219,14 @@ class UrlFinder:
         return True
 
     def is_correct_download(self, download):
+        edition = download["edition"]
         return (
-            download["edition"] == self.wanted.edition
+            (
+                (self.wanted.edition == "enterprise" and edition == "enterprise")
+                # The community edition used to be called "base" but is now
+                # called "targeted".
+                or (edition == "base" or edition == "targeted")
+            )
             and download["target"] == self.wanted.target
             and download["arch"] == self.wanted.arch
         )

--- a/scripts/download_mongod_and_shell.sh
+++ b/scripts/download_mongod_and_shell.sh
@@ -15,8 +15,13 @@ else
     arch="x86_64"
 fi
 
+edition="community"
+if [ "$mongo_edition" = "enterprise" ]; then
+    edition="enterprise"
+fi
+
 ./scripts/download_mongod_and_shell.py \
     --arch "$arch" \
-    --edition "$mongo_edition" \
+    --edition "$edition" \
     --target "$target" \
     --version "$mongo_version"


### PR DESCRIPTION
The old hard-coded data no longer worked with Server 6.1 as the format for
updates has changed.

This PR adds a new file with the new format to be used with Server 6.1+.

In the future, we might want to instead generate this data in the test. That
was the first approach I tried, but it's not possible to generate many
transaction scenarios with the Server API as it stands. Specifically,
generating a set of partial transactions or `abortTransaction` and
`commmitTransaction` ops isn't possible, as these are only created based on
Server internals.
