### PR TITLE
TOOLS-3324 Dump entire config db when --db=config

### DIFF
--- a/common/dumprestore/config.go
+++ b/common/dumprestore/config.go
@@ -1,7 +1,14 @@
 package dumprestore
 
 // ConfigCollectionsToKeep defines a list of collections in the `config`
-// database that we include in backups and restores.
+// database that we include by default in backups and restores.
+//
+// These are the only config collections that are dumped when dumping
+// and entire cluster. If you set mognodump --db=config then everything
+// in the config collection is included.
+//
+// These are the only collections that mongorestore will apply oplog events for
+// if --replayOplog is set.
 var ConfigCollectionsToKeep = []string{
 	"chunks",
 	"collections",

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -145,7 +145,7 @@ func (f *stdoutFile) Close() error {
 // shouldSkipSystemNamespace returns true when a namespace (database +
 // collection name) match certain reserved system namespaces that must
 // not be dumped.
-func shouldSkipSystemNamespace(dbName, collName string) bool {
+func (dump *MongoDump) shouldSkipSystemNamespace(dbName, collName string) bool {
 	// ignore <db>.system.* except for admin; ignore other specific
 	// collections in config and admin databases used for 3.6 features.
 	switch dbName {
@@ -154,7 +154,11 @@ func shouldSkipSystemNamespace(dbName, collName string) bool {
 			return true
 		}
 	case "config":
-		return !slices.Contains(dumprestore.ConfigCollectionsToKeep, collName)
+		if dump.ToolOptions.DB == "config" {
+			return false
+		} else {
+			return !slices.Contains(dumprestore.ConfigCollectionsToKeep, collName)
+		}
 	default:
 		if collName == "system.js" {
 			return false
@@ -410,7 +414,7 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 			return fmt.Errorf("detected resharding in progress. Cannot dump with --oplog while resharding")
 		}
 
-		if shouldSkipSystemNamespace(dbName, collInfo.Name) {
+		if dump.shouldSkipSystemNamespace(dbName, collInfo.Name) {
 			log.Logvf(log.DebugHigh, "will not dump system collection '%s.%s'", dbName, collInfo.Name)
 			continue
 		}

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -145,6 +145,12 @@ func (f *stdoutFile) Close() error {
 // shouldSkipSystemNamespace returns true when a namespace (database +
 // collection name) match certain reserved system namespaces that must
 // not be dumped.
+// By default dumping the entire cluster will only dump config collections
+// in dumprestore.ConfigCollectionsToKeep. Every other config collection is ignoered.
+// If you set --db=config then everything is included.
+// If you set --db=config --collection=foo, then shouldSkipSystemNamespace() is
+// never hit since CreateCollectionIntent() is run directly. In this case
+// config.foo will be the olny collection dumped.
 func (dump *MongoDump) shouldSkipSystemNamespace(dbName, collName string) bool {
 	// ignore <db>.system.* except for admin; ignore other specific
 	// collections in config and admin databases used for 3.6 features.
@@ -156,9 +162,8 @@ func (dump *MongoDump) shouldSkipSystemNamespace(dbName, collName string) bool {
 	case "config":
 		if dump.ToolOptions.DB == "config" {
 			return false
-		} else {
-			return !slices.Contains(dumprestore.ConfigCollectionsToKeep, collName)
 		}
+		return !slices.Contains(dumprestore.ConfigCollectionsToKeep, collName)
 	default:
 		if collName == "system.js" {
 			return false

--- a/mongodump/prepare_test.go
+++ b/mongodump/prepare_test.go
@@ -144,8 +144,49 @@ func TestShouldSkipSystemNamespace(t *testing.T) {
 			output: true,
 		},
 		{
+			db:     "config",
+			coll:   "chunks",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "collections",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "databases",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "settings",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "shards",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "tags",
+			output: false,
+		},
+		{
+			db:     "config",
+			coll:   "version",
+			output: false,
+		},
+		{
 			db:       "config",
 			coll:     "foo",
+			output:   false,
+			dbOption: "config",
+		},
+		{
+			db:       "config",
+			coll:     "chunks",
 			output:   false,
 			dbOption: "config",
 		},

--- a/mongodump/prepare_test.go
+++ b/mongodump/prepare_test.go
@@ -59,9 +59,10 @@ func TestSkipCollection(t *testing.T) {
 }
 
 type testTable struct {
-	db     string
-	coll   string
-	output bool
+	db       string
+	coll     string
+	output   bool
+	dbOption string
 }
 
 func TestShouldSkipSystemNamespace(t *testing.T) {
@@ -142,6 +143,12 @@ func TestShouldSkipSystemNamespace(t *testing.T) {
 			coll:   "foo",
 			output: true,
 		},
+		{
+			db:       "config",
+			coll:     "foo",
+			output:   false,
+			dbOption: "config",
+		},
 	}
 
 	for _, collName := range dumprestore.ConfigCollectionsToKeep {
@@ -152,8 +159,12 @@ func TestShouldSkipSystemNamespace(t *testing.T) {
 		})
 	}
 
+	md := simpleMongoDumpInstance()
+
 	for _, testVals := range tests {
-		if shouldSkipSystemNamespace(testVals.db, testVals.coll) != testVals.output {
+		md.ToolOptions.DB = testVals.dbOption
+
+		if md.shouldSkipSystemNamespace(testVals.db, testVals.coll) != testVals.output {
 			t.Errorf("%s.%s should have been %v but failed\n", testVals.db, testVals.coll, testVals.output)
 		}
 	}


### PR DESCRIPTION
If a user explicitly specifies `--db=config` then we provide the entire collection database. 

We continue to skip most config collections by default. 