### PR TITLE
TOOLS-3309 Use `aarch64` for releases on RHEL platforms

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -3236,7 +3236,7 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
-  - name: rhel82-arm64
+  - name: rhel82-aarch64
     display_name: RHEL 8.2 ARM
     run_on:
       - rhel82-arm64
@@ -3276,7 +3276,7 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
-  - name: rhel90-arm64
+  - name: rhel90-aarch64
     display_name: RHEL 9.0 ARM
     run_on:
       - rhel90-arm64-small
@@ -3581,5 +3581,5 @@ github_pr_aliases:
     task: "integration-5.0"
   # Run a subset of integration tests against the latest version of MongoDB
   # Server on all variants where that is the most recent supported version.
-  - variant: "^(amazon2|amazon2-arm64|debian10|debian11|debian92|rhel70|rhel72-s390x|rhel80|rhel82-arm64|suse12|suse15|ubuntu1804|ubuntu1804-arm64|ubuntu2004|ubuntu2004-arm64|windows)$"
+  - variant: "^(amazon2|amazon2-arm64|debian10|debian11|debian92|rhel70|rhel72-s390x|rhel80|rhel82-aarch64|suse12|suse15|ubuntu1804|ubuntu1804-arm64|ubuntu2004|ubuntu2004-arm64|windows)$"
     task: "integration-latest"

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -36,8 +36,9 @@ type Arch string
 
 const (
 	ArchArm64 Arch = "arm64"
-	// While arm64 and aarch64 are the same architecture, some Linux distros
-	// use arm64 (Debian and RHEL) and others use aarch64 (Amazon 2).
+	// While arm64 and aarch64 are the same architecture, some Linux distros use arm64 and others use aarch64:
+	// - aarch64: RHEL/Amazon/SUSE
+	// - arm64: Debian/Ubuntu
 	ArchAarch64 Arch = "aarch64"
 	ArchS390x   Arch = "s390x"
 	ArchPpc64le Arch = "ppc64le"
@@ -477,7 +478,7 @@ var platforms = []Platform{
 	},
 	{
 		Name:      "rhel82",
-		Arch:      ArchArm64,
+		Arch:      ArchAarch64,
 		OS:        OSLinux,
 		Pkg:       PkgRPM,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
@@ -493,7 +494,7 @@ var platforms = []Platform{
 	},
 	{
 		Name:      "rhel90",
-		Arch:      ArchArm64,
+		Arch:      ArchAarch64,
 		OS:        OSLinux,
 		Pkg:       PkgRPM,
 		Repos:     []Repo{RepoOrg, RepoEnterprise},

--- a/release/platform/platform_test.go
+++ b/release/platform/platform_test.go
@@ -116,3 +116,18 @@ func TestPlatformsHaveNoDuplicates(t *testing.T) {
 		assert.Equal(t, 1, dupes, "platform %v only occurs once in platforms list", p1)
 	}
 }
+
+func TestPlatformCorrectArch(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	for _, p := range platforms {
+		name := p.Name
+		if p.Arch == ArchArm64 || p.Arch == ArchAarch64 {
+			if strings.Contains(name, "rhel") || strings.Contains(name, "amazon") || strings.Contains(name, "suse") {
+				assert.Equal(t, ArchAarch64, p.Arch, "platform %v need arch %s", p, ArchAarch64)
+			} else if strings.Contains(name, "debian") || strings.Contains(name, "ubuntu") {
+				assert.Equal(t, ArchArm64, p.Arch, "platform %v need arch %s", p, ArchArm64)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Updated code comment in `platform.go` and changed arch names for releases on RHEL platforms.