### PR TITLE
TOOLS-3349 Add integration tests for config db dump and restore

### DIFF
--- a/mongorestore/mongorestore_archive_test.go
+++ b/mongorestore/mongorestore_archive_test.go
@@ -335,7 +335,7 @@ func createCollectionWithTestDocument(t *testing.T, db *mongo.Database, collecti
 	collection := db.Collection(collectionName)
 	_, err := collection.InsertOne(
 		context.Background(),
-		bson.M{"key": "value"},
+		testDocument,
 	)
 	require.NoError(err, "can insert documents into collection")
 	return collection

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -2645,7 +2645,8 @@ func testDumpAndRestoreConfigDBIncludesAllCollections(t *testing.T) {
 		t,
 		func(dir string) {
 
-			dropCollections(t, allCollections)
+			dropCollections(t, userDefinedCollections)
+			removeTestDocumentsFromCollections(t, collectionsToKeep)
 
 			restore, err := getRestoreWithArgs(
 				DropOption,
@@ -2697,7 +2698,8 @@ func testDumpAndRestoreAllDBsIgnoresSomeConfigCollections(t *testing.T) {
 		t,
 		func(dir string) {
 
-			dropCollections(t, allCollections)
+			dropCollections(t, userDefinedCollections)
+			removeTestDocumentsFromCollections(t, collectionsToKeep)
 
 			restore, err := getRestoreWithArgs(
 				DropOption,

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -2662,6 +2662,7 @@ func testDumpAndRestoreConfigDBIncludesAllCollections(t *testing.T) {
 
 		},
 		"--db", "config",
+		"--excludeCollection", "transactions",
 	)
 }
 
@@ -2723,7 +2724,6 @@ func clearDB(t *testing.T, db *mongo.Database) {
 	require.NoError(err, "can get collection names")
 	for _, collectionName := range collectionNames {
 		collection := db.Collection(collectionName)
-		_, err := collection.DeleteMany(context.Background(), bson.M{})
-		require.NoError(err, fmt.Sprintf("can delete many from collection %s", collectionName))
+		_, _ = collection.DeleteMany(context.Background(), bson.M{})
 	}
 }

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -2648,10 +2648,7 @@ func testDumpAndRestoreConfigDBIncludesAllCollections(t *testing.T) {
 			dropCollections(t, userDefinedCollections)
 			removeTestDocumentsFromCollections(t, collectionsToKeep)
 
-			restore, err := getRestoreWithArgs(
-				DropOption,
-				dir,
-			)
+			restore, err := getRestoreWithArgs(dir)
 			require.NoError(err)
 			defer restore.Close()
 


### PR DESCRIPTION
This change adds integration tests to verify the behavior of `mongodump` and `mongorestore` on collections in the `config` database.