### PR TITLE
Fix error when compiling for Debian ARM64

### DIFF
--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -122,9 +122,9 @@ func DetectLocal() (Platform, error) {
 
 	switch kernelName {
 	case "Linux":
-		pf, ok := GetByOsAndArch("ubuntu1804", archName)
+		pf, ok := GetByOsAndArch("linux", archName)
 		if !ok {
-			panic("ubuntu1804 platform name changed")
+			panic("linux platform name changed")
 		}
 		return pf, nil
 	case "Darwin":


### PR DESCRIPTION
Trying to compile under docker with debian11 under ARM, error is:
```
panic: ubuntu1804 platform name changed
```

I provide this patch on a "works for me" basis, as I have no clue how this platform.go works or is supposed to work.