### PR TITLE
TOOLS-3250: Fix aws-auth task failures

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1093,6 +1093,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "5.0"
       - func: "start mongod"
         vars:
@@ -1181,6 +1182,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "5.1"
       - func: "start mongod"
         vars:
@@ -1269,6 +1271,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "5.2"
       - func: "start mongod"
         vars:
@@ -1357,6 +1360,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "5.3"
       - func: "start mongod"
         vars:
@@ -1445,6 +1449,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "6.0"
       - func: "start mongod"
         vars:
@@ -1533,6 +1538,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "latest"
       - func: "start mongod"
         vars:
@@ -1553,6 +1559,7 @@ tasks:
       - command: expansions.update
       - func: "download mongod and shell"
         vars:
+          edition: "enterprise"
           mongo_version: "4.4"
       - func: "start mongod"
         vars:

--- a/scripts/download_mongod_and_shell.py
+++ b/scripts/download_mongod_and_shell.py
@@ -28,7 +28,7 @@ def main():
     )
     parser.add_argument(
         "--edition",
-        help="edition of MongoDB to use, either 'community' or 'enterprise'; defaults to 'community'",
+        help="edition of MongoDB to use, either 'targeted' or 'enterprise'; defaults to 'targeted'",
     )
     parser.add_argument(
         "--target",
@@ -121,7 +121,7 @@ class Main:
 class Wanted:
     def __init__(self, edition, version, target, arch):
         if not edition:
-            edition = "community"
+            edition = "targeted"
         if not arch:
             sys.exit("must specify --arch")
         if not target:
@@ -225,7 +225,8 @@ class UrlFinder:
                 (self.wanted.edition == "enterprise" and edition == "enterprise")
                 # The community edition used to be called "base" but is now
                 # called "targeted".
-                or (edition == "base" or edition == "targeted")
+                or ((edition == "base" or edition == "targeted")
+                    and (self.wanted.edition == "base" or self.wanted.edition == "targeted"))
             )
             and download["target"] == self.wanted.target
             and download["arch"] == self.wanted.arch

--- a/scripts/download_mongod_and_shell.sh
+++ b/scripts/download_mongod_and_shell.sh
@@ -15,7 +15,6 @@ else
     arch="x86_64"
 fi
 
-edition="community"
 if [ "$mongo_edition" = "enterprise" ]; then
     edition="enterprise"
 fi


### PR DESCRIPTION
- Changed edition name "community" to "targeted".
- Fixed a bug in `is_correct_download` method.
- Added arguments to specify `enterprise` edition for `aws-auth` tasks.
- [Tests](https://evergreen.mongodb.com/version/63ee78e82fbabe2cd3d7ba69)