### PR TITLE
Fix several issues in the release code

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1121,9 +1121,17 @@ func uploadRelease(v version.Version) {
 		check(err, "getting artifacts list")
 
 		if len(artifacts) != len(pf.ArtifactExtensions()) {
+			var artifactNames []string
+			for _, a := range artifacts {
+				artifactNames = append(artifactNames, a.Name)
+			}
 			log.Fatalf(
-				"expected %d artifacts but found %d for %s",
-				len(pf.ArtifactExtensions()), len(artifacts), task.Variant,
+				"expected %d artifacts but found %d for %s; artifact names are [%s]; expected extensions to include [%s]",
+				len(pf.ArtifactExtensions()),
+				len(artifacts),
+				task.Variant,
+				strings.Join(artifactNames, " "),
+				strings.Join(pf.ArtifactExtensions(), " "),
 			)
 		}
 

--- a/release/release.go
+++ b/release/release.go
@@ -1211,7 +1211,7 @@ func linuxRelease(v version.Version) {
 	check(err, "get platform")
 
 	if pf.OS != platform.OSLinux {
-		log.Printf("cannot release linux packages for non-linux platform")
+		log.Printf("cannot release linux packages for non-linux platform; platform is %s", pf.Name)
 		return
 	}
 

--- a/release/version/version.go
+++ b/release/version/version.go
@@ -86,26 +86,6 @@ func GetCurrent() (Version, error) {
 	return v, nil
 }
 
-func GetFromRev(rev string) (Version, error) {
-	commit, err := git("rev-parse", rev)
-	if err != nil {
-		return Version{}, fmt.Errorf("git rev-parse %s failed: %w", rev, err)
-	}
-
-	desc, err := git("describe", commit)
-	if err != nil {
-		return Version{}, fmt.Errorf("git describe %s failed: %w", commit, err)
-	}
-
-	v, err := Parse(desc)
-	if err != nil {
-		return Version{}, fmt.Errorf("failed to parse version from describe: %w", err)
-	}
-
-	v.Commit = commit
-	return v, nil
-}
-
 func (v Version) String() string {
 	vStr := v.StringWithoutPre()
 	if v.Pre != "" {

--- a/release/version/version.go
+++ b/release/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -61,6 +62,8 @@ func Parse(desc string) (Version, error) {
 	}, nil
 }
 
+var tagRE = regexp.MustCompile(`^\d+\.\d+\.d+$`)
+
 func GetCurrent() (Version, error) {
 	commit, err := git("rev-parse", "HEAD")
 	if err != nil {
@@ -77,7 +80,9 @@ func GetCurrent() (Version, error) {
 		return Version{}, fmt.Errorf("failed to parse version from describe: %w", err)
 	}
 
-	v.Commit = commit
+	if !tagRE.MatchString(desc) {
+		v.Commit = commit
+	}
 	return v, nil
 }
 

--- a/scripts/set-expansions-for-papertrail.sh
+++ b/scripts/set-expansions-for-papertrail.sh
@@ -9,7 +9,7 @@ tag=$(git describe --tags --always --dirty)
 # our real product name for actual tagged releases.
 product_name="database-tools-dev"
 if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    product_name = "database-tools"
+    product_name="database-tools"
 fi
 
 cat <<EOT > expansions.yml


### PR DESCRIPTION
* When creating a `version.Version`, we should not include the commit in the struct if we have a proper release tag. This fixes an issue where filenames for artifacts from a release tag incorrectly included the git commit.
* Fixed a bug in a script used for Papertrail integration where release tags caused the script to just fail.
* Improved some logging.