### PR TITLE
TOOLS-3249: Remove mongo-tools support for server version 3.4 on MacOS

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2307,9 +2307,9 @@ buildvariants:
       smoke_use_tls: --use-tls
       resmoke_use_tls: _tls
       USE_SSL: "true"
+    # We removed support for 3.4 on MacOS in TOOLS-3249
     tasks:
       - name: "unit"
-      - name: ".3.4"
       - name: ".3.6"
       - name: ".4.0"
       - name: ".4.2"


### PR DESCRIPTION
This is removed to prepare for upgrading Go to 1.19.