### PR TITLE
Added support for no admin command error - restoring into DocumentDB

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -144,6 +144,9 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 		if strings.Contains(result.Err().Error(), "CommandNotFound") {
 			return false, nil
 		}
+		if strings.Contains(result.Err().Error(), "Unknown admin command") {
+			return false, nil
+		}
 		// For server 3.4 and below.
 		if strings.Contains(result.Err().Error(), "no such cmd") || strings.Contains(result.Err().Error(), "no such command") {
 			return false, nil


### PR DESCRIPTION
When running restore against DocumentDB on a mongodump taken from Atlas.
This is Mongo5.0 restoring to DocumentDB 5.0