### PR TITLE
TOOLS-3693 Stop using SSH cloning in Evergreen

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -89,6 +89,13 @@ functions:
         go run build.go -v ${target}
 
   "download mongod and shell":
+    - command: github.generate_token
+      params:
+        owner: 10gen
+        repo: mongo-release
+        expansion_name: generated_token_mongo_release
+        permissions:
+          contents: read
     - command: shell.exec
       params:
         working_dir: src/github.com/mongodb/mongo-tools
@@ -97,6 +104,7 @@ functions:
           ${_maybe_enable_devtoolset_7}
           PATH=$PATH:$HOME
           go run release/release.go download-mongod-and-shell --server-version ${mongo_version}
+        add_expansions_to_env: true
 
   "get buildnumber":
     command: keyval.inc

--- a/release/release.go
+++ b/release/release.go
@@ -1579,7 +1579,10 @@ func downloadArtifacts(v string, artifactNames []string) {
 	_, err = run(
 		"git",
 		"clone",
-		fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", getMongoReleaseAccessToken()),
+		fmt.Sprintf(
+			"https://x-access-token:%s@github.com/10gen/mongo-release.git",
+			getMongoReleaseAccessToken(),
+		),
 	)
 	check(err, "git clone")
 

--- a/release/release.go
+++ b/release/release.go
@@ -1576,15 +1576,10 @@ func downloadArtifacts(v string, artifactNames []string) {
 	check(err, "os.Getwd")
 	fmt.Printf("pwd: %s\n", pwd)
 
-	token := os.Getenv("generated_token_mongo_release")
-	if token == "" {
-		log.Fatalf("invalid empty token")
-	}
-
 	_, err = run(
 		"git",
 		"clone",
-		fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", token),
+		fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", getMongoReleaseAccessToken()),
 	)
 	check(err, "git clone")
 
@@ -1626,6 +1621,15 @@ func downloadArtifacts(v string, artifactNames []string) {
 			numArtifactsDownloaded,
 		)
 	}
+}
+
+func getMongoReleaseAccessToken() string {
+	const tokenVar = "generated_token_mongo_release"
+	token := os.Getenv(tokenVar)
+	if token == "" {
+		log.Fatalf("The environment must contain a nonempty %#q.", tokenVar)
+	}
+	return token
 }
 
 func getStaticFiles(repoRoot, releaseFilename string) []string {

--- a/release/release.go
+++ b/release/release.go
@@ -1576,7 +1576,12 @@ func downloadArtifacts(v string, artifactNames []string) {
 	check(err, "os.Getwd")
 	fmt.Printf("pwd: %s\n", pwd)
 
-	_, err = run("git", "clone", "git@github.com:10gen/mongo-release.git")
+	token := os.Getenv("generated_token_mongo_release")
+	if token == "" {
+		log.Fatalf("invalid empty token")
+	}
+
+	_, err = run("git", "clone", fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", token))
 	check(err, "git clone")
 
 	githash, err := run("git", "-C", "mongo-release", "log", "--pretty=format:%H", grepArg)

--- a/release/release.go
+++ b/release/release.go
@@ -1581,7 +1581,11 @@ func downloadArtifacts(v string, artifactNames []string) {
 		log.Fatalf("invalid empty token")
 	}
 
-	_, err = run("git", "clone", fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", token))
+	_, err = run(
+		"git",
+		"clone",
+		fmt.Sprintf("https://x-access-token:%s@github.com/10gen/mongo-release.git", token),
+	)
 	check(err, "git clone")
 
 	githash, err := run("git", "-C", "mongo-release", "log", "--pretty=format:%H", grepArg)


### PR DESCRIPTION
This PR adds the evergreen function to generate the token for accessing `10gen/mongo-release` and replaces the usage of ssh cloning with HTTPS.

The change is also tested [here](https://spruce.mongodb.com/version/6711576e3929410007d3372d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) on a distro without the SSH key.