### PR TITLE
Add lots of missing error handling

### DIFF
--- a/common/archive/demultiplexer.go
+++ b/common/archive/demultiplexer.go
@@ -450,6 +450,7 @@ func (cache *SpecialCollectionCache) Pos() int64 {
 }
 
 func (cache *SpecialCollectionCache) Write(b []byte) (int, error) {
+	// Writes to the hash never return an error.
 	cache.hash.Write(b)
 	return cache.buf.Write(b)
 }
@@ -526,7 +527,9 @@ func (prioritizer *Prioritizer) Get() *intents.Intent {
 		prioritizer.NamespaceErrorChan <- fmt.Errorf("no intent for namespace %v", namespace)
 	} else {
 		if intent.BSONFile != nil {
-			intent.BSONFile.Open()
+			if err := intent.BSONFile.Open(); err != nil {
+				prioritizer.NamespaceErrorChan <- fmt.Errorf("error opening BSON file for %s: %v", intent.Namespace(), err)
+			}
 		}
 		if intent.IsOplog() {
 			// once we see the oplog we

--- a/common/archive/multiplexer.go
+++ b/common/archive/multiplexer.go
@@ -316,6 +316,7 @@ func (muxIn *MuxIn) Write(buf []byte) (int, error) {
 			return 0, io.ErrShortWrite
 		}
 	}
+	// Writes to the hash never return an error.
 	muxIn.hash.Write(buf)
 	return len(buf), nil
 }

