### PR TITLE
TOOLS-3054 Add RHEL 9.0 ARM builds.

### DIFF
--- a/common-pvt.yml
+++ b/common-pvt.yml
@@ -350,6 +350,16 @@ buildvariants:
       build_tags: "ssl"
     tasks: *atlas_live_tasks
 
+  - name: rhel9-arm64-ssl
+    display_name: RHEL 9 ARM SSL
+    run_on:
+      - rhel90-arm64-small
+    stepback: false
+    batchtime: 10080 # weekly
+    expansions:
+      build_tags: "ssl"
+    tasks: *atlas_live_tasks
+
   #######################################
   #        Power Buildvariants          #
   #######################################

--- a/common.yml
+++ b/common.yml
@@ -3243,6 +3243,40 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
+  - name: rhel90-arm64
+    display_name: RHEL 9.0 ARM
+    run_on:
+      - rhel90-arm64-small
+    stepback: false
+    expansions:
+      <<:
+        [
+          *mongod_ssl_startup_args,
+          *mongo_ssl_startup_args,
+          *mongod_tls_startup_args,
+          *mongo_tls_startup_args,
+        ]
+      mongo_os: "rhel90"
+      mongo_edition: "enterprise"
+      mongo_arch: "aarch64"
+      smoke_use_ssl: --use-ssl
+      resmoke_use_ssl: _ssl
+      smoke_use_tls: --use-tls
+      resmoke_use_tls: _tls
+      excludes: requires_mmap_available,requires_large_ram,requires_mongo_24,requires_mongo_26,requires_mongo_30
+      resmoke_args: -j 2
+      edition: "enterprise"
+      USE_SSL: "true"
+    tasks:
+      - name: "unit"
+      - name: ".kerberos"
+      - name: "dist"
+      - name: "sign"
+        run_on: rhel80-small
+      - name: "push"
+        run_on: rhel80-small
+        git_tag_only: true
+
   #######################################
   #        Power Buildvariants          #
   #######################################

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -485,6 +485,14 @@ var platforms = []Platform{
 	},
 	{
 		Name:      "rhel90",
+		Arch:      ArchArm64,
+		OS:        OSLinux,
+		Pkg:       PkgRPM,
+		Repos:     []Repo{RepoOrg, RepoEnterprise},
+		BuildTags: defaultBuildTags,
+	},
+	{
+		Name:      "rhel90",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,
 		Pkg:       PkgRPM,


### PR DESCRIPTION
Note that, due to the unavailability of MongoDB builds for this OS, currently no tests run that require MongoDB (e.g., integration).