### PR TITLE
TOOLS-3202: Fix legacy-jstests failure with latest Server (6.1)

### DIFF
--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -64,7 +64,7 @@ class Main:
         if self.wanted.is_latest() or version_is_greater_or_equal(
             self.wanted.version, "6.0"
         ):
-            for version in ["5.3", "5.2", "5.1", "5.0"]:
+            for version in ["6.3", "5.3", "5.2", "5.1", "5.0"]:
                 finder.wanted.version = version
                 url = finder.url_for_wanted()
                 if url:

--- a/test/legacy42/jstests/tool/gridfs.js
+++ b/test/legacy42/jstests/tool/gridfs.js
@@ -1,7 +1,7 @@
 // tests gridfs with a sharded fs.chunks collection.
 // @tags: [requires_sharding]
 
-var test = new ShardingTest({shards: 3, mongos: 1, verbose: 2, other: {chunkSize: 1}});
+var test = new ShardingTest({shards: 3, mongos: 1, config: 1, verbose: 2, other: {chunkSize: 1}});
 
 var mongos = test.s0;
 

--- a/test/legacy42/jstests/tool/gridfs.js
+++ b/test/legacy42/jstests/tool/gridfs.js
@@ -1,7 +1,7 @@
 // tests gridfs with a sharded fs.chunks collection.
 // @tags: [requires_sharding]
 
-var test = new ShardingTest({shards: 3, mongos: 1, config: 1, verbose: 2, other: {chunkSize: 1}});
+var test = new ShardingTest({shards: 3, mongos: 1, verbose: 2, other: {chunkSize: 1}});
 
 var mongos = test.s0;
 


### PR DESCRIPTION
This reverts commit 0e98667.