### PR TITLE
DEVPROD-6063: run signing on macos 11

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -2002,7 +2002,6 @@ buildvariants:
     tasks:
       - name: "dist"
       - name: "sign"
-        run_on: macos-1014-codesign
       - name: "push"
         run_on: rhel80-small
 
@@ -2019,7 +2018,6 @@ buildvariants:
     tasks:
       - name: "dist"
       - name: "sign"
-        run_on: macos-1014-codesign
       - name: "push"
         run_on: rhel80-small
 


### PR DESCRIPTION
MacOS 10.14 is years out of date and being removed. I have run a successful patch with these changes.