--- a/common/txn/buffer.go
+++ b/common/txn/buffer.go
@@ -54,9 +54,8 @@ func newTxnState(op db.Oplog) *txnState {
 // Because state is currently kept in memory, purge merely drops the reference
 // so the GC will eventually clean up.  Eventually, this might clean up a file
 // on disk.
-func (ts *txnState) purge() error {
+func (ts *txnState) purge() {
 	ts.buffer = nil
-	return nil
 }
 
 // Buffer stores transaction oplog entries until they are needed
@@ -281,10 +280,7 @@ func (b *Buffer) Stop() error {
 	b.wg.Wait()
 	var firstErr error
 	for _, state := range b.txns {
-		err := state.purge()
-		if err != nil && firstErr == nil {
-			firstErr = err
-		}
+		state.purge()
 	}
 
 	return firstErr

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -448,7 +448,10 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 
 func (dump *MongoDump) GetValidDbs() ([]string, error) {
 	var validDbs []string
-	dump.SessionProvider.GetSession()
+	_, err := dump.SessionProvider.GetSession()
+	if err != nil {
+		return nil, fmt.Errorf("error getting session: %v", err)
+	}
 	dbs, err := dump.SessionProvider.DatabaseNames()
 	if err != nil {
 		return nil, fmt.Errorf("error getting database names: %v", err)

--- a/mongoexport/csv.go
+++ b/mongoexport/csv.go
@@ -95,7 +95,9 @@ func (csvExporter *CSVExportOutput) ExportDocument(document bson.D) error {
 			rowOut = append(rowOut, fmt.Sprintf("%v", fieldVal))
 		}
 	}
-	csvExporter.csvWriter.Write(rowOut)
+	if err = csvExporter.csvWriter.Write(rowOut); err != nil {
+		return err
+	}
 	csvExporter.NumExported++
 	return csvExporter.csvWriter.Error()
 }

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -466,7 +466,9 @@ func (exp *MongoExport) exportInternal(out io.Writer) (int64, error) {
 	if err != nil {
 		return docsCount, err
 	}
-	exportOutput.Flush()
+	if err = exportOutput.Flush(); err != nil {
+		return docsCount, err
+	}
 	return docsCount, nil
 }
 

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -127,7 +127,10 @@ func (bd *bomDiscardingReader) Read(p []byte) (int, error) {
 	if !bd.didRead {
 		bom, err := bd.buf.Peek(3)
 		if err == nil && bytes.Equal(bom, UTF8_BOM) {
-			bd.buf.Read(make([]byte, 3)) // discard BOM
+			_, err = bd.buf.Read(make([]byte, 3)) // discard BOM
+			if err != nil {
+				return 0, err
+			}
 		}
 		bd.didRead = true
 	}

--- a/mongoimport/csv.go
+++ b/mongoimport/csv.go
@@ -153,12 +153,14 @@ func (c CSVConverter) Convert() (b bson.D, err error) {
 		c.useArrayIndexFields,
 	)
 	if _, ok := err.(coercionError); ok {
-		c.Print()
+		if err = c.Print(); err != nil {
+			return
+		}
 		err = nil
 	}
 	return
 }
 
-func (c CSVConverter) Print() {
-	c.rejectWriter.Write(c.data)
+func (c CSVConverter) Print() error {
+	return c.rejectWriter.Write(c.data)
 }

--- a/mongoimport/csv/reader.go
+++ b/mongoimport/csv/reader.go
@@ -189,7 +189,9 @@ func (r *Reader) readRune() (rune, error) {
 		r1, _, err = r.r.ReadRune()
 		if err == nil {
 			if r1 != '\n' {
-				r.r.UnreadRune()
+				if err = r.r.UnreadRune(); err != nil {
+					return r1, err
+				}
 				r1 = '\r'
 			}
 		}
@@ -231,7 +233,9 @@ func (r *Reader) parseRecord() (fields []string, err error) {
 	if r.Comment != 0 && r1 == r.Comment {
 		return nil, r.skip('\n')
 	}
-	r.r.UnreadRune()
+	if err := r.r.UnreadRune(); err != nil {
+		return nil, err
+	}
 
 	// At this point we have at least one field.
 	for {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -493,13 +493,13 @@ func (imp *MongoImport) importDocument(inserter *db.BufferedBulkInserter, docume
 		result, err = inserter.Insert(document)
 	} else if imp.IngestOptions.Mode == modeUpsert {
 		if selector == nil {
-			imp.fallbackToInsert(inserter, document)
+			result, err = imp.fallbackToInsert(inserter, document)
 		} else {
 			result, err = inserter.Replace(selector, document)
 		}
 	} else if imp.IngestOptions.Mode == modeMerge {
 		if selector == nil {
-			imp.fallbackToInsert(inserter, document)
+			result, err = imp.fallbackToInsert(inserter, document)
 		} else {
 			updateDoc := bson.D{{"$set", document}}
 			result, err = inserter.Update(selector, updateDoc)

--- a/mongoimport/tsv.go
+++ b/mongoimport/tsv.go
@@ -164,12 +164,12 @@ func (c TSVConverter) Convert() (b bson.D, err error) {
 		c.useArrayIndexFields,
 	)
 	if _, ok := err.(coercionError); ok {
-		c.Print()
-		err = nil
+		err = c.Print()
 	}
 	return
 }
 
-func (c TSVConverter) Print() {
-	c.rejectWriter.Write([]byte(c.data + "\n"))
+func (c TSVConverter) Print() error {
+	_, err := c.rejectWriter.Write([]byte(c.data + "\n"))
+	return err
 }

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -273,7 +273,9 @@ func (restore *MongoRestore) createCollectionWithCommand(session *mongo.Client, 
 	}
 
 	res := bson.M{}
-	singleRes.Decode(&res)
+	if err := singleRes.Decode(&res); err != nil {
+		return fmt.Errorf("error decoding result of create command: %v", err)
+	}
 	if util.IsFalsy(res["ok"]) {
 		return fmt.Errorf("create command: %v", res["errmsg"])
 	}
@@ -469,7 +471,9 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 		return fmt.Errorf("error running merge command: %v", err)
 	}
 	res := bson.M{}
-	resSingle.Decode(&res)
+	if err = resSingle.Decode(&res); err != nil {
+		return fmt.Errorf("error decoding result of merge command: %v", err)
+	}
 	if util.IsFalsy(res["ok"]) {
 		return fmt.Errorf("_mergeAuthzCollections command: %v", res["errmsg"])
 	}

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -336,7 +336,9 @@ func (node *NodeMonitor) Poll(discover chan string, checkShards bool) (*status.S
 				discover <- shardHost
 			}
 		}
-		shardCursor.Close(nil)
+		if closeErr := shardCursor.Close(nil); closeErr != nil {
+			return nil, fmt.Errorf("error closing shard discovery cursor: %v", err)
+		}
 	}
 
 	return stat, nil


### PR DESCRIPTION
When I ran `gosec` without any severity filter it complained about a lot of spots that were missing error handling. This fixes most of them.