### PR TITLE
TOOLS-3203 Ignore config DB for full dump unless specified

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -586,6 +586,8 @@ func TestMongoDumpSkipsConfigDBForFullDump(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, dbNames, "config")
 	require.NotContains(t, dbNames, "local")
+	session.Database("config").Collection("testcol").Drop(nil)
+	session.Database("local").Collection("testcol").Drop(nil)
 }
 
 func TestMongoDumpValidateOptions(t *testing.T) {

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -565,29 +565,6 @@ func testDumpOneCollection(md *MongoDump, dumpDir string) {
 	})
 }
 
-func TestMongoDumpSkipsConfigDBForFullDump(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	log.SetWriter(ioutil.Discard)
-
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
-	require.NoError(t, err)
-	defer sessionProvider.Close()
-
-	md := simpleMongoDumpInstance()
-	md.SessionProvider = sessionProvider
-
-	session, err := sessionProvider.GetSession()
-	_, err = session.Database("config").Collection("testcol").InsertOne(nil, bson.M{})
-	require.NoError(t, err)
-
-	dbNames, err := md.GetValidDbs()
-	require.NoError(t, err)
-	require.NotContains(t, dbNames, "config")
-	require.NotContains(t, dbNames, "local")
-	session.Database("config").Collection("testcol").Drop(nil)
-	session.Database("local").Collection("testcol").Drop(nil)
-}
-
 func TestMongoDumpValidateOptions(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
@@ -1991,6 +1968,28 @@ func TestFailDuringResharding(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
 		})
-
 	})
+}
+
+func TestMongoDumpSkipsConfigDBForFullDump(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	log.SetWriter(ioutil.Discard)
+
+	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	require.NoError(t, err)
+	defer sessionProvider.Close()
+
+	md := simpleMongoDumpInstance()
+	md.SessionProvider = sessionProvider
+
+	session, err := sessionProvider.GetSession()
+	_, err = session.Database("config").Collection("testcol").InsertOne(nil, bson.M{})
+	require.NoError(t, err)
+
+	dbNames, err := md.GetValidDbs()
+	require.NoError(t, err)
+	require.NotContains(t, dbNames, "config")
+	require.NotContains(t, dbNames, "local")
+	session.Database("config").Collection("testcol").Drop(nil)
+	session.Database("local").Collection("testcol").Drop(nil)
 }

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -579,8 +579,6 @@ func TestMongoDumpSkipsConfigDBForFullDump(t *testing.T) {
 	session, err := sessionProvider.GetSession()
 	_, err = session.Database("config").Collection("testcol").InsertOne(nil, bson.M{})
 	require.NoError(t, err)
-	_, err = session.Database("local").Collection("testcol").InsertOne(nil, bson.M{})
-	require.NoError(t, err)
 
 	dbNames, err := md.GetValidDbs()
 	require.NoError(t, err)

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1866,6 +1866,8 @@ func TestFailDuringResharding(t *testing.T) {
 		md.ToolOptions.Namespace = &options.Namespace{}
 		err = md.Init()
 		So(err, ShouldBeNil)
+		// Hack to not fail validating inputs on both --db and --oplog being specified.
+		md.ToolOptions.DB = "config"
 
 		DefaultErrorMsg := "detected resharding in progress. Cannot dump with --oplog while resharding"
 		OplogErrorMsg := "cannot dump with oplog while resharding"


### PR DESCRIPTION
We intermittently get bugs about authorization errors because we don't skip all of the config.* collections that we should in mongodump and mongorestore. 

For **mongodump** instead of blacklisting collections, we can skip the config DB entirely on a full dump, unless it is explicitly specified (eg by passing --db="config").

I didn't modify `shouldSkipSystemNamespace`, and that means that when specifying --db="config", you still won't get collections in the system blacklist dumped. The only way to include collections in the blacklist is to specify both --db="config" and --collection=<collection_in_blacklist>.


For **mongorestore**, instead of creating intents on all DBs, we skip the config DB entirely on a full dump, unless one of the two following scenarios happen:

1. --db="config" is passed in
2. Any --nsInclude filter(s) are passed. In this case we rely on the Matcher matchstring and include all namespaces in the export that match the configured patterns. The result will be that config namespaces will be skipped, unless matched by this filter.


