### PR TITLE
TOOLS-3550 Set `IS_FAKE_TAG` env var when `fake_tag_for_release_testing` param is set

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -580,6 +580,7 @@ pre:
           export EVG_TRIGGERED_BY_TAG='${triggered_by_git_tag}'
           if [ -n "${fake_tag_for_release_testing}" ]; then
             export EVG_TRIGGERED_BY_TAG="${fake_tag_for_release_testing}"
+            export IS_FAKE_TAG=1
           fi
           export EVG_BUILD_ID='${build_id}'
           export EVG_VERSION='${version_id}'

--- a/release/env/env.go
+++ b/release/env/env.go
@@ -34,6 +34,12 @@ func EvgIsTagTriggered() bool {
 	return get("EVG_TRIGGERED_BY_TAG") != ""
 }
 
+// IsFakeTag returns true if the tag set in `EVG_TRIGGERED_BY_TAG` was set via
+// the `fake_tag_for_release_testing` parameter in our Evergreen config.
+func IsFakeTag() bool {
+	return get("IS_FAKE_TAG") != ""
+}
+
 // EvgBuildID returns the build_id of the current evergreen task,
 // based on the value of an env variable set by the evg project file.
 func EvgBuildID() (string, error) {

--- a/release/release.go
+++ b/release/release.go
@@ -1336,7 +1336,7 @@ func linuxRelease(v version.Version) {
 // version is a stable version and the current evg task was triggered
 // by a git tag.
 func canPerformStableRelease(v version.Version) bool {
-	return v.IsStable() && env.EvgIsTagTriggered()
+	return v.IsStable() && env.EvgIsTagTriggered() && !env.IsFakeTag()
 }
 
 func downloadMongodAndShell(v string) {


### PR DESCRIPTION
If this env var is true then it will block doing a real release. This provides a bit of extra safety when using this fake tag param.