### PR TITLE
TOOLS-3499 Remove all tests and config for the long obsolete sasl and ssl build tags

### DIFF
--- a/PLATFORMSUPPORT.md
+++ b/PLATFORMSUPPORT.md
@@ -20,7 +20,7 @@ In this tutorial, we will add a new platform support for Ubuntu2004-arm64.
     mongo_os: "ubuntu2004"
     mongo_edition: "targeted"
     mongo_arch: "aarch64"
-    build_tags: "failpoints ssl"
+    build_tags: "failpoints"
     resmoke_use_tls: _tls
     excludes: requires_mmap_available,requires_large_ram,requires_mongo_24,requires_mongo_26,requires_mongo_30
     resmoke_args: -j 2

--- a/binaryurl.py
+++ b/binaryurl.py
@@ -44,7 +44,7 @@ def isVersionGreaterOrEqual(left, right):
   return True
 
 if opts.version == "latest" or isVersionGreaterOrEqual(opts.version,"4.1.0"):
-  if opts.target in ('osx-ssl', 'osx'):
+  if opts.target in ('osx'):
     opts.target = 'macos'
   if opts.target in ('windows_x86_64-2008plus-ssl', 'windows_x86_64-2008plus'):
     opts.target = 'windows_x86_64-2012plus'

--- a/common-pvt.yml
+++ b/common-pvt.yml
@@ -193,7 +193,7 @@ buildvariants:
     run_on:
       - amazon1-2018-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: amazon2-enterprise
@@ -201,7 +201,7 @@ buildvariants:
     run_on:
       - amazon2-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: amazon2023-enterprise
@@ -209,7 +209,7 @@ buildvariants:
     run_on:
       - amazon2023-small
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -221,7 +221,7 @@ buildvariants:
     run_on:
       - debian81-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: debian92-enterprise
@@ -229,27 +229,23 @@ buildvariants:
     run_on:
       - debian92-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
   #         macOS Buildvariants         #
   #######################################
 
-  - name: macOS-1100-x86_64-ssl
-    display_name: MacOS 11.00 x86_64 SSL
+  - name: macOS-1100-x86_64
+    display_name: MacOS 11.00 x86_64
     run_on:
       - macos-1100
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
-  - name: macOS-1100-arm-ssl
-    display_name: MacOS 11 ARM SSL
+  - name: macOS-1100-arm
+    display_name: MacOS 11 ARM
     run_on:
       - macos-1100-arm64
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -261,7 +257,7 @@ buildvariants:
     run_on:
       - rhel62-small
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: rhel70-enterprise
@@ -269,7 +265,7 @@ buildvariants:
     run_on:
       - rhel70-small
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -281,7 +277,7 @@ buildvariants:
     run_on:
       - suse12-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -293,7 +289,7 @@ buildvariants:
     run_on:
       - ubuntu1404-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: ubuntu1604-enterprise
@@ -301,7 +297,7 @@ buildvariants:
     run_on:
       - ubuntu1604-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: ubuntu1804-enterprise
@@ -309,63 +305,53 @@ buildvariants:
     run_on:
       - ubuntu1804-test
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
   #        Windows Buildvariants        #
   #######################################
 
-  - name: windows-64-ssl
-    display_name: Windows 64-bit SSL
+  - name: windows-64
+    display_name: Windows 64-bit
     run_on:
       - windows-64-vs2017-test
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
   #######################################
   #        ARM Buildvariants            #
   #######################################
 
-  - name: amazon2023-aarch64-ssl
-    display_name: Amazon Linux 2023 ARM SSL
+  - name: amazon2023-aarch64
+    display_name: Amazon Linux 2023 ARM
     run_on:
       - amazon2023-arm64-small
     stepback: false
     batchtime: 10080 # weekly
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
-  - name: ubuntu1804-arm64-ssl
-    display_name: ZAP ARM64 Ubuntu 18.04 SSL
+  - name: ubuntu1804-arm64
+    display_name: ZAP ARM64 Ubuntu 18.04
     run_on:
       - ubuntu1804-arm64-small
     stepback: false
     batchtime: 10080 # weekly
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
-  - name: ubuntu1604-arm64-ssl
-    display_name: ZAP ARM64 Ubuntu 16.04 SSL
+  - name: ubuntu1604-arm64
+    display_name: ZAP ARM64 Ubuntu 16.04
     run_on:
       - ubuntu1604-arm64-small
     stepback: false
     batchtime: 10080 # weekly
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
-  - name: rhel9-arm64-ssl
-    display_name: RHEL 9 ARM SSL
+  - name: rhel9-arm64
+    display_name: RHEL 9 ARM
     run_on:
       - rhel90-arm64-small
     stepback: false
     batchtime: 10080 # weekly
