### PR TITLE
 TOOLS-3251: Update common.yml to run tests with 6.3 

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1463,6 +1463,95 @@ tasks:
         vars:
           target: test:awsauth
 
+  - name: integration-6.3
+    tags: [ "6.3" ]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.3"
+      - func: "start mongod"
+        vars:
+          USE_TLS: "true"
+      - func: "wait for mongod to be ready"
+        vars:
+          USE_TLS: "true"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:integration test:srv -ssl=true
+
+  - name: integration-6.3-auth
+    tags: [ "6.3", "auth" ]
+    commands:
+      - func: "fetch source"
+      # Concat auth args
+      - command: expansions.update
+        params:
+          updates:
+            - key: "mongod_args_tls"
+              concat: " --auth"
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.3"
+      - func: "start mongod"
+        vars:
+          USE_TLS: "true"
+      - func: "wait for mongod to be ready"
+        vars:
+          USE_TLS: "true"
+      - func: "create mongod users"
+        vars:
+          USE_TLS: "true"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:integration test:srv -ssl=true -auth=true
+
+  - name: integration-6.3-cluster
+    tags: [ "6.3", "cluster" ]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.3"
+      - func: "create repl_set"
+        vars:
+          USE_TLS: "true"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:integration test:srv -ssl=true -topology=replSet
+
+  - name: aws-auth-6.3
+    tags: [ "6.3", "aws-auth" ]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          edition: "enterprise"
+          mongo_version: "6.3"
+      - func: "start mongod"
+        vars:
+          AWS_AUTH: "true"
+      - func: "wait for mongod to be ready"
+        vars:
+          AWS_AUTH: "true"
+      - func: "add-aws-auth-variables-to-file"
+      - func: "setup-aws-auth-test-with-assume-role-credentials"
+      - func: "run make target"
+        vars:
+          target: test:awsauth
+
   - name: integration-latest
     tags: ["latest"]
     commands:
@@ -1703,6 +1792,22 @@ tasks:
         vars:
           test_path: "test/legacy42"
 
+  - name: legacy-jstests-6.3 # The server jstests from the tools removal from server in 4.2
+    tags: ["6.3"]
+    commands:
+      - func: "fetch source"
+      - func: "get buildnumber"
+      - func: "setup credentials"
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.3"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run legacy tests"
+        vars:
+          test_path: "test/legacy42"
+
   - name: legacy-jstests-latest # The server jstests from the tools removal from server in 4.2
     tags: ["latest"]
     commands:
@@ -1850,6 +1955,23 @@ tasks:
       - func: "download mongod and shell"
         vars:
           mongo_version: "6.0"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run qa-tests"
+        vars:
+          resmoke_suite: "core${resmoke_use_tls}"
+          excludes: "requires_unstable,${excludes}"
+
+  - name: qa-tests-6.3
+    tags: ["6.3"]
+    commands:
+      - func: "fetch source"
+      - func: "get buildnumber"
+      - func: "setup credentials"
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.3"
       - func: "run make target"
         vars:
           target: build
@@ -2140,6 +2262,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2248,6 +2371,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2282,6 +2406,7 @@ buildvariants:
       - name: "unit"
       - name: ".5.0"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2324,6 +2449,7 @@ buildvariants:
       - name: ".5.0 !.aws-auth"
       - name: ".5.3 !.aws-auth"
       - name: ".6.0 !.aws-auth"
+      - name: ".6.3 !.aws-auth"
       - name: ".latest !.aws-auth"
       - name: ".kerberos"
       - name: "dist"
@@ -2432,6 +2558,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2470,6 +2597,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2502,6 +2630,7 @@ buildvariants:
     tasks:
       - name: "unit"
       #  - name: ".6.0"
+      #  - name: ".6.3"
       #  - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2547,6 +2676,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: "dist"
       - name: "sign"
@@ -2582,6 +2712,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: "dist"
       - name: "sign"
@@ -2658,6 +2789,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2693,6 +2825,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2725,6 +2858,7 @@ buildvariants:
     tasks:
       - name: "unit"
       #  - name: ".6.0"
+      #  - name: ".6.3"
       #  - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2773,6 +2907,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2854,6 +2989,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2893,6 +3029,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2928,6 +3065,7 @@ buildvariants:
     tasks:
       - name: "unit"
       #  - name: ".6.0"
+      #  - name: ".6.3"
       #  - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -2967,6 +3105,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -3005,6 +3144,7 @@ buildvariants:
       - name: ".5.0"
       - name: ".5.3"
       - name: ".6.0"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"
@@ -3087,6 +3227,7 @@ buildvariants:
       - name: ".5.0 !.aws-auth"
       - name: ".5.3 !.aws-auth"
       - name: ".6.0 !.aws-auth"
+      - name: ".6.3 !.aws-auth"
       - name: ".latest !.aws-auth"
       - name: ".kerberos"
       - name: "dist"
@@ -3201,6 +3342,7 @@ buildvariants:
       # 6.x release in the future, but there is no 6.0.
       - name: ".5.1"
       - name: ".5.2"
+      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"


### PR DESCRIPTION
Adds `integration`, `legacy-js-tests`, `aws-auth`, and `qa-tests` for server 6.3 in evergreen. 6.3 tests are added to the following buildvariants:
- Amazon Linux 64 v2
- Debian 10
- Debian 11
- MacOS 10.14
- RHEL 7.0
- RHEL 8.0
- SUSE 12
- SUSE 15
- Ubuntu 18.04
- Ubuntu 20.04
- Windows 64-bit
- ZAP ARM64 Ubuntu 18.04
- ZAP ARM64 Ubuntu 20.04
- Amazon Linux ARM v2
- RHEL 8.2 ARM
- ZAP PPC64LE RHEL 8.1
- ZAP s390x RHEL 7.2