### PR TITLE
TOOLS-3259: Remove 6.3 tests on `ZAP s390x RHEL 7.2` and `ZAP PPC64LE RHEL 8.1`

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -3252,7 +3252,6 @@ buildvariants:
       - name: ".5.0 !.aws-auth"
       - name: ".5.3 !.aws-auth"
       - name: ".6.0 !.aws-auth"
-      - name: ".6.3 !.aws-auth"
       - name: ".latest !.aws-auth"
       - name: ".kerberos"
       - name: "dist"

--- a/common.yml
+++ b/common.yml
@@ -3335,7 +3335,6 @@ buildvariants:
       # 6.x release in the future, but there is no 6.0.
       - name: ".5.1"
       - name: ".5.2"
-      - name: ".6.3"
       - name: ".latest"
       - name: ".kerberos"
       - name: "dist"


### PR DESCRIPTION
There is no url to download server 6.3 from ZAP s390x RHEL 7.2 and ZAP PPC64LE RHEL 8.1. The 6.3 tests on these two systems should be removed.