### PR TITLE
Update the SBOM Lite with the latest version of the Silkbomb tool

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -1139,7 +1139,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-06-06T15:28:05.310216+00:00",
+    "timestamp": "2024-06-17T14:45:52.009745+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1183,8 +1183,9 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 6,
+  "version": 7,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5"
+  "specVersion": "1.5",
+  "vulnerabilities": []
 }


### PR DESCRIPTION
This added a new `"vulnerabilities": []` key. This isn't a _meaningful_ change, but if it's missing from the checked-in file then the `check-sbom-lite` task fails.