### PR TITLE
TOOLS-3257: Override deprecated mongo shell functions to fix qa-tests-latest

### DIFF
--- a/test/qa-tests/buildscripts/resmokeconfig/suites/core_tls.yml
+++ b/test/qa-tests/buildscripts/resmokeconfig/suites/core_tls.yml
@@ -20,6 +20,7 @@ executor:
   js_test:
     config:
       shell_options:
+        eval_prepend: "load('jstests/libs/run_mongod.js');"
         global_vars:
           TestData:
             useTLS: true

--- a/test/qa-tests/jstests/libs/run_mongod.js
+++ b/test/qa-tests/jstests/libs/run_mongod.js
@@ -10,4 +10,4 @@
 
     return oldRunMongod(opts);
   };
-})()
+})();

--- a/test/qa-tests/jstests/libs/run_mongod.js
+++ b/test/qa-tests/jstests/libs/run_mongod.js
@@ -1,0 +1,14 @@
+// Wrap whole file in a function to avoid polluting the global namespace
+(function () {
+    let oldRunMongod = MongoRunner.runMongod;
+
+    MongoRunner.runMongod = function(opts) {
+        print("MongoRunner.runMongod overriden in mongo-tools");
+
+        if (opts != undefined && opts.journal != undefined) {
+            delete opts.journal;
+        }
+
+        return oldRunMongod(opts);
+    };
+})()

--- a/test/qa-tests/jstests/libs/run_mongod.js
+++ b/test/qa-tests/jstests/libs/run_mongod.js
@@ -5,7 +5,7 @@
     MongoRunner.runMongod = function(opts) {
         print("MongoRunner.runMongod overriden in mongo-tools");
 
-        if (opts != undefined && opts.journal != undefined) {
+        if (opts !== undefined && opts.journal !== undefined) {
             delete opts.journal;
         }
 

--- a/test/qa-tests/jstests/libs/run_mongod.js
+++ b/test/qa-tests/jstests/libs/run_mongod.js
@@ -10,4 +10,4 @@
 
     return oldRunMongod(opts);
   };
-})();
+}());

--- a/test/qa-tests/jstests/libs/run_mongod.js
+++ b/test/qa-tests/jstests/libs/run_mongod.js
@@ -1,14 +1,13 @@
 // Wrap whole file in a function to avoid polluting the global namespace
 (function () {
-    let oldRunMongod = MongoRunner.runMongod;
+  let oldRunMongod = MongoRunner.runMongod;
+  MongoRunner.runMongod = function(opts) {
+    print("MongoRunner.runMongod overriden in mongo-tools");
 
-    MongoRunner.runMongod = function(opts) {
-        print("MongoRunner.runMongod overriden in mongo-tools");
+    if (opts !== undefined && opts.journal !== undefined) {
+      delete opts.journal;
+    }
 
-        if (opts !== undefined && opts.journal !== undefined) {
-            delete opts.journal;
-        }
-
-        return oldRunMongod(opts);
-    };
+    return oldRunMongod(opts);
+  };
 })()


### PR DESCRIPTION
This PR fixes the qa-tests-latest by overriding `MongoRunner.runMongod` using `eval_prepend` shell option in the resmoke config file.