### PR TITLE
TOOLS-3551 Fix mongorestore test failure with Server 8.0+

### DIFF
--- a/common/idx/index_catalog_test.go
+++ b/common/idx/index_catalog_test.go
@@ -3,12 +3,15 @@ package idx
 import (
 	"testing"
 
+	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
 func TestDeleteIndexes(t *testing.T) {
 	require := require.New(t)
+
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	t.Run("drop one index by name", func(t *testing.T) {
 		i := newTestIndexCatalog(t)

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1753,7 +1753,7 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 			So(err, ShouldBeNil)
 			// In the 8.0 release, this no longer leads to an error, so
 			// there's nothing to test here.
-			if restore.serverVersion.LT(db.Version{8, 0, 0}) {
+			if restore.serverVersion.GTE(db.Version{8, 0, 0}) {
 				return
 			}
 

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1754,6 +1754,7 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 			// In the 8.0 release, this no longer leads to an error, so
 			// there's nothing to test here.
 			if restore.serverVersion.GTE(db.Version{8, 0, 0}) {
+				SkipSo()
 				return
 			}
 

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1749,10 +1749,16 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 		})
 
 		Convey("restoring a timeseries collection when the system.buckets collection already exists on the destination should fail", func() {
-			testdb.RunCommand(context.Background(), bson.M{"create": "system.buckets.foo_ts"})
-			args = append(args, DirectoryOption, "testdata/timeseries_tests/ts_dump")
 			restore, err := getRestoreWithArgs(args...)
 			So(err, ShouldBeNil)
+			// In the 8.0 release, this no longer leads to an error, so
+			// there's nothing to test here.
+			if restore.serverVersion.LT(db.Version{8, 0, 0}) {
+				return
+			}
+
+			testdb.RunCommand(context.Background(), bson.M{"create": "system.buckets.foo_ts"})
+			args = append(args, DirectoryOption, "testdata/timeseries_tests/ts_dump")
 
 			result := restore.Restore()
 			defer restore.Close()


### PR DESCRIPTION
This test checks expects an error when restoring a timeseries collection where its `system.buckets` already exists. This no longer causes an error with 8.0.