### PR TITLE
TOOLS-3052: Add builds for Amazon Linux 2023

### DIFF
--- a/common-pvt.yml
+++ b/common-pvt.yml
@@ -312,10 +312,10 @@ buildvariants:
   #        ARM Buildvariants            #
   #######################################
 
-  - name: ubuntu1604-arm64-ssl
-    display_name: ZAP ARM64 Ubuntu 16.04 SSL
+  - name: amazon2023-aarch64-ssl
+    display_name: Amazon Linux 2023 ARM SSL
     run_on:
-      - ubuntu1604-arm64-small
+      - amazon2023-arm64-small
     stepback: false
     batchtime: 10080 # weekly
     expansions:
@@ -326,6 +326,16 @@ buildvariants:
     display_name: ZAP ARM64 Ubuntu 18.04 SSL
     run_on:
       - ubuntu1804-arm64-small
+    stepback: false
+    batchtime: 10080 # weekly
+    expansions:
+      build_tags: "ssl"
+    tasks: *atlas_live_tasks
+
+  - name: ubuntu1604-arm64-ssl
+    display_name: ZAP ARM64 Ubuntu 16.04 SSL
+    run_on:
+      - ubuntu1604-arm64-small
     stepback: false
     batchtime: 10080 # weekly
     expansions:

--- a/common.yml
+++ b/common.yml
@@ -3137,6 +3137,41 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
+  - name: amazon2023-aarch64
+    display_name: Amazon Linux 2023 ARM
+    run_on:
+      - amazon2023-arm64-small
+    stepback: false
+    expansions:
+      <<:
+        [
+          *mongod_ssl_startup_args,
+          *mongo_ssl_startup_args,
+          *mongod_tls_startup_args,
+          *mongo_tls_startup_args,
+        ]
+
+      # TODO: Once there are MongoDB builds for Amazon 2023,
+      # add mongo_os et al.
+
+      smoke_use_ssl: --use-ssl
+      resmoke_use_ssl: _ssl
+      smoke_use_tls: --use-tls
+      resmoke_use_tls: _tls
+      excludes: requires_mmap_available,requires_large_ram,requires_mongo_24,requires_mongo_26,requires_mongo_30
+      resmoke_args: -j 2
+      edition: "enterprise"
+      USE_SSL: "true"
+    tasks:
+      - name: "unit"
+      - name: ".kerberos"
+      - name: "dist"
+      - name: "sign"
+        run_on: rhel80-small
+      - name: "push"
+        run_on: rhel80-small
+        git_tag_only: true
+
   - name: rhel82-arm64
     display_name: RHEL 8.2 ARM
     run_on:

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -332,6 +332,14 @@ var platforms = []Platform{
 		BuildTags: defaultBuildTags,
 	},
 	{
+		Name:      "amazon2023",
+		Arch:      ArchAarch64,
+		OS:        OSLinux,
+		Pkg:       PkgRPM,
+		Repos:     []Repo{RepoEnterprise, RepoOrg},
+		BuildTags: defaultBuildTags,
+	},
+	{
 		Name:      "debian10",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,


### PR DESCRIPTION
Note that, due to the unavailability of MongoDB builds for this distribution, currently no tests run that require MongoDB (e.g., integration).