### PR TITLE
TOOLS-3276: Skip columnstore indexes tests in mongodump and mongorestore if error is NotImplemented

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -2019,16 +2019,17 @@ func TestMongoDumpColumnstoreIndexes(t *testing.T) {
 		t.Skip("Requires server with FCV 6.3 or later")
 	}
 
-	require.NoError(t, setUpMongoDumpTestData())
-
 	// Create Columnstore indexes.
 	for _, colName := range testCollectionNames {
 		err := setUpColumnstoreIndex(testDB, colName)
 		if strings.Contains(err.Error(), "(NotImplemented) columnstore indexes are under development and cannot be used without enabling the feature flag") {
 			t.Skip("Requires columnstore indexes to be implemented")
+			return
 		}
 		require.NoError(t, err)
 	}
+
+	require.NoError(t, setUpMongoDumpTestData())
 
 	md := simpleMongoDumpInstance()
 	md.ToolOptions.Namespace.DB = testDB

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -2023,7 +2023,11 @@ func TestMongoDumpColumnstoreIndexes(t *testing.T) {
 
 	// Create Columnstore indexes.
 	for _, colName := range testCollectionNames {
-		require.NoError(t, setUpColumnstoreIndex(testDB, colName))
+		err := setUpColumnstoreIndex(testDB, colName)
+		if strings.Contains(err.Error(), "(NotImplemented) columnstore indexes are under development and cannot be used without enabling the feature flag") {
+			t.Skip("Requires columnstore indexes to be implemented")
+		}
+		require.NoError(t, err)
 	}
 
 	md := simpleMongoDumpInstance()

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -2437,6 +2437,10 @@ func createColumnstoreIndex(t *testing.T, testDB *mongo.Database, key string, co
 		}},
 	}
 	res = testDB.RunCommand(context.Background(), createIndexCmd, nil)
+	if strings.Contains(res.Err().Error(), "(NotImplemented) columnstore indexes are under development and cannot be used without enabling the feature flag") {
+		t.Skip("Requires columnstore indexes to be implemented")
+	}
+
 	require.NoError(res.Err(), "can create a columnstore index")
 
 	var r interface{}


### PR DESCRIPTION
This PR checks `NotImplemented` error message when testing with columnstore indexes and skip those tests if error is `NotImplemented`.