### PR TITLE
TOOLS-3438 Bump minimum go version to 1.20.12

### DIFF
--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -31,7 +31,7 @@ var pkgNames = []string{
 }
 
 // minimumGoVersion must be prefixed with v to be parsed by golang.org/x/mod/semver
-var minimumGoVersion = "v1.20.10"
+const minimumGoVersion = "v1.20.12"
 
 func CheckMinimumGoVersion(ctx *task.Context) error {
 	goVersionStr, err := runCmd(ctx, "go", "version")


### PR DESCRIPTION
This PR bumps the minimum go version to 1.20.12.