### PR TITLE
Remove the `push` task dependency for the `gosec-SARIF-report` task

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -723,9 +723,6 @@ tasks:
 
   - name: gosec-SARIF-report
     tags: ["git_tag"]
-    depends_on:
-      - name: push
-        variant: "*"
     commands:
       - func: "fetch source"
       - command: expansions.update


### PR DESCRIPTION
Generating the SARIF report doesn't depend on the code being pushed anywhere.