### PR TITLE
TOOLS-3344 Fix issue where mongodump failed against Atlas Online Archive and AWS DocumentDB

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -139,10 +139,6 @@ func (sp *SessionProvider) IsAtlasProxy() bool {
 		context.Background(),
 		&bson.M{"atlasVersion": 1},
 	)
-	err = result.Err()
-	if err != nil {
-		fmt.Println("err is not nil", err.Error())
-	}
 	return result.Err() == nil
 }
 

--- a/common/db/command.go
+++ b/common/db/command.go
@@ -9,7 +9,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"go.mongodb.org/mongo-driver/bson"
@@ -129,10 +128,10 @@ func (sp *SessionProvider) DatabaseNames() ([]string, error) {
 // }
 
 // IsAtlasProxy checks if the connected SessionProvider is an atlas proxy.
-func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
+func (sp *SessionProvider) IsAtlasProxy() bool {
 	session, err := sp.GetSession()
 	if err != nil {
-		return false, err
+		return false
 	}
 
 	// Only the atlas proxy will respond to this command without an error.
@@ -142,32 +141,9 @@ func (sp *SessionProvider) IsAtlasProxy() (bool, error) {
 	)
 	err = result.Err()
 	if err != nil {
-		if isUnsupportedCommandError(err) {
-			return false, nil
-		}
-		return false, err
+		fmt.Println("err is not nil", err.Error())
 	}
-	return true, nil
-}
-
-// isUnsupportedCommandError determines if the given error indicates that the server does not support a command
-func isUnsupportedCommandError(err error) bool {
-	unsupportedCommandErrors := []string{
-		// Server > 3.4
-		"CommandNotFound",
-		"CommandNotSupported",
-		// Server <= 3.4
-		"no such cmd",
-		"no such command",
-		// AWS Document DB
-		"Unknown admin command",
-	}
-	for _, unsupportedCommandError := range unsupportedCommandErrors {
-		if strings.Contains(err.Error(), unsupportedCommandError) {
-			return true
-		}
-	}
-	return false
+	return result.Err() == nil
 }
 
 // GetNodeType checks if the connected SessionProvider is a mongos, standalone, or replset,

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -160,10 +160,7 @@ func (dump *MongoDump) Init() error {
 		return fmt.Errorf("error checking for Mongos: %v", err)
 	}
 
-	dump.isAtlasProxy, err = dump.SessionProvider.IsAtlasProxy()
-	if err != nil {
-		return fmt.Errorf("error checking for AtlasProxy: %v", err)
-	}
+	dump.isAtlasProxy = dump.SessionProvider.IsAtlasProxy()
 	if dump.isAtlasProxy {
 		log.Logv(log.DebugLow, "dumping from a MongoDB Atlas free or shared cluster")
 	}

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -132,10 +132,7 @@ func New(opts Options) (*MongoRestore, error) {
 	if restore.isMongos {
 		log.Logv(log.DebugLow, "restoring to a sharded system")
 	}
-	restore.isAtlasProxy, err = restore.SessionProvider.IsAtlasProxy()
-	if err != nil {
-		return nil, err
-	}
+	restore.isAtlasProxy = restore.SessionProvider.IsAtlasProxy()
 	if restore.isAtlasProxy {
 		log.Logv(log.DebugLow, "restoring to a MongoDB Atlas free or shared cluster")
 	}


### PR DESCRIPTION
Fixes issues where `mongodump` crashed when run against Atlas Online Archive or AWS DocumentDB by handling their errors properly. This will still break if any of these error messages change in the future.

I tested by running my local `mongosync` binary against an online archive cluster directly, and against an AWS DocumentDB instance tunneled through EC2 (instructions [here](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect-from-outside-a-vpc.html)). 