### PR TITLE
TOOLS-3368 update release infra to support uploading tools to 7.0 linux repos

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -654,6 +654,7 @@ pre:
           export NOTARY_TOKEN_4_4='${signing_auth_token_server_4_4}'
           export NOTARY_TOKEN_5_0='${signing_auth_token_server_5_0}'
           export NOTARY_TOKEN_6_0='${signing_auth_token_server_6_0}'
+          export NOTARY_TOKEN_7_0='${signing_auth_token_server_7_0}'
           export BARQUE_USERNAME='${evg_user}'
           export BARQUE_API_KEY='${barque_api_key}'
           export TOOLS_TESTING_AUTH_USERNAME='${auth_username}'

--- a/release/release.go
+++ b/release/release.go
@@ -1134,6 +1134,7 @@ var linuxRepoVersionsStable = []LinuxRepo{
 	{"4.4", "4.4.0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")}, // any 4.4 stable release version will send the package to the "4.4" repo
 	{"5.0", "5.0.0", "server-5.0", os.Getenv("NOTARY_TOKEN_5_0")}, // any 5.0 stable release version will send the package to the "5.0" repo
 	{"6.0", "6.0.0", "server-6.0", os.Getenv("NOTARY_TOKEN_6_0")}, // any 6.0 stable release version will send the package to the "6.0" repo
+	{"7.0", "7.0.0", "server-7.0", os.Getenv("NOTARY_TOKEN_7_0")}, // any 7.0 stable release version will send the package to the "6.0" repo
 }
 
 var linuxRepoVersionsUnstable = []LinuxRepo{

--- a/release/release.go
+++ b/release/release.go
@@ -1134,7 +1134,7 @@ var linuxRepoVersionsStable = []LinuxRepo{
 	{"4.4", "4.4.0", "server-4.4", os.Getenv("NOTARY_TOKEN_4_4")}, // any 4.4 stable release version will send the package to the "4.4" repo
 	{"5.0", "5.0.0", "server-5.0", os.Getenv("NOTARY_TOKEN_5_0")}, // any 5.0 stable release version will send the package to the "5.0" repo
 	{"6.0", "6.0.0", "server-6.0", os.Getenv("NOTARY_TOKEN_6_0")}, // any 6.0 stable release version will send the package to the "6.0" repo
-	{"7.0", "7.0.0", "server-7.0", os.Getenv("NOTARY_TOKEN_7_0")}, // any 7.0 stable release version will send the package to the "6.0" repo
+	{"7.0", "7.0.0", "server-7.0", os.Getenv("NOTARY_TOKEN_7_0")}, // any 7.0 stable release version will send the package to the "7.0" repo
 }
 
 var linuxRepoVersionsUnstable = []LinuxRepo{


### PR DESCRIPTION
The database tools release script was not configured to be uploaded to the v7.0 server linux repos. Because of this, anyone trying to download mongodb v7.0 on linux can run into a problem. This adds the infra needed to also upload to the 7.0 repos. It uses an evergreen project level variable.