### PR TITLE
TOOLS-3535 Add gosec as a linter and generate a SARIF report as part of release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.zip
 
 !**/testdata/**
+/dev-bin
 
 /mongorestore/testdata/txntest/oplog.bson
 

--- a/build.go
+++ b/build.go
@@ -17,6 +17,8 @@ func init() {
 	taskRegistry.Declare("checkMinVersion").Description("check if the minimum required Go version exists").Do(buildscript.CheckMinimumGoVersion)
 
 	// Static Analysis
+	taskRegistry.Declare("sa:installdevtools").Description("installs dev tools").Do(buildscript.SAInstallDevTools)
+	taskRegistry.Declare("sa:lint").Description("runs precious linting").DependsOn("sa:installdevtools").Do(buildscript.SAPreciousLint)
 	taskRegistry.Declare("sa:modtidy").Description("runs go mod tidy").Do(buildscript.SAModTidy)
 	taskRegistry.Declare("sa:evgvalidate").Description("runs evergreen validate").Do(buildscript.SAEvergreenValidate)
 

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -4,12 +4,198 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/craiggwilson/goke/pkg/sh"
 	"github.com/craiggwilson/goke/task"
 )
+
+const (
+	gosecPkg = "github.com/securego/gosec/v2/cmd/gosec@v2.20.0"
+
+	preciousVersion = "0.7.2"
+	ubiVersion      = "0.0.18"
+)
+
+func SAInstallDevTools(ctx *task.Context) error {
+	if err := installGosec(ctx); err != nil {
+		return err
+	}
+	if err := installUBI(ctx); err != nil {
+		return err
+	}
+	return installBinaryTool(
+		ctx,
+		"precious",
+		preciousVersion,
+		"houseabsolute/precious",
+		fmt.Sprintf(
+			"https://github.com/houseabsolute/precious/releases/download/v%s/precious-Linux-x86_64-musl.tar.gz",
+			preciousVersion,
+		),
+	)
+}
+
+// Install UBI.
+func installUBI(ctx *task.Context) error {
+	var err error
+	devBin, err := devBinDir()
+	if err != nil {
+		return err
+	}
+
+	ubi, err := devBinFile("ubi")
+	if err != nil {
+		return err
+	}
+
+	exists, err := executableExistsWithVersion(ctx, ubi, ubiVersion)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	var ubiBootstrapURL string
+	switch runtime.GOOS {
+	case "windows":
+		ubiBootstrapURL = "https://raw.githubusercontent.com/houseabsolute/ubi/ci-for-bootstrap/bootstrap/bootstrap-ubi.ps1"
+	default:
+		ubiBootstrapURL = "https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh"
+	}
+
+	s := strings.Split(ubiBootstrapURL, "/")
+	bootstrapPath := filepath.Join(os.TempDir(), s[len(s)-1])
+
+	out, err := os.Create(bootstrapPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	resp, err := httpGetWithRetries(ubiBootstrapURL, 5)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var cmd []string
+	if strings.HasSuffix(ubiBootstrapURL, ".ps1") {
+		cmd = []string{"powershell", bootstrapPath}
+	} else {
+		cmd = []string{"sh", bootstrapPath}
+	}
+
+	// On Windows the bootstrapper always installs into the current directory,
+	// so chdir there first.
+	return doInDir(devBin, func() error {
+		c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+		c.Env = []string{"TARGET=" + devBin, "TAG=v" + ubiVersion}
+		return sh.RunCmd(ctx, c)
+	})
+}
+
+// Install gosec.
+func installGosec(ctx *task.Context) error {
+	return goInstall(ctx, gosecPkg)
+}
+
+// Install a Golang package as an executable with "go install".
+func goInstall(ctx *task.Context, link string) error {
+	return withRetries(
+		5,
+		fmt.Sprintf("go install %s", link),
+		func() error {
+			return sh.Run(ctx, "go", "install", link)
+		},
+	)
+}
+
+func installBinaryTool(ctx *task.Context, exeName, toolVersion, githubProject, downloadURLForCI string) error {
+	devBin, err := devBinDir()
+	if err != nil {
+		return err
+	}
+
+	devBinExe, err := devBinFile(exeName)
+	if err != nil {
+		return err
+	}
+
+	exists, err := executableExistsWithVersion(ctx, devBinExe, preciousVersion)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	cmd := []string{
+		filepath.Join(devBin, "ubi"),
+		"--in", devBin,
+	}
+	if inCI() {
+		// Using the `--url` arg avoids hitting the GitHub API, but it skips
+		// all the platform detection ubi provides. We do it this way because
+		// even with authentication, the limits on the GitHub API are
+		// something like 5,000 requests an hour. Without it, the limit is way
+		// lower.
+		//
+		// This seemed simpler than adding a GitHub token to Evergreen. If we
+		// ever switch to GH Actions we can reconsider, since in that case
+		// we'd have a token automatically available in the `GITHUB_TOKEN` env
+		// var.
+		cmd = append(cmd, "--url", downloadURLForCI)
+	} else {
+		cmd = append(
+			cmd,
+			"--project", githubProject,
+			"--tag", "v"+toolVersion,
+		)
+	}
+
+	return withRetries(
+		5,
+		fmt.Sprintf("installing %s", exeName),
+		func() error {
+			return sh.Run(ctx, cmd[0], cmd[1:]...)
+		},
+	)
+}
+
+func SAPreciousLint(ctx *task.Context) error {
+	return runPrecious(ctx, "lint", "--all")
+}
+
+func runPrecious(ctx *task.Context, args ...string) error {
+	devBin, err := devBinDir()
+	if err != nil {
+		return err
+	}
+
+	cmd := append(
+		[]string{filepath.Join(devBin, "precious")},
+		args...,
+	)
+
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	return sh.RunCmd(ctx, c)
+}
 
 // SAModTidy runs go mod tidy and ensure no changes were made.
 // Copied from mongohouse: https://github.com/10gen/mongohouse/blob/333308814f96a0909c8125f71af7748b263e3263/buildscript/sa.go#L72

--- a/buildscript/util.go
+++ b/buildscript/util.go
@@ -1,0 +1,205 @@
+package buildscript
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/craiggwilson/goke/pkg/sh"
+	"github.com/craiggwilson/goke/task"
+	"github.com/pkg/errors"
+)
+
+func devBinDir() (string, error) {
+	return getRepoRootSubdir("dev-bin")
+}
+
+func devBinFile(filename string) (string, error) {
+	return getDirExeName("dev-bin", filename)
+}
+
+// getDirExeName returns the full path to the file in a subdirectory of the repo
+// root. For example: getDirExeName("dev-bin", "precious") returns
+// /path/to/mongosync/dev-bin/precious on unix-like systems and
+// C:\path\to\mongosync\dev-bin\precious.exe on Windows.
+func getDirExeName(dirname, filename string) (string, error) {
+	dir, err := getRepoRootSubdir(dirname)
+	if err != nil {
+		return "", err
+	}
+
+	target := filepath.Join(dir, filename)
+	if runtime.GOOS == "windows" {
+		target += ".exe"
+	}
+
+	return target, nil
+}
+
+// getRepoRootSubdir returns the absolute path to dirname inside the root of
+// the repository, creating it if it doesn't exist.
+func getRepoRootSubdir(dirname string) (string, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return "", err
+	}
+
+	fullPath := filepath.Join(root, dirname)
+	err = os.MkdirAll(fullPath, 0755)
+
+	return fullPath, err
+}
+
+var repoRootDir string
+
+// repoRoot is a wrapper around git.FindRepoRoot(), but caches it so that
+// multiple calls in the same invocation of the program won't run git multiple
+// times.
+func repoRoot() (string, error) {
+	if repoRootDir != "" {
+		return repoRootDir, nil
+	}
+
+	var err error
+	repoRootDir, err = findRepoRoot(context.Background())
+	return repoRootDir, err
+}
+
+// findRepoRoot returns the filesystem path of the root of the git repository
+// that contains the process’s current directory.
+func findRepoRoot(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find git repo root folder: %s", string(output))
+	}
+
+	return string(bytes.TrimSpace(output)), nil
+}
+
+func executableExistsWithVersion(ctx *task.Context, exe, exeVersion string) (bool, error) {
+	exists, err := pathExists(exe)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		var matches bool
+		matches, err = versionMatches(ctx, exe, exeVersion)
+		if err != nil {
+			return false, err
+		}
+		if matches {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func pathExists(p string) (bool, error) {
+	_, err := os.Stat(p)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func versionMatches(ctx *task.Context, exe, wantVersion string) (bool, error) {
+	out, err := sh.RunOutput(ctx, exe, "--version")
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(out, wantVersion), nil
+}
+
+func httpGetWithRetries(url string, n int) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+
+	err = withRetries(
+		n,
+		fmt.Sprintf("Getting %s\n", url),
+		func() error {
+			resp, err = http.Get(url)
+			return err
+		},
+	)
+
+	return resp, err
+}
+
+// withRetries attempts to run cb up to n times, with exponential backoff. The
+// backoff starts at 250ms and doubles each time, with a max of 32 seconds, so
+// in practice you cannot retry something more than 9 times, which will take
+// about a minute.
+func withRetries(n int, what string, cb func() error) error {
+	backoff := 250 * time.Millisecond
+	var err error
+
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			fmt.Printf("sleeping %s before retrying %s after error: %s\n", backoff, what, err)
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+
+		err = cb()
+		if err == nil {
+			return nil
+		}
+
+		// fail-safe
+		if backoff > 32*time.Second {
+			return errors.Wrapf(
+				err,
+				"%s failed to succeed before reaching max backoff duration",
+				what,
+			)
+		}
+	}
+
+	return errors.Wrapf(err, "%s failed to succeed after %d times", what, n)
+}
+
+// doInDir changes directory to dirname and runs cb, then restores the original
+// working directory before it returns.
+func doInDir(dirname string, cb func() error) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	err = os.Chdir(dirname)
+	if err != nil {
+		return errors.Wrapf(err, "cannot change directory to %s", dirname)
+	}
+
+	defer func() {
+		chdirErr := os.Chdir(wd)
+		if chdirErr != nil {
+			panic(
+				fmt.Sprintf(
+					"cannot change back to original working directory %s: %v",
+					wd,
+					chdirErr,
+				),
+			)
+		}
+	}()
+
+	return cb()
+}
+
+func inCI() bool {
+	return os.Getenv("EVG_BUILD_ID") != "" || os.Getenv("CI") != ""
+}

--- a/common.yml
+++ b/common.yml
@@ -528,6 +528,20 @@ functions:
           ./etc/generate-notices.pl > ./THIRD-PARTY-NOTICES
           git diff --exit-code
 
+  "generate gosec SARIF report":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        script: |
+          ${_set_shell_env}
+          set -x
+          set -v
+          set -e
+          go run build.go sa:installdevtools
+          GOSEC_SARIF_REPORT=1 ./dev-bin/precious lint --all --command gosec
+          cat SARIF.json
+
 pre:
   - command: shell.exec
     params:
@@ -659,6 +673,16 @@ tasks:
       - command: expansions.update
       - func: "upload release packages to s3"
       - func: "upload release packages to linux repos"
+
+  - name: gosec-SARIF-report
+    tags: ["git_tag"]
+    depends_on:
+      - name: push
+        variant: "*"
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "generate gosec SARIF report"
 
   - name: release-json
     tags: ["git_tag"]
@@ -1707,6 +1731,7 @@ buildvariants:
     run_on:
       - amazon1-2018-test
     tasks:
+      - name: gosec-SARIF-report
       - name: release-json
       - name: generate-full-json
 

--- a/common.yml
+++ b/common.yml
@@ -1460,6 +1460,7 @@ tasks:
             ${_set_shell_env}
             retVal=$(go run vendor/github.com/3rf/mongo-lint/golint/golint.go mongo* bson*);
             if [ "$retVal" = "" ]; then exit 0; else echo $retVal; exit 1; fi;
+            go run build.go sa:lint
 
   - name: lint-js
     commands:

--- a/common/archive/demultiplexer.go
+++ b/common/archive/demultiplexer.go
@@ -450,7 +450,9 @@ func (cache *SpecialCollectionCache) Pos() int64 {
 }
 
 func (cache *SpecialCollectionCache) Write(b []byte) (int, error) {
-	cache.hash.Write(b)
+	if _, err := cache.hash.Write(b); err != nil {
+		return 0, err
+	}
 	return cache.buf.Write(b)
 }
 
@@ -526,7 +528,9 @@ func (prioritizer *Prioritizer) Get() *intents.Intent {
 		prioritizer.NamespaceErrorChan <- fmt.Errorf("no intent for namespace %v", namespace)
 	} else {
 		if intent.BSONFile != nil {
-			intent.BSONFile.Open()
+			if err := intent.BSONFile.Open(); err != nil {
+				prioritizer.NamespaceErrorChan <- fmt.Errorf("error opening BSON file for %s: %v", intent.Namespace(), err)
+			}
 		}
 		if intent.IsOplog() {
 			// once we see the oplog we

--- a/common/db/db.go
+++ b/common/db/db.go
@@ -452,6 +452,7 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 			return nil, fmt.Errorf("CRL files are not supported on this platform")
 		}
 
+		// #nosec G402 -- we intentionally allow old TLS version for backwards compatibility
 		tlsConfig := &tls.Config{}
 		if opts.SSLAllowInvalidCert || opts.SSLAllowInvalidHost || opts.TLSInsecure {
 			tlsConfig.InsecureSkipVerify = true

--- a/common/json/encode.go
+++ b/common/json/encode.go
@@ -241,6 +241,9 @@ func (e *MarshalerError) Error() string {
 
 var hex = "0123456789abcdef"
 
+// Any write on the encodeState cannot fail because we're writing to a
+// `bytes.Buffer`, which never fails.
+//
 // An encodeState encodes JSON into a bytes.Buffer.
 type encodeState struct {
 	bytes.Buffer // accumulated output

--- a/common/json/stream.go
+++ b/common/json/stream.go
@@ -216,7 +216,9 @@ func (enc *Encoder) Encode(v interface{}) error {
 	// is required if the encoded value was a number,
 	// so that the reader knows there aren't more
 	// digits coming.
-	e.WriteByte('\n')
+	if err = e.WriteByte('\n'); err != nil {
+		return err
+	}
 
 	if _, err = enc.w.Write(e.Bytes()); err != nil {
 		enc.err = err

--- a/common/txn/buffer.go
+++ b/common/txn/buffer.go
@@ -54,9 +54,8 @@ func newTxnState(op db.Oplog) *txnState {
 // Because state is currently kept in memory, purge merely drops the reference
 // so the GC will eventually clean up.  Eventually, this might clean up a file
 // on disk.
-func (ts *txnState) purge() error {
+func (ts *txnState) purge() {
 	ts.buffer = nil
-	return nil
 }
 
 // Buffer stores transaction oplog entries until they are needed
@@ -281,10 +280,7 @@ func (b *Buffer) Stop() error {
 	b.wg.Wait()
 	var firstErr error
 	for _, state := range b.txns {
-		err := state.purge()
-		if err != nil && firstErr == nil {
-			firstErr = err
-		}
+		state.purge()
 	}
 
 	return firstErr

--- a/etc/gosec-wrapper.sh
+++ b/etc/gosec-wrapper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# This rule complains about reading or writing to paths based on user input,
+# but most of the tools exist for the purpose of reading and writing from/to
+# user-provided paths.
+EXCLUDE="-exclude=G304"
+SEVERITY="-severity=high"
+
+if [ -n "$GOSEC_SARIF_REPORT" ]; then
+    gosec -fmt sarif $EXCLUDE $SEVERITY -track-suppressions $@ | tee SARIF.json
+else
+    gosec $EXCLUDE $SEVERITY $@
+fi

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+go run build.go sa:installdevtools
+./dev-bin/precious lint --staged

--- a/git-hooks/setup
+++ b/git-hooks/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DIR=$(dirname "$0")
+ln -sf "../../$DIR/pre-commit" "$DIR/../.git/hooks/pre-commit"

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -272,7 +272,6 @@ func (dump *MongoDump) Dump() (err error) {
 			// The Mux runs until its Control is closed
 			close(dump.archive.Mux.Control)
 			muxErr := <-dump.archive.Mux.Completed
-			archiveOut.Close()
 			if muxErr != nil {
 				if err != nil {
 					err = fmt.Errorf("archive writer: %v / %v", err, muxErr)
@@ -280,6 +279,7 @@ func (dump *MongoDump) Dump() (err error) {
 					err = fmt.Errorf("archive writer: %v", muxErr)
 				}
 				log.Logvf(log.DebugLow, "%v", err)
+				err = archiveOut.Close()
 			} else {
 				log.Logvf(log.DebugLow, "mux completed successfully")
 			}

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -445,7 +445,10 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 
 func (dump *MongoDump) GetValidDbs() ([]string, error) {
 	var validDbs []string
-	dump.SessionProvider.GetSession()
+	_, err := dump.SessionProvider.GetSession()
+	if err != nil {
+		return nil, fmt.Errorf("error getting session: %v", err)
+	}
 	dbs, err := dump.SessionProvider.DatabaseNames()
 	if err != nil {
 		return nil, fmt.Errorf("error getting database names: %v", err)

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -9,6 +9,8 @@ package mongodump
 import (
 	"bytes"
 	"context"
+
+	// #nosec G505 -- we do not use this digest algorithm in a security-sensitive way.
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
@@ -223,6 +225,7 @@ func (dump *MongoDump) outputPath(dbName, colName string) string {
 	escapedColName := util.EscapeCollectionName(colName)
 	if len(escapedColName) > 238 {
 		colNameTruncated := escapedColName[:208]
+		// #nosec G401 -- we do not use this digest algorithm in a security-sensitive way.
 		colNameHashBytes := sha1.Sum([]byte(colName))
 		colNameHashBase64 := base64.RawURLEncoding.EncodeToString(colNameHashBytes[:])
 

--- a/mongoexport/csv.go
+++ b/mongoexport/csv.go
@@ -95,7 +95,9 @@ func (csvExporter *CSVExportOutput) ExportDocument(document bson.D) error {
 			rowOut = append(rowOut, fmt.Sprintf("%v", fieldVal))
 		}
 	}
-	csvExporter.csvWriter.Write(rowOut)
+	if err = csvExporter.csvWriter.Write(rowOut); err != nil {
+		return err
+	}
 	csvExporter.NumExported++
 	return csvExporter.csvWriter.Error()
 }

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -466,7 +466,9 @@ func (exp *MongoExport) exportInternal(out io.Writer) (int64, error) {
 	if err != nil {
 		return docsCount, err
 	}
-	exportOutput.Flush()
+	if err = exportOutput.Flush(); err != nil {
+		return docsCount, err
+	}
 	return docsCount, nil
 }
 

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -127,7 +127,10 @@ func (bd *bomDiscardingReader) Read(p []byte) (int, error) {
 	if !bd.didRead {
 		bom, err := bd.buf.Peek(3)
 		if err == nil && bytes.Equal(bom, UTF8_BOM) {
-			bd.buf.Read(make([]byte, 3)) // discard BOM
+			_, err = bd.buf.Read(make([]byte, 3)) // discard BOM
+			if err != nil {
+				return 0, err
+			}
 		}
 		bd.didRead = true
 	}

--- a/mongoimport/csv.go
+++ b/mongoimport/csv.go
@@ -153,12 +153,14 @@ func (c CSVConverter) Convert() (b bson.D, err error) {
 		c.useArrayIndexFields,
 	)
 	if _, ok := err.(coercionError); ok {
-		c.Print()
+		if err = c.Print(); err != nil {
+			return
+		}
 		err = nil
 	}
 	return
 }
 
-func (c CSVConverter) Print() {
-	c.rejectWriter.Write(c.data)
+func (c CSVConverter) Print() error {
+	return c.rejectWriter.Write(c.data)
 }

--- a/mongoimport/csv/reader.go
+++ b/mongoimport/csv/reader.go
@@ -189,7 +189,9 @@ func (r *Reader) readRune() (rune, error) {
 		r1, _, err = r.r.ReadRune()
 		if err == nil {
 			if r1 != '\n' {
-				r.r.UnreadRune()
+				if err = r.r.UnreadRune(); err != nil {
+					return r1, err
+				}
 				r1 = '\r'
 			}
 		}
@@ -231,7 +233,9 @@ func (r *Reader) parseRecord() (fields []string, err error) {
 	if r.Comment != 0 && r1 == r.Comment {
 		return nil, r.skip('\n')
 	}
-	r.r.UnreadRune()
+	if err := r.r.UnreadRune(); err != nil {
+		return nil, err
+	}
 
 	// At this point we have at least one field.
 	for {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -493,13 +493,13 @@ func (imp *MongoImport) importDocument(inserter *db.BufferedBulkInserter, docume
 		result, err = inserter.Insert(document)
 	} else if imp.IngestOptions.Mode == modeUpsert {
 		if selector == nil {
-			imp.fallbackToInsert(inserter, document)
+			result, err = imp.fallbackToInsert(inserter, document)
 		} else {
 			result, err = inserter.Replace(selector, document)
 		}
 	} else if imp.IngestOptions.Mode == modeMerge {
 		if selector == nil {
-			imp.fallbackToInsert(inserter, document)
+			result, err = imp.fallbackToInsert(inserter, document)
 		} else {
 			updateDoc := bson.D{{"$set", document}}
 			result, err = inserter.Update(selector, updateDoc)

--- a/mongoimport/tsv.go
+++ b/mongoimport/tsv.go
@@ -164,12 +164,12 @@ func (c TSVConverter) Convert() (b bson.D, err error) {
 		c.useArrayIndexFields,
 	)
 	if _, ok := err.(coercionError); ok {
-		c.Print()
-		err = nil
+		err = c.Print()
 	}
 	return
 }
 
-func (c TSVConverter) Print() {
-	c.rejectWriter.Write([]byte(c.data + "\n"))
+func (c TSVConverter) Print() error {
+	_, err := c.rejectWriter.Write([]byte(c.data + "\n"))
+	return err
 }

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -273,7 +273,9 @@ func (restore *MongoRestore) createCollectionWithCommand(session *mongo.Client, 
 	}
 
 	res := bson.M{}
-	singleRes.Decode(&res)
+	if err := singleRes.Decode(&res); err != nil {
+		return fmt.Errorf("error decoding result of create command: %v", err)
+	}
 	if util.IsFalsy(res["ok"]) {
 		return fmt.Errorf("create command: %v", res["errmsg"])
 	}
@@ -469,7 +471,9 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 		return fmt.Errorf("error running merge command: %v", err)
 	}
 	res := bson.M{}
-	resSingle.Decode(&res)
+	if err = resSingle.Decode(&res); err != nil {
+		return fmt.Errorf("error decoding result of merge command: %v", err)
+	}
 	if util.IsFalsy(res["ok"]) {
 		return fmt.Errorf("_mergeAuthzCollections command: %v", res["errmsg"])
 	}

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -336,7 +336,9 @@ func (node *NodeMonitor) Poll(discover chan string, checkShards bool) (*status.S
 				discover <- shardHost
 			}
 		}
-		shardCursor.Close(nil)
+		if closeErr := shardCursor.Close(nil); closeErr != nil {
+			return nil, fmt.Errorf("error closing shard discovery cursor: %v", err)
+		}
 	}
 
 	return stat, nil

--- a/precious.toml
+++ b/precious.toml
@@ -1,0 +1,20 @@
+# We could run this via golangci-lint but we want to exclude more directories
+# for gosec than we do for other linting. There doesn't seem to be a way to
+# configure these excludes when running gosec as part of golangci-lint.
+[commands.gosec]
+type = "lint"
+include = "**/*.go"
+exclude = [
+    "buildscript/**/*.go",
+    "common/testutil/**/*.go",
+    "release/**/*.go",
+    "vendor/**/*.go",
+]
+invoke.per-dir-or-once = 7
+working-dir = "root"
+path-args = "dir"
+# This wrapper lets us control the output with an env var so we can generate a
+# SARIF report in Evergreen but use the default format for linting.
+cmd = [ "$PRECIOUS_ROOT/etc/gosec-wrapper.sh", "-terse" ]
+ok_exit_codes = [0]
+lint_failure_exit_codes = [1]

--- a/set_goenv.sh
+++ b/set_goenv.sh
@@ -70,5 +70,7 @@ set_goenv() {
         return 1
     fi
 
+    export PATH="$PATH:$GOPATH/bin"
+
     return
 }


### PR DESCRIPTION
This PR adds infrastructure to install dev tools including `precious`, which we use to run `gosec` as a linter. As part of the release process, this will generate a SARIF report. If there are new issues in the code base, then the release will be blocked.

It also updates the `lint-go` Evergreen task to run our new linting, which right now will just run `gosec`.