-    expansions:
-      build_tags: "ssl"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -379,7 +365,7 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "ssl sasl gssapi"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: ubuntu1604-ppc64le-enterprise
@@ -389,7 +375,7 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "ssl sasl gssapi"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   #######################################
@@ -403,7 +389,7 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: rhel72-s390x-enterprise
@@ -413,7 +399,7 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: rhel83-s390x-enterprise
@@ -423,7 +409,7 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks
 
   - name: ubuntu1604-s390x-enterprise
@@ -433,5 +419,5 @@ buildvariants:
     stepback: false
     batchtime: 10080 # weekly
     expansions:
-      build_tags: "sasl gssapi ssl"
+      build_tags: "gssapi"
     tasks: *atlas_live_tasks

--- a/common.yml
+++ b/common.yml
@@ -1858,7 +1858,7 @@ buildvariants:
 
  # This build is specifically for Splunk
   - name: rhel62-no-kerberos
-    display_name: "# RHEL 6.2 w/o SASL or Kerberos"
+    display_name: "# RHEL 6.2 w/o Kerberos"
     expansions:
       <<:
         [

--- a/common.yml
+++ b/common.yml
@@ -1856,8 +1856,8 @@ buildvariants:
         run_on: rhel80-small
         git_tag_only: true
 
-  # This build is specifically for Splunk
-  - name: rhel62-no-sasl-or-kerberos
+ # This build is specifically for Splunk
+  - name: rhel62-no-kerberos
     display_name: "# RHEL 6.2 w/o SASL or Kerberos"
     expansions:
       <<:
@@ -2296,7 +2296,7 @@ github_pr_aliases:
     task: "integration-4.2"
   # Run a subset of integration tests against the 4.4 version of MongoDB
   # Server on all variants where that is the most recent supported version.
-  - variant: "^rhel62-no-sasl-or-kerberos$"
+  - variant: "^rhel62-no-kerberos$"
     task: "integration-4.4"
   # Run a subset of integration tests against the 5.0 version of MongoDB
   # Server on all variants where that is the most recent supported version.

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -33,10 +33,7 @@ import (
 
 // XXX Force these true as the Go driver supports them always.  Once the
 // conditionals that depend on them are removed, these can be removed.
-var (
-	BuiltWithSSL    = true
-	BuiltWithGSSAPI = true
-)
+var BuiltWithGSSAPI = true
 
 const IncompatibleArgsErrorFormat = "illegal argument combination: cannot specify %s and --uri"
 
@@ -972,14 +969,6 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 	opts.Direct = cs.DirectConnection || (cs.Connect == connstring.SingleConnect)
 	if opts.Direct && opts.ConnString.LoadBalanced {
 		return fmt.Errorf("loadBalanced cannot be set to true if the direct connection option is specified")
-	}
-
-	if (cs.SSL || opts.UseSSL) && !BuiltWithSSL {
-		if strings.HasPrefix(cs.Original, "mongodb+srv") {
-			return fmt.Errorf("SSL enabled by default when using SRV but tool not built with SSL: " +
-				"SSL must be explicitly disabled with ssl=false in the connection string")
-		}
-		return fmt.Errorf("cannot use ssl: tool not built with SSL support")
 	}
 
 	if cs.RetryWritesSet {

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -154,7 +154,6 @@ type uriTester struct {
 	CS                       connstring.ConnString
 	OptsIn                   *ToolOptions
 	OptsExpected             *ToolOptions
-	WithSSL                  bool
 	WithGSSAPI               bool
 	ShouldError              bool
 	AuthShouldAskForPassword bool
@@ -169,36 +168,12 @@ func TestParseAndSetOptions(t *testing.T) {
 		enabledURIOnly := EnabledOptions{false, false, false, true}
 		testCases := []uriTester{
 			{
-				Name: "not built with ssl",
-				CS: connstring.ConnString{
-					SSL:    true,
-					SSLSet: true,
-				},
-				WithSSL:      false,
-				OptsIn:       New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: New("", "", "", "", true, enabledURIOnly),
-				ShouldError:  true,
-			},
-			{
-				Name: "not built with ssl using SRV",
-				CS: connstring.ConnString{
-					SSL:      true,
-					SSLSet:   true,
-					Original: "mongodb+srv://example.com/",
-				},
-				WithSSL:      false,
-				OptsIn:       New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: New("", "", "", "", true, enabledURIOnly),
-				ShouldError:  true,
-			},
-			{
 				Name: "built with ssl",
 				CS: connstring.ConnString{
 					SSL:    true,
 					SSLSet: true,
 				},
-				WithSSL: true,
-				OptsIn:  New("", "", "", "", true, enabledURIOnly),
+				OptsIn: New("", "", "", "", true, enabledURIOnly),
 				OptsExpected: &ToolOptions{
 					General:    &General{},
 					Verbosity:  &Verbosity{},
@@ -221,8 +196,7 @@ func TestParseAndSetOptions(t *testing.T) {
 					SSLSet:   true,
 					Original: "mongodb+srv://example.com/",
 				},
-				WithSSL: true,
-				OptsIn:  New("", "", "", "", true, enabledURIOnly),
+				OptsIn: New("", "", "", "", true, enabledURIOnly),
 				OptsExpected: &ToolOptions{
 					General:    &General{},
 					Verbosity:  &Verbosity{},
@@ -612,10 +586,8 @@ func TestParseAndSetOptions(t *testing.T) {
 				testCase.OptsIn.URI.ConnectionString = "mongodb://dummy"
 				testCase.OptsExpected.URI.ConnectionString = "mongodb://dummy"
 
-				BuiltWithSSL = testCase.WithSSL
 				BuiltWithGSSAPI = testCase.WithGSSAPI
 				defer func() {
-					BuiltWithSSL = true
 					BuiltWithGSSAPI = true
 				}()
 

--- a/installer/msi/BinaryFragment.wxs
+++ b/installer/msi/BinaryFragment.wxs
@@ -31,9 +31,6 @@
        <Component Guid="{A234055C-9F7D-4738-B1A3-FAF3B85D3302}" Id="mongotop" Win64="yes">
             <File DiskId="1" Id="mongotop.exe"  Name="mongotop.exe" Source="mongotop.exe" />
        </Component>
-	   <Component Guid="{50EE4D70-D68B-4D02-A55C-DDA8F7AAFB25}" Id="libsasl" SharedDllRefCount="yes" Win64="yes">
-            <File DiskId="1" Id="libsasl.dll"  Name="libsasl.dll" Source="libsasl.dll" />
-       </Component>
       </DirectoryRef>
       <ComponentGroup Id="base">
           <ComponentRef Id="RegKeys" />
@@ -45,7 +42,6 @@
           <ComponentRef Id="mongorestore" />
           <ComponentRef Id="mongostat" />
           <ComponentRef Id="mongotop" />
-          <ComponentRef Id="libsasl" />
        </ComponentGroup>
   </Fragment>
 </Wix>

--- a/installer/rpm/mongodb-database-tools.spec
+++ b/installer/rpm/mongodb-database-tools.spec
@@ -8,7 +8,7 @@ Group: Applications/Databases
 License: Apache
 URL:        http://www.mongodb.com
 Vendor:     MongoDB
-Requires: openssl, cyrus-sasl, cyrus-sasl-plain, cyrus-sasl-gssapi
+Requires: cyrus-sasl, cyrus-sasl-plain, cyrus-sasl-gssapi
 Conflicts: mongodb-org-tools <= 4.3.2, mongodb-org-unstable-tools <= 4.3.2, mongodb-enterprise-tools <= 4.3.2, mongodb-enterprise-unstable-tools <= 4.3.2
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}
 

--- a/installer/rpm/mongodb-database-tools.spec
+++ b/installer/rpm/mongodb-database-tools.spec
@@ -8,7 +8,6 @@ Group: Applications/Databases
 License: Apache
 URL:        http://www.mongodb.com
 Vendor:     MongoDB
-Requires: cyrus-sasl, cyrus-sasl-plain, cyrus-sasl-gssapi
 Conflicts: mongodb-org-tools <= 4.3.2, mongodb-org-unstable-tools <= 4.3.2, mongodb-enterprise-tools <= 4.3.2, mongodb-enterprise-unstable-tools <= 4.3.2
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}
 

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -327,7 +327,7 @@ func (a Arch) String() string {
 }
 
 var platformsByVariant map[string]Platform
-var defaultBuildTags = []string{"ssl", "sasl", "gssapi", "failpoints"}
+var defaultBuildTags = []string{"gssapi", "failpoints"}
 
 // Please keep this list sorted by Name and then Arch. This makes it easier to determine
 // whether a given platform exists in the list.
@@ -427,6 +427,20 @@ var platforms = []Platform{
 		BuildTags:         defaultBuildTags,
 		ServerVariantName: "enterprise-macos",
 	},
+	// This is a special build that we upload to S3 but not to the release
+	// repos.
+	{
+		Name: "rhel62",
+		// This needs to match the name of the buildvariant in the Evergreen
+		// config.
+		VariantName:       "rhel62-no-kerberos",
+		Arch:              ArchX86_64,
+		OS:                OSLinux,
+		Pkg:               PkgRPM,
+		BuildTags:         []string{"failpoints"},
+		SkipForJSONFeed:   true,
+		ServerVariantName: "enterprise-rhel-62-64-bit",
+	},
 	{
 		Name:      "rhel62",
 		Arch:      ArchX86_64,
@@ -434,20 +448,6 @@ var platforms = []Platform{
 		Pkg:       PkgRPM,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
 		BuildTags: defaultBuildTags,
-	},
-	// This is a special build that we upload to S3 but not to the release
-	// repos.
-	{
-		Name: "rhel62",
-		// This needs to match the name of the buildvariant in the Evergreen
-		// config.
-		VariantName:       "rhel62-no-sasl-or-kerberos",
-		Arch:              ArchX86_64,
-		OS:                OSLinux,
-		Pkg:               PkgRPM,
-		BuildTags:         []string{"ssl", "failpoints"},
-		SkipForJSONFeed:   true,
-		ServerVariantName: "enterprise-rhel-62-64-bit",
 	},
 	{
 		Name:      "rhel70",
@@ -544,7 +544,7 @@ var platforms = []Platform{
 		OS:        OSLinux,
 		Pkg:       PkgDeb,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
-		BuildTags: []string{"failpoints", "ssl"},
+		BuildTags: []string{"failpoints"},
 	},
 	{
 		Name:      "ubuntu1604",
@@ -560,7 +560,7 @@ var platforms = []Platform{
 		OS:        OSLinux,
 		Pkg:       PkgDeb,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
-		BuildTags: []string{"failpoints", "ssl"},
+		BuildTags: []string{"failpoints"},
 	},
 	{
 		Name:      "ubuntu1804",
@@ -576,7 +576,7 @@ var platforms = []Platform{
 		OS:        OSLinux,
 		Pkg:       PkgDeb,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
-		BuildTags: []string{"failpoints", "ssl"},
+		BuildTags: []string{"failpoints"},
 	},
 	{
 		Name:      "ubuntu2004",
@@ -592,7 +592,7 @@ var platforms = []Platform{
 		OS:        OSLinux,
 		Pkg:       PkgDeb,
 		Repos:     []Repo{RepoEnterprise, RepoOrg},
-		BuildTags: []string{"failpoints", "ssl"},
+		BuildTags: []string{"failpoints"},
 	},
 	{
 		Name:      "ubuntu2204",

--- a/release/release.go
+++ b/release/release.go
@@ -644,7 +644,6 @@ func buildMSI() {
 	msiStaticFilesPath := ".."
 	// Note that the file functions do not allow for drive letters on Windows, absolute paths
 	// must be specified with a leading os.PathSeparator.
-	saslDLLsPath := string(os.PathSeparator) + filepath.Join("sasl", "bin")
 	msiFilesPath := filepath.Join("..", "installer", "msi")
 
 	// These are the meta-text files that are part of mongo-tools, relative
@@ -653,10 +652,6 @@ func buildMSI() {
 	var msiStaticFiles = []string{
 		"README.md",
 		"THIRD-PARTY-NOTICES",
-	}
-
-	var saslDLLs = []string{
-		"libsasl.dll",
 	}
 
 	// location of the necessary data files to build the msi.
@@ -681,16 +676,6 @@ func buildMSI() {
 	cdBack := useWorkingDir(msiBuildDir)
 	// we'll want to go back to the original directory, just in case.
 	defer cdBack()
-
-	// Copy sasldlls. They need to be in this directory for Wix. Linking will
-	// not work as the dlls are on a different file system.
-	for _, name := range saslDLLs {
-		err := copyFile(
-			filepath.Join(saslDLLsPath, name),
-			name,
-		)
-		check(err, "copy sasl dlls into "+msiBuildDir)
-	}
 
 	// make links to all the staticFiles. They need to be in this
 	// directory for Wix.

--- a/test/qa-tests/README.md
+++ b/test/qa-tests/README.md
@@ -1,6 +1,6 @@
 # How to run resmoke tests
 
-* Build all tools first; use the 'failpoints' tag and optionally ssl/sasl tags
+* Build all tools first; use the 'failpoints' tag.
 
 * From this directory, run `prep-for-resmoke.sh` to copy binaries to this directory.
   Optional arguments are (1) directory to find tools binaries (defaults to `bin`


### PR DESCRIPTION
This also removes some internal code that checked for a `BuiltWithSSL` var that was always true.