### PR TITLE
TOOLS-3255: Fix qa-tests-3.4

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -145,7 +145,7 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 			return false, nil
 		}
 		// For server 3.4 and below.
-		if strings.Contains(result.Err().Error(), "no such cmd") {
+		if strings.Contains(result.Err().Error(), "no such cmd") || strings.Contains(result.Err().Error(), "no such command") {
 			return false, nil
 		}
 		return false, result.Err()

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -141,9 +141,11 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		&bson.M{"atlasVersion": 1},
 	)
 	if result.Err() != nil {
+		// For server version 3.4+.
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}
+		// For server version 3.4 and below.
 		if strings.Contains(result.Err().Error(), "no such cmd") {
 			return false, nil
 		}

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -141,11 +141,10 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		&bson.M{"atlasVersion": 1},
 	)
 	if result.Err() != nil {
-		// For server version 3.4+.
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}
-		// For server version 3.4 and below.
+		// For server 3.4 and below.
 		if strings.Contains(result.Err().Error(), "no such cmd") {
 			return false, nil
 		}

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -144,7 +144,9 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}
-		return false, result.Err()
+		if strings.Contains(result.Err().Error(), "no such cmd") {
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -148,6 +148,7 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		if strings.Contains(result.Err().Error(), "no such cmd") {
 			return false, nil
 		}
+		return false, result.Err()
 	}
 
 	return true, nil


### PR DESCRIPTION
This PR fixes test failures on server 3.4. This fix should make `IsAtlasProxy` method in `SessionProvider` backward compatible with server 3.4.