### PR TITLE
TOOLS-3248: Change the expected behavior of --noIndexRestore in TestRestoreTimeseriesCollections for server 6.3+

### DIFF
--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1970,7 +1970,13 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 				numIndexes++
 			}
 
-			So(numIndexes, ShouldEqual, 0)
+			if (restore.serverVersion.GTE(db.Version{6, 3, 0})) {
+				Convey("--noIndexRestore should make no impact on the default meta, time index for time-series collections if server version >= 6.3.0", func() {
+					So(numIndexes, ShouldEqual, 1)
+				})
+			} else {
+				So(numIndexes, ShouldEqual, 0)
+			}
 
 			cur, err := testdb.ListCollections(ctx, bson.M{"name": "system.buckets.foo_ts"})
 			So(err, ShouldBeNil)

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1971,7 +1971,7 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 			}
 
 			if (restore.serverVersion.GTE(db.Version{6, 3, 0})) {
-				Convey("--noIndexRestore should make no impact on the default meta, time index for time-series collections if server version >= 6.3.0", func() {
+				Convey("--noIndexRestore should build the index on meta, time by default for time-series collections if server version >= 6.3.0", func() {
 					So(numIndexes, ShouldEqual, 1)
 				})
 			} else {


### PR DESCRIPTION
In older server versions, running `mongorestore` with `--noIndexRestore` creates a time series collection with no index. In the current `TestRestoreTimeseriesCollections` test, we check this by listing the indexes from the collection and expect no index to be created.

After [SERVER-66689](https://jira.mongodb.org/browse/SERVER-66689), the server automatically creates a default index on timestamp, metadata fields in time series collections upon creation. This causes `TestRestoreTimeseriesCollections` to [fail](https://parsley.mongodb.com/test/mongo_tools_amazon2_integration_latest_252cab37f1c57910db9eef2950a47ef83a5c4c50_23_02_16_17_12_14/0/mongorestore?bookmarks=0,854&shareLine=549). We should modify the test to check the server version and expect 1 index for server versions 6.3+.