### PR TITLE
Fix Ubi download

### DIFF
--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -90,7 +90,10 @@ func installUBI(ctx *task.Context) error {
 	case "windows":
 		ubiBootstrapURL = "https://raw.githubusercontent.com/houseabsolute/ubi/ci-for-bootstrap/bootstrap/bootstrap-ubi.ps1"
 	default:
-		ubiBootstrapURL = "https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh"
+		ubiBootstrapURL = fmt.Sprintf(
+			"https://raw.githubusercontent.com/houseabsolute/ubi/v%s/bootstrap/bootstrap-ubi.sh",
+			ubiVersion,
+		)
 	}
 
 	s := strings.Split(ubiBootstrapURL, "/")


### PR DESCRIPTION
[ubi](https://github.com/houseabsolute/ubi) recently changed its bootstrap mechanism, which has broken linting in Evergreen CI.

This changeset fixes that by downloading the bootstrap script for the ubi version that this project’s build system uses.