### PR TITLE
TOOLS-3202: Fix legacy-jstests failure with latest Server 

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -49,7 +49,7 @@ functions:
         chmod +x bin/*
         mv bin/* ${test_path}/
         cd ${test_path}
-        ./mongo --nodb jstests/tool/*.js
+        ./mongo --nodb lib/run_mongod.js jstests/tool/*.js
 
   "run qa-tests":
     command: subprocess.exec

--- a/test/legacy42/jstests/tool/restorewithauth.js
+++ b/test/legacy42/jstests/tool/restorewithauth.js
@@ -15,7 +15,7 @@
  */
 
 baseName = "jstests_restorewithauth";
-var conn = MongoRunner.runMongod({nojournal: "", bind_ip: "127.0.0.1"});
+var conn = MongoRunner.runMongod({bind_ip: "127.0.0.1"});
 
 // write to ns foo.bar
 var foo = conn.getDB("foo");
@@ -54,7 +54,7 @@ foo.dropDatabase();
 MongoRunner.stopMongod(conn);
 
 // start mongod with --auth
-conn = MongoRunner.runMongod({auth: "", nojournal: "", bind_ip: "127.0.0.1"});
+conn = MongoRunner.runMongod({auth: "", bind_ip: "127.0.0.1"});
 
 // admin user
 var admin = conn.getDB("admin");

--- a/test/legacy42/lib/run_mongod.js
+++ b/test/legacy42/lib/run_mongod.js
@@ -6,14 +6,16 @@
  *
  * MongoRunner.runMongod Starts a mongod instance.
  */
-var oldRunMongod = MongoRunner.runMongod;
+(function () {
+    var oldRunMongod = MongoRunner.runMongod;
 
-MongoRunner.runMongod = function(opts) {
-    print("MongoRunner.runMongod overriden in mongo-tools");
+    MongoRunner.runMongod = function (opts) {
+        print("MongoRunner.runMongod overriden in mongo-tools");
 
-    if (opts != undefined && opts.journal != undefined) {
-        delete opts.journal;
-    }
+        if (opts != undefined && opts.journal != undefined) {
+            delete opts.journal;
+        }
 
-    return oldRunMongod(opts);
-};
+        return oldRunMongod(opts);
+    };
+})()

--- a/test/legacy42/lib/run_mongod.js
+++ b/test/legacy42/lib/run_mongod.js
@@ -1,7 +1,8 @@
 /**
- * This file overrides MongoRunner.runMongod function in mongo shell to remove "journal" option before starting mongod
- * to make the deprecated mongo shell com
  * This file has to be loaded to mongo shell before loading js tests.
+ *
+ * This file overrides MongoRunner.runMongod function in mongo shell:
+ *  - Removes "journal" option before starting mongod to make the deprecated mongo shell compatible with MongoDB 6.1+
  *
  * MongoRunner.runMongod Starts a mongod instance.
  */

--- a/test/legacy42/lib/run_mongod.js
+++ b/test/legacy42/lib/run_mongod.js
@@ -9,7 +9,7 @@
 var oldRunMongod = MongoRunner.runMongod;
 
 MongoRunner.runMongod = function(opts) {
-    print("Running MongoRunner.runMongod overriden in mongo-tools");
+    print("MongoRunner.runMongod overriden in mongo-tools");
 
     if (opts != undefined && opts.journal != undefined) {
         delete opts.journal;

--- a/test/legacy42/lib/run_mongod.js
+++ b/test/legacy42/lib/run_mongod.js
@@ -1,0 +1,18 @@
+/**
+ * This file overrides MongoRunner.runMongod function in mongo shell to remove "journal" option before starting mongod
+ * to make the deprecated mongo shell com
+ * This file has to be loaded to mongo shell before loading js tests.
+ *
+ * MongoRunner.runMongod Starts a mongod instance.
+ */
+var oldRunMongod = MongoRunner.runMongod;
+
+MongoRunner.runMongod = function(opts) {
+    print("Running MongoRunner.runMongod overriden in mongo-tools");
+
+    if (opts != undefined && opts.journal != undefined) {
+        delete opts.journal;
+    }
+
+    return oldRunMongod(opts);
+};

--- a/test/legacy42/lib/run_mongod.js
+++ b/test/legacy42/lib/run_mongod.js
@@ -7,7 +7,7 @@
  * MongoRunner.runMongod Starts a mongod instance.
  */
 (function () {
-    var oldRunMongod = MongoRunner.runMongod;
+    let oldRunMongod = MongoRunner.runMongod;
 
     MongoRunner.runMongod = function (opts) {
         print("MongoRunner.runMongod overriden in mongo-tools");


### PR DESCRIPTION
This PR creates a workaround to make the deprecated mongo shell compatible with new MongoDB server versions by overriding JS functions used by mongo shell. It is a temporary fix to re-enable `legacy-jstests` in mongo-tools failed due to deprecated mongo shell commands.

[evergreen](https://evergreen.mongodb.com/version/63f68ffc61837d43cb6cb4e9?redirect_spruce_users=true)