### PR TITLE
Fix lint-js and SRV test failures and clean up options testing code

### DIFF
--- a/build.go
+++ b/build.go
@@ -24,7 +24,6 @@ func init() {
 	taskRegistry.Declare("test:unit").Description("runs all unit tests").OptionalArgs("pkgs").Do(buildscript.TestUnit)
 	taskRegistry.Declare("test:integration").Description("runs all integration tests").OptionalArgs("pkgs", "ssl", "auth", "kerberos", "topology").Do(buildscript.TestIntegration)
 	taskRegistry.Declare("test:kerberos").Description("runs all kerberos tests").Do(buildscript.TestKerberos)
-	taskRegistry.Declare("test:srv").Description("runs all srv tests").Do(buildscript.TestSRV)
 	taskRegistry.Declare("test:awsauth").Description("runs all aws auth tests").Do(buildscript.TestAWSAuth)
 }
 

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -87,11 +87,6 @@ func TestIntegration(ctx *task.Context) error {
 	return runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
 }
 
-// TestSRV is an Executor that runs all SRV tests for the provided packages.
-func TestSRV(ctx *task.Context) error {
-	return runTests(ctx, selectedPkgs(ctx), testtype.SRVConnectionStringTestType)
-}
-
 // TestAWSAuth is an Executor that runs all AWS auth tests for the provided packages.
 func TestAWSAuth(ctx *task.Context) error {
 	return runTests(ctx, selectedPkgs(ctx), testtype.AWSAuthTestType)

--- a/common.yml
+++ b/common.yml
@@ -1448,9 +1448,9 @@ tasks:
             set -x
             set -v
             set -e
-            PATH="/opt/node/bin:$PATH"
-            /opt/node/bin/npm install eslint@3.2
-            /opt/node/bin/node node_modules/eslint/bin/eslint.js test/qa-tests/jstests/**/*.js
+            PATH="/opt/nodejs/node-v16.17.0-linux-x64/bin:$PATH"
+            npm install eslint@3.2
+            node node_modules/eslint/bin/eslint.js test/qa-tests/jstests/**/*.js
 
   - name: qa-tests-5.0
     tags: ["5.0"]

--- a/common.yml
+++ b/common.yml
@@ -567,7 +567,6 @@ pre:
           export TOOLS_TESTING_AUTH_USERNAME='${auth_username}'
           export TOOLS_TESTING_AUTH_PASSWORD='${auth_password}'
           export MONGODB_KERBEROS_PASSWORD='${kerberos_password}'
-          export ATLAS_URI='${atlas_srv_uri}'
           export TOOLS_TESTING_PKCS8_PASSWORD='${pkcs8_password}'
           set -o xtrace
           set -o verbose
@@ -1647,17 +1646,6 @@ tasks:
         vars:
           target: test:unit
 
-  - name: srv
-    commands:
-      - command: expansions.update
-      - func: "fetch source"
-      - func: "run make target"
-        vars:
-          target: build
-      - func: "run make target"
-        vars:
-          target: test:srv
-
   - name: vet
     commands:
       - func: "fetch source"
@@ -1923,7 +1911,6 @@ buildvariants:
       resmoke_args: --jobs 4
     tasks:
       - name: "unit"
-      - name: "srv"
       - name: ".4.0"
       - name: ".4.2"
       - name: ".4.4"
@@ -2275,10 +2262,6 @@ github_pr_aliases:
   # a relatively recent platform that supports a wide range of servers.
   - variant: "rhel80"
     task: "^(aws-auth|integration|legacy|native-cert-ssl|qa-dump-restore|qa-tests)-.*"
-  # Run srv tests on one variant. We pick RHEL 8.0 because it's a relatively
-  # recent platform that supports a wide range of servers.
-  - variant: "rhel80"
-    task: "^srv*"
   # RHEL 8.0 doesn't run against server 3.4, so we do that with RHEL 7.0.
   - variant: "rhel70"
     task: "^(aws-auth|integration|native-cert-ssl|qa-dump-restore|qa-tests)-3.4$"

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -792,16 +792,18 @@ func runOptionsTestCases(t *testing.T, testCases []optionsTester) {
 	}
 
 	for _, c := range testCases {
-		toolOptions := New("test", "", "", "", true, enabled)
 		argString := fmt.Sprintf("%s --uri %s", c.options, c.uri)
-		t.Logf("Test Case: %s\n", argString)
-		args := strings.Split(argString, " ")
-		_, err := toolOptions.ParseArgs(args)
-		if c.outcome == ShouldFail {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-		}
+		t.Run(argString, func(t *testing.T) {
+			t.Log(argString)
+			toolOptions := New("test", "", "", "", true, enabled)
+			args := strings.Split(argString, " ")
+			_, err := toolOptions.ParseArgs(args)
+			if c.outcome == ShouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -12,15 +12,14 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/testtype"
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 
-	"runtime"
 	"testing"
 	"time"
 )
@@ -33,120 +32,120 @@ const (
 func TestLogUnsupportedOptions(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	Convey("With all command-line options enabled", t, func() {
-		var buffer bytes.Buffer
+	var buffer bytes.Buffer
 
-		log.SetWriter(&buffer)
-		defer log.SetWriter(os.Stderr)
+	log.SetWriter(&buffer)
+	defer log.SetWriter(os.Stderr)
+
+	t.Run("no warning should be logged if there are no unsupported options", func(t *testing.T) {
+		args := []string{"mongodb://mongodb.test.com:27017"}
 
 		enabled := EnabledOptions{true, true, true, true}
 		opts := New("", "", "", "", true, enabled)
 
-		Convey("no warning should be logged if there are no unsupported options", func() {
-			args := []string{"mongodb://mongodb.test.com:27017"}
+		_, err := opts.ParseArgs(args)
+		require.NoError(t, err)
 
-			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
+		opts.LogUnsupportedOptions()
 
-			opts.LogUnsupportedOptions()
+		result := buffer.String()
+		require.Empty(t, result)
+	})
 
-			result := buffer.String()
-			So(result, ShouldBeEmpty)
-		})
+	t.Run("a warning should be logged if there is an unsupported option", func(t *testing.T) {
+		args := []string{"mongodb://mongodb.test.com:27017/?foo=bar"}
 
-		Convey("a warning should be logged if there is an unsupported option", func() {
-			args := []string{"mongodb://mongodb.test.com:27017/?foo=bar"}
+		enabled := EnabledOptions{true, true, true, true}
+		opts := New("", "", "", "", true, enabled)
 
-			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
+		_, err := opts.ParseArgs(args)
+		require.NoError(t, err)
 
-			opts.LogUnsupportedOptions()
+		opts.LogUnsupportedOptions()
 
-			result := buffer.String()
-			expectedResult := fmt.Sprintf(unknownOptionsWarningFormat, "foo")
+		result := buffer.String()
+		expectedResult := fmt.Sprintf(unknownOptionsWarningFormat, "foo")
 
-			So(result, ShouldContainSubstring, expectedResult)
-		})
+		require.Contains(t, result, expectedResult)
 	})
 }
 
 func TestVerbosityFlag(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
-	Convey("With a new ToolOptions", t, func() {
-		enabled := EnabledOptions{false, false, false, false}
-		optPtr := New("", "", "", "", true, enabled)
-		So(optPtr, ShouldNotBeNil)
-		So(optPtr.parser, ShouldNotBeNil)
+	enabled := EnabledOptions{false, false, false, false}
+	optPtr := New("", "", "", "", true, enabled)
+	require.NotNil(t, optPtr)
+	require.NotNil(t, optPtr.parser)
 
-		Convey("no verbosity flags, Level should be 0", func() {
-			_, err := optPtr.CallArgParser([]string{})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 0)
-		})
-
-		Convey("one short verbosity flag, Level should be 1", func() {
-			_, err := optPtr.CallArgParser([]string{"-v"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 1)
-		})
-
-		Convey("three short verbosity flags (consecutive), Level should be 3", func() {
-			_, err := optPtr.CallArgParser([]string{"-vvv"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("three short verbosity flags (dispersed), Level should be 3", func() {
-			_, err := optPtr.CallArgParser([]string{"-v", "-v", "-v"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("short verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.CallArgParser([]string{"-v=3"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("consecutive short flags with assignment, only assignment holds", func() {
-			_, err := optPtr.CallArgParser([]string{"-vv=3"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("one long verbose flag, Level should be 1", func() {
-			_, err := optPtr.CallArgParser([]string{"--verbose"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 1)
-		})
-
-		Convey("three long verbosity flags, Level should be 3", func() {
-			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose", "--verbose"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("long verbosity flag assigned to 3, Level should be 3", func() {
-			_, err := optPtr.CallArgParser([]string{"--verbose=3"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 3)
-		})
-
-		Convey("mixed assignment and bare flag, total is sum", func() {
-			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 4)
-		})
-
-		Convey("run CallArgParser multiple times, level should be correct", func() {
-			_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
-			So(err, ShouldBeNil)
-			_, err = optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
-			So(err, ShouldBeNil)
-			So(optPtr.Level(), ShouldEqual, 4)
-		})
+	t.Run("no verbosity flags, Level should be 0", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{})
+		require.NoError(t, err)
+		require.Equal(t, 0, optPtr.Level())
 	})
+
+	t.Run("one short verbosity flag, Level should be 1", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"-v"})
+		require.NoError(t, err)
+		require.Equal(t, 1, optPtr.Level())
+	})
+
+	t.Run("three short verbosity flags (consecutive), Level should be 3", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"-vvv"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("three short verbosity flags (dispersed), Level should be 3", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"-v", "-v", "-v"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("short verbosity flag assigned to 3, Level should be 3", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"-v=3"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("consecutive short flags with assignment, only assignment holds", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"-vv=3"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("one long verbose flag, Level should be 1", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"--verbose"})
+		require.NoError(t, err)
+		require.Equal(t, 1, optPtr.Level())
+	})
+
+	t.Run("three long verbosity flags, Level should be 3", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose", "--verbose"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("long verbosity flag assigned to 3, Level should be 3", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"--verbose=3"})
+		require.NoError(t, err)
+		require.Equal(t, 3, optPtr.Level())
+	})
+
+	t.Run("mixed assignment and bare flag, total is sum", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
+		require.NoError(t, err)
+		require.Equal(t, 4, optPtr.Level())
+	})
+
+	t.Run("run CallArgParser multiple times, level should be correct", func(t *testing.T) {
+		_, err := optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
+		require.NoError(t, err)
+		_, err = optPtr.CallArgParser([]string{"--verbose", "--verbose=3"})
+		require.NoError(t, err)
+		require.Equal(t, 4, optPtr.Level())
+	})
+
 }
 
 type uriTester struct {
@@ -164,460 +163,456 @@ func TestParseAndSetOptions(t *testing.T) {
 
 	FalseValue := false
 
-	Convey("With a matrix of URIs and expected results", t, func() {
-		enabledURIOnly := EnabledOptions{false, false, false, true}
-		testCases := []uriTester{
-			{
-				Name: "built with ssl",
-				CS: connstring.ConnString{
-					SSL:    true,
-					SSLSet: true,
-				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL: &SSL{
-						UseSSL: true,
-					},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: enabledURIOnly,
-				},
-				ShouldError: false,
+	enabledURIOnly := EnabledOptions{false, false, false, true}
+	testCases := []uriTester{
+		{
+			Name: "built with ssl",
+			CS: connstring.ConnString{
+				SSL:    true,
+				SSLSet: true,
 			},
-			{
-				Name: "built with ssl using SRV",
-				CS: connstring.ConnString{
-					SSL:      true,
-					SSLSet:   true,
-					Original: "mongodb+srv://example.com/",
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL: &SSL{
+					UseSSL: true,
 				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL: &SSL{
-						UseSSL: true,
-					},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: enabledURIOnly,
-				},
-				ShouldError: false,
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: enabledURIOnly,
 			},
-			{
-				Name: "not built with gssapi",
-				CS: connstring.ConnString{
-					AuthMechanism: "GSSAPI",
-				},
-				WithGSSAPI:   false,
-				OptsIn:       New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: New("", "", "", "", true, enabledURIOnly),
-				ShouldError:  true,
+			ShouldError: false,
+		},
+		{
+			Name: "built with ssl using SRV",
+			CS: connstring.ConnString{
+				SSL:      true,
+				SSLSet:   true,
+				Original: "mongodb+srv://example.com/",
 			},
-			{
-				Name: "built with gssapi",
-				CS: connstring.ConnString{
-					AuthMechanism: "GSSAPI",
-					AuthMechanismProperties: map[string]string{
-						"SERVICE_NAME": "service",
-					},
-					AuthMechanismPropertiesSet: true,
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL: &SSL{
+					UseSSL: true,
 				},
-				WithGSSAPI: true,
-				OptsIn:     New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth:       &Auth{},
-					Namespace:  &Namespace{},
-					Kerberos: &Kerberos{
-						Service: "service",
-					},
-					enabledOptions: enabledURIOnly,
-				},
-				ShouldError: false,
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: enabledURIOnly,
 			},
-			{
-				Name: "connection fields set",
-				CS: connstring.ConnString{
-					ConnectTimeout:    time.Duration(100) * time.Millisecond,
-					ConnectTimeoutSet: true,
-					SocketTimeout:     time.Duration(200) * time.Millisecond,
-					SocketTimeoutSet:  true,
-				},
-				OptsIn: &ToolOptions{
-					General:   &General{},
-					Verbosity: &Verbosity{},
-					Connection: &Connection{
-						Timeout: 3, // The default value
-					},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:   &General{},
-					Verbosity: &Verbosity{},
-					Connection: &Connection{
-						Timeout:       100,
-						SocketTimeout: 200,
-					},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError: false,
+			ShouldError: false,
+		},
+		{
+			Name: "not built with gssapi",
+			CS: connstring.ConnString{
+				AuthMechanism: "GSSAPI",
 			},
-			{
-				Name: "auth fields set",
-				CS: connstring.ConnString{
-					AuthMechanism: "MONGODB-X509",
-					AuthSource:    "",
-					AuthSourceSet: true,
-					Username:      "user",
-					Password:      "password",
-					PasswordSet:   true,
+			WithGSSAPI:   false,
+			OptsIn:       New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: New("", "", "", "", true, enabledURIOnly),
+			ShouldError:  true,
+		},
+		{
+			Name: "built with gssapi",
+			CS: connstring.ConnString{
+				AuthMechanism: "GSSAPI",
+				AuthMechanismProperties: map[string]string{
+					"SERVICE_NAME": "service",
 				},
-				OptsIn: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Auth: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth: &Auth{
-						Username:  "user",
-						Password:  "password",
-						Source:    "",
-						Mechanism: "MONGODB-X509",
-					},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError: false,
+				AuthMechanismPropertiesSet: true,
 			},
-			{
-				Name: "aws auth fields set",
-				CS: connstring.ConnString{
-					AuthMechanism: "MONGODB-AWS",
-					AuthSource:    "",
-					AuthSourceSet: true,
-					PasswordSet:   true,
-					AuthMechanismProperties: map[string]string{
-						"AWS_SESSION_TOKEN": "token",
-					},
-					AuthMechanismPropertiesSet: true,
+			WithGSSAPI: true,
+			OptsIn:     New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth:       &Auth{},
+				Namespace:  &Namespace{},
+				Kerberos: &Kerberos{
+					Service: "service",
 				},
-				OptsIn: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Auth: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth: &Auth{
-						Source:          "",
-						Mechanism:       "MONGODB-AWS",
-						AWSSessionToken: "token",
-					},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError: false,
+				enabledOptions: enabledURIOnly,
 			},
-			{
-				Name: "kerberos fields set but AuthMechanismProperties not init in connString",
-				CS: connstring.ConnString{
-					AuthMechanism:              "GSSAPI",
-					AuthSource:                 "",
-					AuthSourceSet:              true,
-					PasswordSet:                true,
-					AuthMechanismPropertiesSet: false,
-				},
-				WithGSSAPI: true,
-				OptsIn: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth:       &Auth{},
-					Namespace:  &Namespace{},
-					Kerberos: &Kerberos{
-						Service: "service",
-					},
-					enabledOptions: EnabledOptions{Auth: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth: &Auth{
-						Source:    "",
-						Mechanism: "GSSAPI",
-					},
-					Namespace: &Namespace{},
-					Kerberos: &Kerberos{
-						Service: "service",
-					},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError: false,
+			ShouldError: false,
+		},
+		{
+			Name: "connection fields set",
+			CS: connstring.ConnString{
+				ConnectTimeout:    time.Duration(100) * time.Millisecond,
+				ConnectTimeoutSet: true,
+				SocketTimeout:     time.Duration(200) * time.Millisecond,
+				SocketTimeoutSet:  true,
 			},
-			{
-				Name: "should ask for user password",
-				CS: connstring.ConnString{
-					AuthMechanism: "MONGODB-X509",
-					AuthSource:    "",
-					Username:      "user",
+			OptsIn: &ToolOptions{
+				General:   &General{},
+				Verbosity: &Verbosity{},
+				Connection: &Connection{
+					Timeout: 3, // The default value
 				},
-				OptsIn: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Auth: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:    &General{},
-					Verbosity:  &Verbosity{},
-					Connection: &Connection{},
-					URI:        &URI{},
-					SSL:        &SSL{},
-					Auth: &Auth{
-						Username:  "user",
-						Source:    "",
-						Mechanism: "MONGODB-X509",
-					},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError:              false,
-				AuthShouldAskForPassword: true,
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
 			},
-			{
-				Name: "single connect sets 'Direct'",
-				CS: connstring.ConnString{
-					Connect: connstring.SingleConnect,
+			OptsExpected: &ToolOptions{
+				General:   &General{},
+				Verbosity: &Verbosity{},
+				Connection: &Connection{
+					Timeout:       100,
+					SocketTimeout: 200,
 				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Direct:         true,
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{URI: true},
-				},
-				ShouldError: false,
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
 			},
-			{
-				Name: "direct connection sets 'Direct'",
-				CS: connstring.ConnString{
-					DirectConnection: true,
-				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Direct:         true,
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{URI: true},
-				},
-				ShouldError: false,
+			ShouldError: false,
+		},
+		{
+			Name: "auth fields set",
+			CS: connstring.ConnString{
+				AuthMechanism: "MONGODB-X509",
+				AuthSource:    "",
+				AuthSourceSet: true,
+				Username:      "user",
+				Password:      "password",
+				PasswordSet:   true,
 			},
-			{
-				Name: "ReplSetName is set when CS contains it",
-				CS: connstring.ConnString{
-					ReplicaSet: "replset",
-				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{URI: true},
-					ReplicaSetName: "replset",
-				},
-				ShouldError: false,
+			OptsIn: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Auth: true, URI: true},
 			},
-			{
-				Name: "RetryWrites is set when CS contains it",
-				CS: connstring.ConnString{
-					RetryWritesSet: true,
-					RetryWrites:    false,
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth: &Auth{
+					Username:  "user",
+					Password:  "password",
+					Source:    "",
+					Mechanism: "MONGODB-X509",
 				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{URI: true},
-					RetryWrites:    &FalseValue,
-				},
-				ShouldError: false,
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
 			},
-			{
-				Name: "Direct is false when loadbalanced == true",
-				CS: connstring.ConnString{
-					LoadBalanced:    true,
-					LoadBalancedSet: true,
+			ShouldError: false,
+		},
+		{
+			Name: "aws auth fields set",
+			CS: connstring.ConnString{
+				AuthMechanism: "MONGODB-AWS",
+				AuthSource:    "",
+				AuthSourceSet: true,
+				PasswordSet:   true,
+				AuthMechanismProperties: map[string]string{
+					"AWS_SESSION_TOKEN": "token",
 				},
-				OptsIn: New("", "", "", "", true, enabledURIOnly),
-				OptsExpected: &ToolOptions{
-					General:        &General{},
-					Verbosity:      &Verbosity{},
-					Connection:     &Connection{},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{URI: true},
-					ReplicaSetName: "",
-					Direct:         false,
-				},
-				ShouldError: false,
+				AuthMechanismPropertiesSet: true,
 			},
-			{
-				Name: "Don't fail when uri and options set",
-				CS: connstring.ConnString{
-					Hosts: []string{"host"},
-				},
-				OptsIn: &ToolOptions{
-					General:   &General{},
-					Verbosity: &Verbosity{},
-					Connection: &Connection{
-						Host: "host",
-					},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				OptsExpected: &ToolOptions{
-					General:   &General{},
-					Verbosity: &Verbosity{},
-					Connection: &Connection{
-						Host: "host",
-					},
-					URI:            &URI{},
-					SSL:            &SSL{},
-					Auth:           &Auth{},
-					Namespace:      &Namespace{},
-					Kerberos:       &Kerberos{},
-					enabledOptions: EnabledOptions{Connection: true, URI: true},
-				},
-				ShouldError: false,
+			OptsIn: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Auth: true, URI: true},
 			},
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth: &Auth{
+					Source:          "",
+					Mechanism:       "MONGODB-AWS",
+					AWSSessionToken: "token",
+				},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "kerberos fields set but AuthMechanismProperties not init in connString",
+			CS: connstring.ConnString{
+				AuthMechanism:              "GSSAPI",
+				AuthSource:                 "",
+				AuthSourceSet:              true,
+				PasswordSet:                true,
+				AuthMechanismPropertiesSet: false,
+			},
+			WithGSSAPI: true,
+			OptsIn: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth:       &Auth{},
+				Namespace:  &Namespace{},
+				Kerberos: &Kerberos{
+					Service: "service",
+				},
+				enabledOptions: EnabledOptions{Auth: true, URI: true},
+			},
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth: &Auth{
+					Source:    "",
+					Mechanism: "GSSAPI",
+				},
+				Namespace: &Namespace{},
+				Kerberos: &Kerberos{
+					Service: "service",
+				},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "should ask for user password",
+			CS: connstring.ConnString{
+				AuthMechanism: "MONGODB-X509",
+				AuthSource:    "",
+				Username:      "user",
+			},
+			OptsIn: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Auth: true, URI: true},
+			},
+			OptsExpected: &ToolOptions{
+				General:    &General{},
+				Verbosity:  &Verbosity{},
+				Connection: &Connection{},
+				URI:        &URI{},
+				SSL:        &SSL{},
+				Auth: &Auth{
+					Username:  "user",
+					Source:    "",
+					Mechanism: "MONGODB-X509",
+				},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
+			},
+			ShouldError:              false,
+			AuthShouldAskForPassword: true,
+		},
+		{
+			Name: "single connect sets 'Direct'",
+			CS: connstring.ConnString{
+				Connect: connstring.SingleConnect,
+			},
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Direct:         true,
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{URI: true},
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "direct connection sets 'Direct'",
+			CS: connstring.ConnString{
+				DirectConnection: true,
+			},
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Direct:         true,
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{URI: true},
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "ReplSetName is set when CS contains it",
+			CS: connstring.ConnString{
+				ReplicaSet: "replset",
+			},
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{URI: true},
+				ReplicaSetName: "replset",
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "RetryWrites is set when CS contains it",
+			CS: connstring.ConnString{
+				RetryWritesSet: true,
+				RetryWrites:    false,
+			},
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{URI: true},
+				RetryWrites:    &FalseValue,
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "Direct is false when loadbalanced == true",
+			CS: connstring.ConnString{
+				LoadBalanced:    true,
+				LoadBalancedSet: true,
+			},
+			OptsIn: New("", "", "", "", true, enabledURIOnly),
+			OptsExpected: &ToolOptions{
+				General:        &General{},
+				Verbosity:      &Verbosity{},
+				Connection:     &Connection{},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{URI: true},
+				ReplicaSetName: "",
+				Direct:         false,
+			},
+			ShouldError: false,
+		},
+		{
+			Name: "Don't fail when uri and options set",
+			CS: connstring.ConnString{
+				Hosts: []string{"host"},
+			},
+			OptsIn: &ToolOptions{
+				General:   &General{},
+				Verbosity: &Verbosity{},
+				Connection: &Connection{
+					Host: "host",
+				},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
+			},
+			OptsExpected: &ToolOptions{
+				General:   &General{},
+				Verbosity: &Verbosity{},
+				Connection: &Connection{
+					Host: "host",
+				},
+				URI:            &URI{},
+				SSL:            &SSL{},
+				Auth:           &Auth{},
+				Namespace:      &Namespace{},
+				Kerberos:       &Kerberos{},
+				enabledOptions: EnabledOptions{Connection: true, URI: true},
+			},
+			ShouldError: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Log("Test Case:", testCase.Name)
+
+		testCase.OptsIn.URI.ConnectionString = "mongodb://dummy"
+		testCase.OptsExpected.URI.ConnectionString = "mongodb://dummy"
+
+		BuiltWithGSSAPI = testCase.WithGSSAPI
+		defer func() {
+			BuiltWithGSSAPI = true
+		}()
+
+		testCase.OptsIn.URI.ConnString = testCase.CS
+
+		err := testCase.OptsIn.setOptionsFromURI(testCase.CS)
+
+		if testCase.ShouldError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
 		}
 
-		Convey("results should match expected", func() {
-			for _, testCase := range testCases {
-				t.Log("Test Case:", testCase.Name)
-
-				testCase.OptsIn.URI.ConnectionString = "mongodb://dummy"
-				testCase.OptsExpected.URI.ConnectionString = "mongodb://dummy"
-
-				BuiltWithGSSAPI = testCase.WithGSSAPI
-				defer func() {
-					BuiltWithGSSAPI = true
-				}()
-
-				testCase.OptsIn.URI.ConnString = testCase.CS
-
-				err := testCase.OptsIn.setOptionsFromURI(testCase.CS)
-
-				if testCase.ShouldError {
-					So(err, ShouldNotBeNil)
-				} else {
-					So(err, ShouldBeNil)
-				}
-
-				So(testCase.OptsIn.Connection.Timeout, ShouldResemble, testCase.OptsExpected.Connection.Timeout)
-				So(testCase.OptsIn.Connection.SocketTimeout, ShouldResemble, testCase.OptsExpected.Connection.SocketTimeout)
-				So(testCase.OptsIn.Username, ShouldResemble, testCase.OptsExpected.Username)
-				So(testCase.OptsIn.Password, ShouldResemble, testCase.OptsExpected.Password)
-				So(testCase.OptsIn.Source, ShouldResemble, testCase.OptsExpected.Source)
-				So(testCase.OptsIn.Auth.Mechanism, ShouldResemble, testCase.OptsExpected.Auth.Mechanism)
-				So(testCase.OptsIn.Auth.AWSSessionToken, ShouldResemble, testCase.OptsExpected.Auth.AWSSessionToken)
-				So(testCase.OptsIn.Direct, ShouldResemble, testCase.OptsExpected.Direct)
-				So(testCase.OptsIn.ReplicaSetName, ShouldResemble, testCase.OptsExpected.ReplicaSetName)
-				So(testCase.OptsIn.SSL.UseSSL, ShouldResemble, testCase.OptsExpected.SSL.UseSSL)
-				So(testCase.OptsIn.Kerberos.Service, ShouldResemble, testCase.OptsExpected.Kerberos.Service)
-				So(testCase.OptsIn.Kerberos.ServiceHost, ShouldResemble, testCase.OptsExpected.Kerberos.ServiceHost)
-				So(testCase.OptsIn.RetryWrites, ShouldResemble, testCase.OptsExpected.RetryWrites)
-				So(testCase.OptsIn.Auth.ShouldAskForPassword(), ShouldEqual, testCase.OptsExpected.Auth.ShouldAskForPassword())
-			}
-		})
-	})
+		require.Equal(t, testCase.OptsExpected.Connection.Timeout, testCase.OptsIn.Connection.Timeout)
+		require.Equal(t, testCase.OptsExpected.Connection.SocketTimeout, testCase.OptsIn.Connection.SocketTimeout)
+		require.Equal(t, testCase.OptsExpected.Username, testCase.OptsIn.Username)
+		require.Equal(t, testCase.OptsExpected.Password, testCase.OptsIn.Password)
+		require.Equal(t, testCase.OptsExpected.Source, testCase.OptsIn.Source)
+		require.Equal(t, testCase.OptsExpected.Auth.Mechanism, testCase.OptsIn.Auth.Mechanism)
+		require.Equal(t, testCase.OptsExpected.Auth.AWSSessionToken, testCase.OptsIn.Auth.AWSSessionToken)
+		require.Equal(t, testCase.OptsExpected.Direct, testCase.OptsIn.Direct)
+		require.Equal(t, testCase.OptsExpected.ReplicaSetName, testCase.OptsIn.ReplicaSetName)
+		require.Equal(t, testCase.OptsExpected.SSL.UseSSL, testCase.OptsIn.SSL.UseSSL)
+		require.Equal(t, testCase.OptsExpected.Kerberos.Service, testCase.OptsIn.Kerberos.Service)
+		require.Equal(t, testCase.OptsExpected.Kerberos.ServiceHost, testCase.OptsIn.Kerberos.ServiceHost)
+		require.Equal(t, testCase.OptsExpected.RetryWrites, testCase.OptsIn.RetryWrites)
+		require.Equal(t, testCase.OptsExpected.Auth.ShouldAskForPassword(), testCase.OptsIn.Auth.ShouldAskForPassword())
+	}
 }
 
 type configTester struct {
@@ -627,33 +622,28 @@ type configTester struct {
 	outcome      int
 }
 
-func runConfigFileTestCases(testCases []configTester) {
+func runConfigFileTestCases(t *testing.T, testCases []configTester) {
 	configFilePath := "./test-config.yaml"
 	args := []string{"--config", configFilePath}
 	defer os.Remove(configFilePath)
 
 	for _, testCase := range testCases {
-		if err := ioutil.WriteFile(configFilePath, testCase.yamlBytes, 0644); err != nil {
-			So(err, ShouldBeNil)
-		}
-		opts := New("test", "", "", "", false, EnabledOptions{true, true, true, true})
-		err := opts.ParseConfigFile(args)
-
-		var assertion func()
-		if testCase.outcome == ShouldSucceed {
-			assertion = func() {
-				So(err, ShouldBeNil)
-				So(opts.Auth.Password, ShouldEqual, testCase.expectedOpts.Auth.Password)
-				So(opts.URI.ConnectionString, ShouldEqual, testCase.expectedOpts.URI.ConnectionString)
-				So(opts.SSL.SSLPEMKeyPassword, ShouldEqual, testCase.expectedOpts.SSL.SSLPEMKeyPassword)
+		t.Run(testCase.description, func(t *testing.T) {
+			if err := ioutil.WriteFile(configFilePath, testCase.yamlBytes, 0644); err != nil {
+				require.NoError(t, err)
 			}
-		} else {
-			assertion = func() {
-				So(err, ShouldNotBeNil)
-			}
-		}
+			opts := New("test", "", "", "", false, EnabledOptions{true, true, true, true})
+			err := opts.ParseConfigFile(args)
 
-		Convey(testCase.description, assertion)
+			if testCase.outcome == ShouldSucceed {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedOpts.Auth.Password, opts.Auth.Password)
+				require.Equal(t, testCase.expectedOpts.URI.ConnectionString, opts.URI.ConnectionString)
+				require.Equal(t, testCase.expectedOpts.SSL.SSLPEMKeyPassword, opts.SSL.SSLPEMKeyPassword)
+			} else {
+				require.Error(t, err)
+			}
+		})
 	}
 }
 
@@ -668,40 +658,40 @@ func createExpectedOpts(pw string, uri string, ssl string) *ToolOptions {
 func TestParseConfigFile(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
-	Convey("should error with no config file specified", t, func() {
+	t.Run("should error with no config file specified", func(t *testing.T) {
 		opts := New("test", "", "", "", false, EnabledOptions{})
 
 		// --config at beginning of args list
 		args := []string{"--config", "--database", "myDB"}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 
 		// --config at end of args list
 		args = []string{"--database", "myDB", "--config"}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 
 		// --config= at beginning of args list
 		args = []string{"--config=", "--database", "myDB"}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 
 		// --config= at end of args list
 		args = []string{"--database", "myDB", "--config="}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 	})
 
-	Convey("should error with non-existent config file specified", t, func() {
+	t.Run("should error with non-existent config file specified", func(t *testing.T) {
 		opts := New("test", "", "", "", false, EnabledOptions{})
 
 		// --config with non-existent file
 		args := []string{"--config", "DoesNotExist.yaml", "--database", "myDB"}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 
 		// --config= with non-existent file
 		args = []string{"--config=DoesNotExist.yaml", "--database", "myDB"}
-		So(opts.ParseConfigFile(args), ShouldNotBeNil)
+		require.NotNil(t, opts.ParseConfigFile(args))
 	})
 
-	Convey("with an existing config file specified", t, func() {
-		runConfigFileTestCases([]configTester{
+	t.Run("with an existing config file specified", func(t *testing.T) {
+		runConfigFileTestCases(t, []configTester{
 			{
 				"containing nothing (empty file)",
 				[]byte(""),
@@ -747,27 +737,27 @@ func TestParseConfigFile(t *testing.T) {
 		})
 	})
 
-	Convey("with command line args that override config file values", t, func() {
+	t.Run("with command line args that override config file values", func(t *testing.T) {
 		configFilePath := "./test-config.yaml"
 		defer os.Remove(configFilePath)
 		if err := ioutil.WriteFile(configFilePath, []byte("password: abc123"), 0644); err != nil {
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 		}
 
-		Convey("with --config followed by --password", func() {
+		t.Run("with --config followed by --password", func(t *testing.T) {
 			args := []string{"--config=" + configFilePath, "--password=def456"}
 			opts := New("test", "", "", "", false, EnabledOptions{Auth: true})
 			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
-			So(opts.Auth.Password, ShouldEqual, "def456")
+			require.NoError(t, err)
+			require.Equal(t, "def456", opts.Auth.Password)
 		})
 
-		Convey("with --password followed by --config", func() {
+		t.Run("with --password followed by --config", func(t *testing.T) {
 			args := []string{"--password=ghi789", "--config=" + configFilePath}
 			opts := New("test", "", "", "", false, EnabledOptions{Auth: true})
 			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
-			So(opts.Auth.Password, ShouldEqual, "ghi789")
+			require.NoError(t, err)
+			require.Equal(t, "ghi789", opts.Auth.Password)
 		})
 	})
 }
@@ -808,9 +798,9 @@ func runOptionsTestCases(t *testing.T, testCases []optionsTester) {
 		args := strings.Split(argString, " ")
 		_, err := toolOptions.ParseArgs(args)
 		if c.outcome == ShouldFail {
-			So(err, ShouldNotBeNil)
+			require.Error(t, err)
 		} else {
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 		}
 	}
 }
@@ -818,130 +808,126 @@ func runOptionsTestCases(t *testing.T, testCases []optionsTester) {
 func TestOptionsParsing(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
-	Convey("With a list of CLI options and URIs", t, func() {
-		// handwritten test cases
-		specialTestCases := []optionsTester{
-			// Hosts and Ports
-			{"--host foo", "mongodb://foo", ShouldSucceed},
-			{"--host foo", "mongodb://bar", ShouldFail},
-			{"--port 27018", "mongodb://foo", ShouldSucceed},
-			{"--port 27018", "mongodb://foo:27017", ShouldFail},
-			{"--port 27018", "mongodb://foo:27019", ShouldFail},
-			{"--port 27018", "mongodb://foo:27018", ShouldSucceed},
-			{"--host foo:27019 --port 27018", "mongodb://foo", ShouldFail},
-			{"--host foo:27018 --port 27018", "mongodb://foo:27018", ShouldSucceed},
-			{"--host foo:27019 --port 27018", "mongodb://foo:27018", ShouldFail},
+	// handwritten test cases
+	specialTestCases := []optionsTester{
+		// Hosts and Ports
+		{"--host foo", "mongodb://foo", ShouldSucceed},
+		{"--host foo", "mongodb://bar", ShouldFail},
+		{"--port 27018", "mongodb://foo", ShouldSucceed},
+		{"--port 27018", "mongodb://foo:27017", ShouldFail},
+		{"--port 27018", "mongodb://foo:27019", ShouldFail},
+		{"--port 27018", "mongodb://foo:27018", ShouldSucceed},
+		{"--host foo:27019 --port 27018", "mongodb://foo", ShouldFail},
+		{"--host foo:27018 --port 27018", "mongodb://foo:27018", ShouldSucceed},
+		{"--host foo:27019 --port 27018", "mongodb://foo:27018", ShouldFail},
 
-			{"--host foo,bar,baz", "mongodb://foo,bar,baz", ShouldSucceed},
-			{"--host foo,bar,baz", "mongodb://baz,bar,foo", ShouldSucceed},
-			{"--host foo:27018,bar:27019,baz:27020", "mongodb://baz:27020,bar:27019,foo:27018", ShouldSucceed},
-			{"--host foo:27018,bar:27019,baz:27020", "mongodb://baz:27018,bar:27019,foo:27020", ShouldFail},
-			{"--host foo:27018,bar:27019,baz:27020 --port 27018", "mongodb://baz:27018,bar:27019,foo:27020", ShouldFail},
-			{"--host foo,bar,baz --port 27018", "mongodb://foo,bar,baz", ShouldSucceed},
-			{"--host foo,bar,baz --port 27018", "mongodb://foo:27018,bar:27018,baz:27018", ShouldSucceed},
-			{"--host foo,bar,baz --port 27018", "mongodb://foo:27018,bar:27019,baz:27020", ShouldFail},
+		{"--host foo,bar,baz", "mongodb://foo,bar,baz", ShouldSucceed},
+		{"--host foo,bar,baz", "mongodb://baz,bar,foo", ShouldSucceed},
+		{"--host foo:27018,bar:27019,baz:27020", "mongodb://baz:27020,bar:27019,foo:27018", ShouldSucceed},
+		{"--host foo:27018,bar:27019,baz:27020", "mongodb://baz:27018,bar:27019,foo:27020", ShouldFail},
+		{"--host foo:27018,bar:27019,baz:27020 --port 27018", "mongodb://baz:27018,bar:27019,foo:27020", ShouldFail},
+		{"--host foo,bar,baz --port 27018", "mongodb://foo,bar,baz", ShouldSucceed},
+		{"--host foo,bar,baz --port 27018", "mongodb://foo:27018,bar:27018,baz:27018", ShouldSucceed},
+		{"--host foo,bar,baz --port 27018", "mongodb://foo:27018,bar:27019,baz:27020", ShouldFail},
 
-			{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz", ShouldSucceed},
-			{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz/?replicaSet=repl", ShouldSucceed},
-			{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz/?replicaSet=quux", ShouldFail},
+		{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz", ShouldSucceed},
+		{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz/?replicaSet=repl", ShouldSucceed},
+		{"--host repl/foo,bar,baz", "mongodb://foo,bar,baz/?replicaSet=quux", ShouldFail},
 
-			// Compressors
-			{"--compressors snappy", "mongodb://foo/?compressors=snappy", ShouldSucceed},
-			{"", "mongodb://foo/?compressors=snappy", ShouldSucceed},
-			{"--compressors snappy", "mongodb://foo/", ShouldSucceed},
-			{"--compressors snappy", "mongodb://foo/?compressors=zlib", ShouldFail},
-			// {"--compressors none", "mongodb://foo/?compressors=snappy", ShouldFail}, // Note: zero value problem
-			{"--compressors snappy", "mongodb://foo/?compressors=none", ShouldFail},
+		// Compressors
+		{"--compressors snappy", "mongodb://foo/?compressors=snappy", ShouldSucceed},
+		{"", "mongodb://foo/?compressors=snappy", ShouldSucceed},
+		{"--compressors snappy", "mongodb://foo/", ShouldSucceed},
+		{"--compressors snappy", "mongodb://foo/?compressors=zlib", ShouldFail},
+		// {"--compressors none", "mongodb://foo/?compressors=snappy", ShouldFail}, // Note: zero value problem
+		{"--compressors snappy", "mongodb://foo/?compressors=none", ShouldFail},
 
-			// Auth
-			{"--username alice", "mongodb://alice@foo", ShouldSucceed},
-			{"--username alice", "mongodb://foo", ShouldSucceed},
-			{"--username bob", "mongodb://alice@foo", ShouldFail},
-			{"", "mongodb://alice@foo", ShouldSucceed},
+		// Auth
+		{"--username alice", "mongodb://alice@foo", ShouldSucceed},
+		{"--username alice", "mongodb://foo", ShouldSucceed},
+		{"--username bob", "mongodb://alice@foo", ShouldFail},
+		{"", "mongodb://alice@foo", ShouldSucceed},
 
-			{"--password hunter2", "mongodb://alice@foo", ShouldSucceed},
-			{"--password hunter2", "mongodb://alice:hunter2@foo", ShouldSucceed},
-			{"--password hunter2", "mongodb://alice:swordfish@foo", ShouldFail},
-			{"", "mongodb://alice:hunter2@foo", ShouldSucceed},
+		{"--password hunter2", "mongodb://alice@foo", ShouldSucceed},
+		{"--password hunter2", "mongodb://alice:hunter2@foo", ShouldSucceed},
+		{"--password hunter2", "mongodb://alice:swordfish@foo", ShouldFail},
+		{"", "mongodb://alice:hunter2@foo", ShouldSucceed},
 
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo", ShouldSucceed},
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo/?authSource=db1", ShouldSucceed},
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo/?authSource=db2", ShouldFail},
-			{"", "mongodb://user:pass@foo/?authSource=db1", ShouldSucceed},
-			{"", "mongodb://a/b:@foo/authSource=db1", ShouldFail},
-			{"", "mongodb://user:pass:a@foo/authSource=db1", ShouldFail},
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo/db2", ShouldSucceed},
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo/db2?authSource=db1", ShouldSucceed},
-			{"--authenticationDatabase db1", "mongodb://user:pass@foo/db1?authSource=db2", ShouldFail},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo", ShouldSucceed},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo/?authSource=db1", ShouldSucceed},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo/?authSource=db2", ShouldFail},
+		{"", "mongodb://user:pass@foo/?authSource=db1", ShouldSucceed},
+		{"", "mongodb://a/b:@foo/authSource=db1", ShouldFail},
+		{"", "mongodb://user:pass:a@foo/authSource=db1", ShouldFail},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo/db2", ShouldSucceed},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo/db2?authSource=db1", ShouldSucceed},
+		{"--authenticationDatabase db1", "mongodb://user:pass@foo/db1?authSource=db2", ShouldFail},
 
-			{"--awsSessionToken token", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token", ShouldSucceed},
-			{"", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token", ShouldSucceed},
-			{"--awsSessionToken token", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:bar", ShouldFail},
-			{"--gssapiServiceName foo, --authenticationMechanism GSSAPI", "mongodb://user:pass@foo", ShouldSucceed},
+		{"--awsSessionToken token", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token", ShouldSucceed},
+		{"", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token", ShouldSucceed},
+		{"--awsSessionToken token", "mongodb://user:pass@foo/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:bar", ShouldFail},
+		{"--gssapiServiceName foo, --authenticationMechanism GSSAPI", "mongodb://user:pass@foo", ShouldSucceed},
 
-			// Namespace
-			{"--db db1", "mongodb://foo", ShouldSucceed},
-			{"--db db1", "mongodb://foo/db1", ShouldSucceed},
-			{"--db db1", "mongodb://foo/db2", ShouldFail},
-			{"", "mongodb://foo/db1", ShouldSucceed},
-			{"--db db1", "mongodb://user:pass@foo/?authSource=db2", ShouldSucceed},
-			{"--db db1", "mongodb://user:pass@foo/db1?authSource=db2", ShouldSucceed},
-			{"--db db1", "mongodb://user:pass@foo/db2?authSource=db2", ShouldFail},
+		// Namespace
+		{"--db db1", "mongodb://foo", ShouldSucceed},
+		{"--db db1", "mongodb://foo/db1", ShouldSucceed},
+		{"--db db1", "mongodb://foo/db2", ShouldFail},
+		{"", "mongodb://foo/db1", ShouldSucceed},
+		{"--db db1", "mongodb://user:pass@foo/?authSource=db2", ShouldSucceed},
+		{"--db db1", "mongodb://user:pass@foo/db1?authSource=db2", ShouldSucceed},
+		{"--db db1", "mongodb://user:pass@foo/db2?authSource=db2", ShouldFail},
 
-			// Kerberos
-			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:foo", ShouldSucceed},
-			{"", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:foo", ShouldSucceed},
-			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:bar", ShouldFail},
-			{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI", ShouldSucceed},
+		// Kerberos
+		{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:foo", ShouldSucceed},
+		{"", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:foo", ShouldSucceed},
+		{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:bar", ShouldFail},
+		{"--gssapiServiceName foo", "mongodb://user:pass@foo/?authMechanism=GSSAPI", ShouldSucceed},
 
-			// Loadbalanced
-			{"", "mongodb://foo,bar/?loadbalanced=true", ShouldFail},
-			{"", "mongodb://foo/?loadbalanced=true&replicaSet=foo", ShouldFail},
-			{"", "mongodb://foo/?loadbalanced=true&connect=direct", ShouldFail},
-		}
+		// Loadbalanced
+		{"", "mongodb://foo,bar/?loadbalanced=true", ShouldFail},
+		{"", "mongodb://foo/?loadbalanced=true&replicaSet=foo", ShouldFail},
+		{"", "mongodb://foo/?loadbalanced=true&connect=direct", ShouldFail},
+	}
 
-		// Each entry is expanded into 4 test cases with createTestCases()
-		genericTestCases := [][]string{
-			{"--serverSelectionTimeout", "serverSelectionTimeoutMS", "1000", "2000"},
-			{"--dialTimeout", "connectTimeoutMS", "1000", "2000"},
-			{"--socketTimeout", "socketTimeoutMS", "1000", "2000"},
+	// Each entry is expanded into 4 test cases with createTestCases()
+	genericTestCases := [][]string{
+		{"--serverSelectionTimeout", "serverSelectionTimeoutMS", "1000", "2000"},
+		{"--dialTimeout", "connectTimeoutMS", "1000", "2000"},
+		{"--socketTimeout", "socketTimeoutMS", "1000", "2000"},
 
-			{"--authenticationMechanism", "authMechanism", "SCRAM-SHA-1", "GSSAPI"},
+		{"--authenticationMechanism", "authMechanism", "SCRAM-SHA-1", "GSSAPI"},
 
-			{"--ssl", "ssl", "true", "false"},
-			{"--ssl", "tls", "true", "false"},
+		{"--ssl", "ssl", "true", "false"},
+		{"--ssl", "tls", "true", "false"},
 
-			{"--sslCAFile", "sslCertificateAuthorityFile", "foo", "bar"},
-			{"--sslCAFile", "tlsCAFile", "foo", "bar"},
+		{"--sslCAFile", "sslCertificateAuthorityFile", "foo", "bar"},
+		{"--sslCAFile", "tlsCAFile", "foo", "bar"},
 
-			{"--sslPEMKeyFile", "sslClientCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
-			{"--sslPEMKeyFile", "tlsCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
+		{"--sslPEMKeyFile", "sslClientCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
+		{"--sslPEMKeyFile", "tlsCertificateKeyFile", "../db/testdata/test-client-pkcs8-unencrypted.pem", "bar"},
 
-			{"--sslPEMKeyPassword", "sslClientCertificateKeyPassword", "foo", "bar"},
-			{"--sslPEMKeyPassword", "tlsCertificateKeyFilePassword", "foo", "bar"},
+		{"--sslPEMKeyPassword", "sslClientCertificateKeyPassword", "foo", "bar"},
+		{"--sslPEMKeyPassword", "tlsCertificateKeyFilePassword", "foo", "bar"},
 
-			{"--sslAllowInvalidCertificates", "sslInsecure", "true", "false"},
-			{"--sslAllowInvalidCertificates", "tlsInsecure", "true", "false"},
+		{"--sslAllowInvalidCertificates", "sslInsecure", "true", "false"},
+		{"--sslAllowInvalidCertificates", "tlsInsecure", "true", "false"},
 
-			{"--sslAllowInvalidHostnames", "sslInsecure", "true", "false"},
-			{"--sslAllowInvalidHostnames", "tlsInsecure", "true", "false"},
+		{"--sslAllowInvalidHostnames", "sslInsecure", "true", "false"},
+		{"--sslAllowInvalidHostnames", "tlsInsecure", "true", "false"},
 
-			{"--tlsInsecure", "sslInsecure", "true", "false"},
-			{"--tlsInsecure", "tlsInsecure", "true", "false"},
-		}
+		{"--tlsInsecure", "sslInsecure", "true", "false"},
+		{"--tlsInsecure", "tlsInsecure", "true", "false"},
+	}
 
-		testCases := []optionsTester{}
+	testCases := []optionsTester{}
 
-		for _, c := range genericTestCases {
-			testCases = append(testCases, createOptionsTestCases(c)...)
-		}
+	for _, c := range genericTestCases {
+		testCases = append(testCases, createOptionsTestCases(c)...)
+	}
 
-		testCases = append(testCases, specialTestCases...)
+	testCases = append(testCases, specialTestCases...)
 
-		Convey("parsing should succeed or fail as expected", func() {
-			runOptionsTestCases(t, testCases)
-		})
-	})
+	runOptionsTestCases(t, testCases)
 }
 
 func TestParsePositionalArgsAsURI(t *testing.T) {
@@ -955,16 +941,16 @@ func TestParsePositionalArgsAsURI(t *testing.T) {
 	}
 	toolOptions := New("test", "", "", "", true, enabled)
 
-	Convey("Uri as positional argument", t, func() {
-		Convey("schema error is not reported", func() {
+	t.Run("Uri as positional argument", func(t *testing.T) {
+		t.Run("schema error is not reported", func(t *testing.T) {
 			args := []string{"localhost:27017"}
 			_, err := toolOptions.ParseArgs(args)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 		})
-		Convey("non-schema errors should be reported", func() {
+		t.Run("non-schema errors should be reported", func(t *testing.T) {
 			args := []string{"mongodb://a/b@localhost:27017"}
 			_, err := toolOptions.ParseArgs(args)
-			So(err.Error(), ShouldEqual, "error parsing uri: unescaped slash in username")
+			require.Equal(t, "error parsing uri: unescaped slash in username", err.Error())
 		})
 	})
 }
@@ -981,39 +967,36 @@ func TestOptionsParsingForSRV(t *testing.T) {
 		t.Fatalf("Failed to parse ATLAS_URI (%s): %s", atlasURI, err)
 	}
 
-	Convey("With a list of CLI options and URIs parsing should succeed or fail as expected", t, func() {
-		testCases := []optionsTester{
-			{"", atlasURI, ShouldSucceed},
-			{"--username foo", atlasURI, ShouldSucceed},
-			{"--username foo --password bar", atlasURI, ShouldSucceed},
-			{"--username foo --authenticationDatabase admin", atlasURI, ShouldSucceed},
-			{"--username foo --authenticationDatabase db1", atlasURI, ShouldFail},
-			{"--username foo --ssl", atlasURI, ShouldSucceed},
-			{"--username foo --db db1", atlasURI, ShouldSucceed},
-			{fmt.Sprintf("--username foo --host %s/%s", cs.ReplicaSet, strings.Join(cs.Hosts, ",")), atlasURI, ShouldSucceed},
-			{fmt.Sprintf("--username foo --host %s/%s", "wrongReplSet", strings.Join(cs.Hosts, ",")), atlasURI, ShouldFail},
-		}
+	testCases := []optionsTester{
+		{"", atlasURI, ShouldSucceed},
+		{"--username foo", atlasURI, ShouldSucceed},
+		{"--username foo --password bar", atlasURI, ShouldSucceed},
+		{"--username foo --authenticationDatabase admin", atlasURI, ShouldSucceed},
+		{"--username foo --authenticationDatabase db1", atlasURI, ShouldFail},
+		{"--username foo --ssl", atlasURI, ShouldSucceed},
+		{"--username foo --db db1", atlasURI, ShouldSucceed},
+		{fmt.Sprintf("--username foo --host %s/%s", cs.ReplicaSet, strings.Join(cs.Hosts, ",")), atlasURI, ShouldSucceed},
+		{fmt.Sprintf("--username foo --host %s/%s", "wrongReplSet", strings.Join(cs.Hosts, ",")), atlasURI, ShouldFail},
+	}
 
-		runOptionsTestCases(t, testCases)
-	})
+	runOptionsTestCases(t, testCases)
 }
 
 // Regression test for TOOLS-1694 to prevent issue from TOOLS-1115
 func TestHiddenOptionsDefaults(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
-	Convey("With a ToolOptions parsed", t, func() {
+	t.Run("With a ToolOptions parsed", func(t *testing.T) {
 		enabled := EnabledOptions{Connection: true}
 		opts := New("", "", "", "", true, enabled)
 		_, err := opts.CallArgParser([]string{})
-		So(err, ShouldBeNil)
-		Convey("hidden options should have expected values", func() {
-			So(opts.MaxProcs, ShouldEqual, runtime.NumCPU())
-			So(opts.Timeout, ShouldEqual, 3)
-			So(opts.SocketTimeout, ShouldEqual, 0)
+		require.NoError(t, err)
+		t.Run("hidden options should have expected values", func(t *testing.T) {
+			require.Equal(t, runtime.NumCPU(), opts.MaxProcs)
+			require.Equal(t, 3, opts.Timeout)
+			require.Equal(t, 0, opts.SocketTimeout)
 		})
 	})
-
 }
 
 func TestNamespace_String(t *testing.T) {
@@ -1038,30 +1021,30 @@ func TestNamespace_String(t *testing.T) {
 
 func TestDeprecationWarning(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
-	Convey("deprecate message", t, func() {
+	t.Run("deprecate message", func(t *testing.T) {
 		var buffer bytes.Buffer
 
 		log.SetWriter(&buffer)
 		defer log.SetWriter(os.Stderr)
 
-		Convey("Warning for sslAllowInvalidHostnames", func() {
+		t.Run("Warning for sslAllowInvalidHostnames", func(t *testing.T) {
 			enabled := EnabledOptions{Connection: true}
 			opts := New("test", "", "", "", true, enabled)
 			args := []string{"--ssl", "--sslAllowInvalidHostnames", "mongodb://user:pass@foo/"}
 			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 			result := buffer.String()
-			So(result, ShouldContainSubstring, deprecationWarningSSLAllow)
+			require.Contains(t, result, deprecationWarningSSLAllow)
 		})
 
-		Convey("Warning for sslAllowInvalidCertificates", func() {
+		t.Run("Warning for sslAllowInvalidCertificates", func(t *testing.T) {
 			enabled := EnabledOptions{Connection: true}
 			opts := New("test", "", "", "", true, enabled)
 			args := []string{"--ssl", "--sslAllowInvalidCertificates", "mongodb://user:pass@foo/"}
 			_, err := opts.ParseArgs(args)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 			result := buffer.String()
-			So(result, ShouldContainSubstring, deprecationWarningSSLAllow)
+			require.Contains(t, result, deprecationWarningSSLAllow)
 		})
 	})
 }

--- a/common/options/options_test.go
+++ b/common/options/options_test.go
@@ -960,8 +960,7 @@ func TestParsePositionalArgsAsURI(t *testing.T) {
 }
 
 func TestOptionsParsingForSRV(t *testing.T) {
-
-	testtype.SkipUnlessTestType(t, testtype.SRVConnectionStringTestType)
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	currentDefault := dns.DefaultResolver
 	defer func() {

--- a/common/testtype/types.go
+++ b/common/testtype/types.go
@@ -37,9 +37,6 @@ const (
 	// For now mongoreplay tests are unique, and will have to be explicitly run.
 	MongoReplayTestType = "TOOLS_TESTING_REPLAY"
 
-	// For testing options parsing. Requires an SRV URI in the ATLAS_URI environment variable.
-	SRVConnectionStringTestType = "TOOLS_TESTING_SRV"
-
 	// For testing AWS auth via an STS AssumeRole request.
 	AWSAuthTestType = "TOOLS_TESTING_AWS_AUTH"
 )

--- a/evergreen/evergreen.go
+++ b/evergreen/evergreen.go
@@ -122,13 +122,6 @@ func (c *Config) GitHubPRAliasesYAML() (string, error) {
 			tasks:   `^(aws-auth|integration|legacy|native-cert-ssl|qa-dump-restore|qa-tests)-.*`,
 		},
 		{
-			comment: "Run srv tests on one variant. We pick RHEL 8.0 because" +
-				" it's a relatively recent platform that supports a wide range of" +
-				" servers.",
-			variant: `rhel80`,
-			tasks:   `^srv*`,
-		},
-		{
 			comment: "RHEL 8.0 doesn't run against server 3.4, so we do that with RHEL 7.0.",
 			variant: `rhel70`,
 			tasks:   `^(aws-auth|integration|native-cert-ssl|qa-dump-restore|qa-tests)-3.4$`,


### PR DESCRIPTION
This PR fixes an issue with the Evergreen config for our lint-js testing.

It fixes the SRV tests by mocking DNS so we no longer rely on a particular cluster existing in Atlas when the tests are run. Since these tests are no longer special, the `test:srv` build target is gone and these tests are just run as normal unit tests.

It also cleans up the options testing code to use testify.