### PR TITLE
DEVPROD-13316: template authenticode key name

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -307,6 +307,7 @@ functions:
         ARTIFACTORY_USERNAME: ${artifactory_username}
         GARASIGN_PASSWORD: ${garasign_password}
         GARASIGN_USERNAME: ${garasign_username}
+        AUTHENTICODE_KEY_NAME: ${authenticode_key_name}
         TASK_ID: ${task_id}
       args:
         - "./scripts/sign_artifacts.sh"

--- a/scripts/sign_artifacts.sh
+++ b/scripts/sign_artifacts.sh
@@ -22,7 +22,7 @@ authenticode_sign() {
   -v $PWD:$PWD \
   -w $PWD \
   artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
-  /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 ${file_name}"
+  /bin/bash -c "jsign -a ${AUTHENTICODE_KEY_NAME} --replace --tsaurl http://timestamp.digicert.com -d SHA-256 ${file_name}"
 }
 
 setup_garasign_authentication() {


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our Evergreen project as mongo-authenticode-2024.