### PR TITLE
Write out an `.evergreen.yml` file before running `evergreen validate`

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -565,6 +565,18 @@ functions:
           GOSEC_SARIF_REPORT=1 ./dev-bin/precious lint --all --command gosec
           cat SARIF.json
 
+  "create evergreen config file":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        script: |
+          ${_set_shell_env}
+          set -x
+          set -v
+          set -e
+          ./scripts/write-evergreen-config-file.sh
+
 pre:
   - command: shell.exec
     params:
@@ -1511,6 +1523,7 @@ tasks:
   - name: evergreen-validate
     commands:
       - func: "fetch source"
+      - func: "create evergreen config file"
       - func: "run make target"
         vars:
           target: sa:evgvalidate

--- a/scripts/write-evergreen-config-file.sh
+++ b/scripts/write-evergreen-config-file.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# We don't want to print out the Evergreen key (though it should be redacted
+# by Evergreen anyway).
+set +x
+
+cat <<EOF > "$HOME/.evergreen.yml"
+user: "$EVG_USER"
+api_key: "$EVG_KEY"
+api_server_host: "https://evergreen.mongodb.com/api"
+ui_server_host: "https://evergreen.mongodb.com"
+EOF


### PR DESCRIPTION
This task never worked properly, but in the past `evergreen validate` would incorrectly exit with `0` when it couldn't authenticate itself.