### PR TITLE
TOOLS-3062 Add Amazon Linux 2023 x86 builds.

### DIFF
--- a/common-pvt.yml
+++ b/common-pvt.yml
@@ -204,6 +204,14 @@ buildvariants:
       build_tags: "sasl gssapi ssl"
     tasks: *atlas_live_tasks
 
+  - name: amazon2023-enterprise
+    display_name: Amazon Linux 2023 Enterprise
+    run_on:
+      - amazon2023-small
+    expansions:
+      build_tags: "sasl gssapi ssl"
+    tasks: *atlas_live_tasks
+
   #######################################
   #     Debian x86_64 Buildvariants     #
   #######################################

--- a/common.yml
+++ b/common.yml
@@ -2682,6 +2682,39 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
+  - name: amazon2023
+    display_name: Amazon Linux 2023
+    run_on:
+      - amazon2023-small
+    stepback: false
+    expansions:
+      <<:
+        [
+          *mongod_ssl_startup_args,
+          *mongo_ssl_startup_args,
+          *mongod_tls_startup_args,
+          *mongo_tls_startup_args,
+        ]
+      mongo_os: amazon2023
+      mongo_edition: enterprise
+      smoke_use_ssl: --use-ssl
+      resmoke_use_ssl: _ssl
+      smoke_use_tls: --use-tls
+      resmoke_use_tls: _tls
+      resmoke_args: -j 2
+      edition: "enterprise"
+      run_kinit: true
+      resmoke_args: --jobs 4
+    tasks:
+      - name: "unit"
+      - name: ".kerberos"
+      - name: "dist"
+      - name: "sign"
+        run_on: rhel80-small
+      - name: "push"
+        run_on: rhel80-small
+        git_tag_only: true
+
   #######################################
   #     SUSE x86_64 Buildvariants       #
   #######################################

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -363,6 +363,14 @@ var platforms = []Platform{
 		BuildTags: defaultBuildTags,
 	},
 	{
+		Name:      "amazon2023",
+		Arch:      ArchX86_64,
+		OS:        OSLinux,
+		Pkg:       PkgRPM,
+		Repos:     []Repo{RepoEnterprise, RepoOrg},
+		BuildTags: defaultBuildTags,
+	},
+	{
 		Name:      "debian10",
 		Arch:      ArchX86_64,
 		OS:        OSLinux,


### PR DESCRIPTION
Note that, due to the unavailability of MongoDB builds for this distribution, currently no tests run that require MongoDB (e.g., integration).