### PR TITLE
Pass `--file=./go.mod` to `snyk test`

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -717,7 +717,7 @@ tasks:
             set -e
             curl -sSL -o ./snyk https://static.snyk.io/cli/latest/snyk-linux
             chmod 0755 ./snyk
-            ./snyk test --org="${snyk_organization_id}"
+            ./snyk test --org="${snyk_organization_id}" --file=./go.mod
 
   - name: require-augmented-sbom
     tags: ["git_tag"]


### PR DESCRIPTION
Right now it uses `go.mod` by default, but if for some reason we ever added a deps file for another language, like a `package.json`, it might start testing that instead.