### PR TITLE
TOOLS-3411 Fix issue where sort order of views was not always preserved on dump

### DIFF
--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -21,7 +21,7 @@ import (
 type CollectionInfo struct {
 	Name    string `bson:"name"`
 	Type    string `bson:"type"`
-	Options bson.M `bson:"options"`
+	Options bson.D `bson:"options"`
 	Info    bson.M `bson:"info"`
 }
 

--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -21,8 +21,8 @@ import (
 type CollectionInfo struct {
 	Name    string `bson:"name"`
 	Type    string `bson:"type"`
-	Options bson.M `bson:"options"`
-	Info    bson.M `bson:"info"`
+	Options bson.D `bson:"options"`
+	Info    bson.M `bson:"info"` // TODO (Johnny) does this need to be ordered?
 }
 
 func (ci *CollectionInfo) IsView() bool {

--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -21,8 +21,8 @@ import (
 type CollectionInfo struct {
 	Name    string `bson:"name"`
 	Type    string `bson:"type"`
-	Options bson.D `bson:"options"`
-	Info    bson.M `bson:"info"` // TODO (Johnny) does this need to be ordered?
+	Options bson.M `bson:"options"`
+	Info    bson.M `bson:"info"`
 }
 
 func (ci *CollectionInfo) IsView() bool {

--- a/common/idx/idx.go
+++ b/common/idx/idx.go
@@ -14,7 +14,7 @@ import (
 
 // IndexDocument holds information about a collection's index.
 type IndexDocument struct {
-	Options                 bson.M `bson:",inline"` // TODO (Johnny) does this need to be ordered
+	Options                 bson.M `bson:",inline"`
 	Key                     bson.D `bson:"key"`
 	PartialFilterExpression bson.D `bson:"partialFilterExpression,omitempty"`
 }

--- a/common/idx/idx.go
+++ b/common/idx/idx.go
@@ -14,7 +14,7 @@ import (
 
 // IndexDocument holds information about a collection's index.
 type IndexDocument struct {
-	Options                 bson.M `bson:",inline"`
+	Options                 bson.M `bson:",inline"` // TODO (Johnny) does this need to be ordered
 	Key                     bson.D `bson:"key"`
 	PartialFilterExpression bson.D `bson:"partialFilterExpression,omitempty"`
 }

--- a/common/intents/intent.go
+++ b/common/intents/intent.go
@@ -170,7 +170,6 @@ func (it *Intent) HasSimpleCollation() bool {
 	if it == nil || it.Options == nil {
 		return true
 	}
-
 	collation, err := bsonutil.FindSubdocumentByKey("collation", &it.Options)
 	if err != nil {
 		return true

--- a/common/intents/intent.go
+++ b/common/intents/intent.go
@@ -59,7 +59,7 @@ type Intent struct {
 	MetadataLocation string
 
 	// Collection options
-	Options bson.M
+	Options bson.D
 
 	// UUID (for MongoDB 3.6+) as a big-endian hex string
 	UUID string
@@ -170,8 +170,9 @@ func (it *Intent) HasSimpleCollation() bool {
 	if it == nil || it.Options == nil {
 		return true
 	}
-	collation, ok := it.Options["collation"].(bson.D)
-	if !ok {
+
+	collation, err := bsonutil.FindSubdocumentByKey("collation", &it.Options)
+	if err != nil {
 		return true
 	}
 	localeValue, _ := bsonutil.FindValueByKey("locale", &collation)

--- a/common/intents/intent_prioritizer_test.go
+++ b/common/intents/intent_prioritizer_test.go
@@ -124,13 +124,13 @@ func TestBySizeAndView(t *testing.T) {
 		intents := []*Intent{
 			{C: "non-view2", Size: 32},
 			{C: "view", Size: 0,
-				Options: bson.M{"viewOn": true},
+				Options: bson.D{{Key: "viewOn", Value: true}},
 				Type:    "view",
 			},
 			{C: "non-view1", Size: 1024},
 			{C: "non-view3", Size: 2},
 			{C: "view", Size: 0,
-				Options: bson.M{"viewOn": true},
+				Options: bson.D{{Key: "viewOn", Value: true}},
 				Type:    "view",
 			},
 		}

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -19,7 +19,7 @@ import (
 
 // Metadata holds information about a collection's options and indexes.
 type Metadata struct {
-	Options        bson.M   `bson:"options,omitempty"`
+	Options        bson.D   `bson:"options,omitempty"`
 	Indexes        []bson.D `bson:"indexes"`
 	UUID           string   `bson:"uuid,omitempty"`
 	CollectionName string   `bson:"collectionName"`
@@ -28,7 +28,7 @@ type Metadata struct {
 
 // IndexDocumentFromDB is used internally to preserve key ordering.
 type IndexDocumentFromDB struct {
-	Options bson.M `bson:",inline"`
+	Options bson.M `bson:",inline"` // TODO (Johnny) does this need to be ordered
 	Key     bson.D `bson:"key"`
 }
 

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -28,7 +28,7 @@ type Metadata struct {
 
 // IndexDocumentFromDB is used internally to preserve key ordering.
 type IndexDocumentFromDB struct {
-	Options bson.M `bson:",inline"` // TODO (Johnny) does this need to be ordered
+	Options bson.M `bson:",inline"`
 	Key     bson.D `bson:"key"`
 }
 

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/progress"
 	"github.com/mongodb/mongo-tools/common/util"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -588,11 +589,11 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 		if intent.IsTimeseries() {
 			timeseriesOptions, err := bsonutil.FindSubdocumentByKey("timeseries", &intent.Options)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "could not find timeseries options for %s", intent.Namespace())
 			}
 			metaKey, err := bsonutil.FindStringValueByKey("metaField", &timeseriesOptions)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "could not determine the metaField for %s", intent.Namespace())
 			}
 			for i, predicate := range dump.query {
 				splitPredicateKey := strings.SplitN(predicate.Key, ".", 2)

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/mongodb/mongo-tools/common/archive"
+	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/dumprestore"
 	"github.com/mongodb/mongo-tools/common/intents"
@@ -354,8 +355,8 @@ func (dump *MongoDump) NewIntentFromOptions(dbName string, ci *db.CollectionInfo
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && ci.IsView() {
-			delete(intent.Options, "viewOn")
-			delete(intent.Options, "pipeline")
+			bsonutil.RemoveKey("viewOn", &intent.Options)
+			bsonutil.RemoveKey("pipeline", &intent.Options)
 		}
 		//Set the MetadataFile path.
 		if dump.OutputOptions.Archive != "" {

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -353,8 +353,8 @@ func (exp *MongoExport) getCursor() (*mongo.Cursor, error) {
 		!exp.collInfo.IsView() && !exp.collInfo.IsSystemCollection() {
 
 		// Don't hint autoIndexId:false collections
-		autoIndexId, found := exp.collInfo.Options["autoIndexId"]
-		if !found || autoIndexId == true {
+		autoIndexId, err := bsonutil.FindValueByKey("autoIndexId", &exp.collInfo.Options)
+		if err != nil || autoIndexId == true {
 			findOpts.SetHint(bson.D{{"_id", 1}})
 		}
 	}


### PR DESCRIPTION
Fixes an issue where `mongodump` did not always preserve the order of options for a view or collection. This could result in different sort orders than expected on views. It is easily fixed by moving from the unordered `bson.M` type to the ordered `bson.D` type for collection options. Index options are still a `bson.M`, but the keys are `bson.D` so they are not affected by this issue.

I tested manually by viewing the metadata JSON files produced by `mongodump` on both this branch and master. I also verified that the added test succeeds every time on this branch, but fails most of the time on master.