### PR TITLE
TOOLS-3572 Fix the version used for Debian packages and add tests for version code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/*.cdx.json
 /deb_build
 /dev-bin
 /mongo-release

--- a/release/version/version.go
+++ b/release/version/version.go
@@ -99,7 +99,7 @@ func (v Version) DebVersion() string {
 		return v.String()
 	}
 
-	return fmt.Sprintf("%s+%s.%s", v.String(), getDate(), v.Commit[:8])
+	return fmt.Sprintf("%s~%s.%s", v.String(), getDate(), v.Commit[:8])
 }
 
 func (v Version) RPMRelease() string {

--- a/release/version/version.go
+++ b/release/version/version.go
@@ -37,7 +37,7 @@ func Parse(desc string) (Version, error) {
 	}
 
 	var patch int
-	if len(parts) > 2 {
+	if len(parts) == 3 {
 		patch, err = strconv.Atoi(parts[2])
 		if err != nil {
 			return Version{}, fmt.Errorf("failed to parse patch version %q", parts[2])

--- a/release/version/version.go
+++ b/release/version/version.go
@@ -84,6 +84,8 @@ func (v Version) StringWithCommit() string {
 	if v.Commit == "" {
 		return v.String()
 	}
+	// The "g" before the commit is to imitate the output of "git describe",
+	// which gives us something like "100.9.5-4-gab7ebc58".
 	return fmt.Sprintf("%s-g%s", v.String(), v.Commit[:8])
 }
 

--- a/release/version/version_test.go
+++ b/release/version/version_test.go
@@ -1,0 +1,81 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCurrent(t *testing.T) {
+
+	origGetDate := getDate
+	defer func() { getDate = origGetDate }()
+	fakeDate := "20240619"
+	getDate = func() string { return fakeDate }
+
+	var (
+		major             = 100
+		minor             = 9
+		patch             = 5
+		commit            = "94783802ae607be7e3afd5cdcf2ed9853176c0ab"
+		vStr              = fmt.Sprintf("%d.%d.%d", major, minor, patch)
+		nonStableDescribe = fmt.Sprintf("%s-g%s", vStr, commit[:8])
+		stableDescribe    = vStr
+	)
+
+	defer func() { fakeGitOutput = nil }()
+
+	t.Run("not stable", func(t *testing.T) {
+		r := require.New(t)
+
+		fakeGitOutput = []string{commit, nonStableDescribe}
+
+		v, err := GetCurrent()
+		r.NoError(err)
+
+		r.Equal(major, v.Major)
+		r.Equal(minor, v.Minor)
+		r.Equal(patch, v.Patch)
+		r.Equal(commit, v.Commit)
+		r.Equal(vStr, v.String())
+		r.Equal(fmt.Sprintf("%s+%s.%s", vStr, fakeDate, commit[:8]), v.DebVersion())
+		r.Equal(fmt.Sprintf("%s.%s", fakeDate, commit[:8]), v.RPMRelease())
+	})
+
+	t.Run("stable", func(t *testing.T) {
+		r := require.New(t)
+
+		fakeGitOutput = []string{commit, stableDescribe}
+
+		v, err := GetCurrent()
+		r.NoError(err)
+
+		r.Equal(major, v.Major)
+		r.Equal(minor, v.Minor)
+		r.Equal(patch, v.Patch)
+		r.Empty(v.Commit)
+		r.Equal(vStr, v.String())
+		r.Equal(v.String(), v.DebVersion())
+		r.Equal("1", v.RPMRelease())
+	})
+}
+
+func TestGreaterThan(t *testing.T) {
+	r := require.New(t)
+
+	v1, err := Parse("100.9.3")
+	r.NoError(err)
+	v2, err := Parse("100.9.5")
+	r.NoError(err)
+	v3, err := Parse("101.1.2")
+	r.NoError(err)
+
+	r.True(v3.GreaterThan(v2))
+	r.True(v3.GreaterThan(v1))
+	r.True(v2.GreaterThan(v1))
+
+	r.False(v1.GreaterThan(v2))
+	r.False(v1.GreaterThan(v3))
+	r.False(v2.GreaterThan(v3))
+}

--- a/release/version/version_test.go
+++ b/release/version/version_test.go
@@ -39,7 +39,7 @@ func TestGetCurrent(t *testing.T) {
 		r.Equal(patch, v.Patch)
 		r.Equal(commit, v.Commit)
 		r.Equal(vStr, v.String())
-		r.Equal(fmt.Sprintf("%s+%s.%s", vStr, fakeDate, commit[:8]), v.DebVersion())
+		r.Equal(fmt.Sprintf("%s~%s.%s", vStr, fakeDate, commit[:8]), v.DebVersion())
 		r.Equal(fmt.Sprintf("%s.%s", fakeDate, commit[:8]), v.RPMRelease())
 	})
 


### PR DESCRIPTION
For non-stable releases, we want to use `VERSION~DATE.COMMIT` (e.g. ` mongodb-database-tools_100.9.5+20240619.d8f2d106_amd64.deb`) in the Debian package name. For stable releases, the commit should not be included.

This also removes the `Pre` field from the version. This was no longer used with our current tagging scheme, because we're not doing rc releases.