### PR TITLE
TOOLS-3241 Fix TestFailDuringResharding so it doesn't sometimes error with a different message

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1927,6 +1927,7 @@ func TestFailDuringResharding(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, DefaultErrorMsg)
 		})
 
+		md.ToolOptions.DB = "test"
 		Convey("dump should fail if config.reshardingOperations created in oplog", func() {
 			failpoint.ParseFailpoints("PauseBeforeDumping")
 			defer failpoint.Reset()

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1197,7 +1197,7 @@ func TestMongoDumpTOOLS2498(t *testing.T) {
 		err = md.Dump()
 		// Mongodump should not panic, but return correct error if failed to getCollectionInfo
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "client is disconnected")
+		So(err.Error(), ShouldContainSubstring, "client is disconnected")
 	})
 }
 

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1927,7 +1927,6 @@ func TestFailDuringResharding(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, DefaultErrorMsg)
 		})
 
-		md.ToolOptions.DB = "test"
 		Convey("dump should fail if config.reshardingOperations created in oplog", func() {
 			failpoint.ParseFailpoints("PauseBeforeDumping")
 			defer failpoint.Reset()

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1931,21 +1931,13 @@ func TestFailDuringResharding(t *testing.T) {
 			failpoint.ParseFailpoints("PauseBeforeDumping")
 			defer failpoint.Reset()
 
-			done := make(chan struct{})
 			go func() {
-				select {
-				case <-done:
-					return
-				default:
-					session.Database("config").CreateCollection(ctx, "reshardingOperations")
-					time.Sleep(1 * time.Second)
-					session.Database("config").Collection("reshardingOperations").Drop(ctx)
-					time.Sleep(1 * time.Second)
-				}
+				time.Sleep(2 * time.Second)
+				session.Database("config").CreateCollection(ctx, "reshardingOperations")
+				session.Database("config").Collection("reshardingOperations").Drop(ctx)
 			}()
 
 			err = md.Dump()
-			close(done)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1947,21 +1947,13 @@ func TestFailDuringResharding(t *testing.T) {
 			failpoint.ParseFailpoints("PauseBeforeDumping")
 			defer failpoint.Reset()
 
-			done := make(chan struct{})
 			go func() {
-				select {
-				case <-done:
-					return
-				default:
-					session.Database("config").CreateCollection(ctx, "localReshardingOperations.donor")
-					time.Sleep(1 * time.Second)
-					session.Database("config").Collection("localReshardingOperations.donor").Drop(ctx)
-					time.Sleep(1 * time.Second)
-				}
+				time.Sleep(2 * time.Second)
+				session.Database("config").CreateCollection(ctx, "localReshardingOperations.donor")
+				session.Database("config").Collection("localReshardingOperations.donor").Drop(ctx)
 			}()
 
 			err = md.Dump()
-			close(done)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
@@ -1971,21 +1963,13 @@ func TestFailDuringResharding(t *testing.T) {
 			failpoint.ParseFailpoints("PauseBeforeDumping")
 			defer failpoint.Reset()
 
-			done := make(chan struct{})
 			go func() {
-				select {
-				case <-done:
-					return
-				default:
-					session.Database("config").CreateCollection(ctx, "localReshardingOperations.recipient")
-					time.Sleep(1 * time.Second)
-					session.Database("config").Collection("localReshardingOperations.recipient").Drop(ctx)
-					time.Sleep(1 * time.Second)
-				}
+				time.Sleep(2 * time.Second)
+				session.Database("config").CreateCollection(ctx, "localReshardingOperations.recipient")
+				session.Database("config").Collection("localReshardingOperations.recipient").Drop(ctx)
 			}()
 
 			err = md.Dump()
-			close(done)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)


### PR DESCRIPTION
In the last 3 sub-tests of TestFailDuringResharding, it expects to fail when trying to dump the oplog, but it fails earlier, when it tries to create the intents for a database. This is a flaky test, most of the time it seems that it doesn't error early, but it is possible. We can skip creating the intents for the database if we specify a database, but it should still try to dump the oplog since its specified. This will ensure that it doesn't error on the earlier case and fail on that string comparison.

An example error is here: https://evergreen.mongodb.com/lobster/evergreen/test/mongo_tools_rhel83_s390x_integration_5.0_cluster_patch_5d5402b0da91ca3a99a3d19f0265d98cae16a7f6_63dbec3ed1fe074e9be5a1da_23_02_02_17_00_47/0/mongodump/#bookmarks=0%2C212&l=1&shareLine=131