### PR TITLE
BF-27644 Fix atlas proxy detection for sharded clusters

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -141,7 +141,8 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		&bson.M{"atlasVersion": 1},
 	)
 	if result.Err() != nil {
-		if strings.Contains(result.Err().Error(), "no such command") {
+		// Sharded clusters use "cmd" and non-sharded clusters use "command".
+		if strings.Contains(result.Err().Error(), "no such command") || strings.Contains(result.Err().Error(), "no such cmd") {
 			return false, nil
 		}
 		return false, result.Err()

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -140,7 +140,6 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		context.Background(),
 		&bson.M{"atlasVersion": 1},
 	)
-
 	if result.Err() != nil {
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -142,7 +142,6 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 	)
 
 	if result.Err() != nil {
-		// Sharded clusters use "cmd" and non-sharded clusters use "command".
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -140,9 +140,10 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		context.Background(),
 		&bson.M{"atlasVersion": 1},
 	)
+
 	if result.Err() != nil {
 		// Sharded clusters use "cmd" and non-sharded clusters use "command".
-		if strings.Contains(result.Err().Error(), "no such command") || strings.Contains(result.Err().Error(), "no such cmd") {
+		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}
 		return false, result.Err()

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1996,7 +1996,7 @@ func TestFailDuringResharding(t *testing.T) {
 			close(done)
 
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, DefaultErrorMsg)
+			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
 		})
 
 	})

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1996,7 +1996,7 @@ func TestFailDuringResharding(t *testing.T) {
 			close(done)
 
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
+			So(err.Error(), ShouldContainSubstring, DefaultErrorMsg)
 		})
 
 	})


### PR DESCRIPTION
For some reason, on replica sets the error message is: "MongoServerError: no such command: 'atlasVersion'" and on sharded clusters the error message is: "MongoServerError: no such cmd: atlasVersion". 

This should account for both scenarios.

It turns out that a careful examination of the tests could have uncovered this: https://evergreen.mongodb.com/lobster/evergreen/complete-test/mongo_tools_rhel80_qa_tests_6.0_5d5402b0da91ca3a99a3d19f0265d98cae16a7f6_23_01_26_16_28_49/0#bookmarks=0%2C201199%2C460654&f~=000~sharded_fullrestore&f~=000~CommandNotFound&l=1&shareLine=201199 but it was quite hard to find after the fact (unless I know the exact failure mode).

