### PR TITLE
Update release docs to say we should look at Jira for open vulnerabilities, not Silk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,16 +267,11 @@ Organization ID from there. **Make sure you are in the `dev-prod` organization!*
 
 If the dependency you just added has any known vulnerabilities this command will report them.
 
-**We do not merge PRs which contain unaddressed vulnerabilities in third-party dependencies. All
-vulnerabilities found in the `master` branch must be resolved before a release.**
+**We do not merge PRs which contain unaddressed vulnerabilities in third-party dependencies unless
+there is no fixed version available. All vulnerabilities found in the `master` branch must be
+resolved before a release.**
 
-We can address them in one of the following ways:
-
-1. Upgrade to a new version of the dependency which contains a fix.
-2. **MongoDB employees only** - Use [the Silk UI](https://us1.app.silk.security/) to create a new
-   ticket in the `VULN` project and transition the ticket to "Rejected". You will need to select a
-   "State" describing why this ticket was rejected, which can be one of "not affected", or "false
-   positive". You will also supply a "Justification", which will end up in the Augmented SBOM.
+There are more details about how we handle vulnerabilities in [the release docs](RELEASE.md)
 
 ### Software Security Development Lifecycle (SSDLC) Notes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,10 +45,18 @@ Complete these tasks before tagging a new release.
 Move the JIRA ticket for the release to the "In Progress" state. Ensure that its fixVersion matches
 the version being released.
 
-#### Check for Outstanding Vulnerabilities in Dependencies in Silk
+#### Check for Outstanding Vulnerabilities in Dependencies
 
-You can view open findings on
-[the Silk dashboard for this project](https://us1.app.silk.security/inventory/code-repositories?assetId=mongodb____DedupedCodeAsset____dd18b99bbdf5e991fa452636302d07dd04bb48bd&assets-filters=%5B%7B%22filterCriteria%22%3A%22is%22%2C%22filterField%22%3A%22ignored_info.ignored%22%2C%22filterString%22%3A%5B%22false%22%5D%2C%22filterType%22%3A%22boolean%22%7D%2C%7B%22filterCriteria%22%3A%22is%22%2C%22filterField%22%3A%22project_name%22%2C%22filterString%22%3A%5B%22mongodb%2Fmongo-tools%22%5D%2C%22filterType%22%3A%22string%22%7D%5D&assets-page=1).
+See [our internal wiki](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=276642867) for
+more details on how we handle third-party vulnerabilities, in particular
+[our vulnerability issue lifecycle](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=285096119).
+
+We want to make sure that we have taken action on all reported vulnerabities in third-party
+dependencies before release. To find these, we should look for
+[TOOLS tickets linked to VULN tickets](<https://jira.mongodb.org/issues/?jql=project%20%3D%20TOOLS%20and%20issue%20in%20linkedTo(%22project%20%3D%20VULN%22)>).
+Ideally, all of these tickets should have the "Remediation Completed" status. However, in some
+cases, there may not be a version of the dependency available that addresses the vulnerability. In
+that case, it's okay to do a release with the vulnerability still present in the dependency we use.
 
 We have an SLA for releasing an updated version of the Database Tools to address _applicable_
 vulnerabilities in dependencies, based on the issue's severity. It's possible that a vulnerability
@@ -65,11 +73,6 @@ Critical severity levels, even if this would not violate our SLA.
 
 If possible, we would like to avoid releasing with known, applicable issues at the Medium severity
 level, but these can be deferred at the team's discretion.
-
-Sometimes Silk will report findings that are not actual vulnerabilities. If you are confident this
-is the case, you can click on an individual finding, then click on the "Ignore" button. This will
-prompt you for the ignore reason. Pick the appropriate one and add a comment explaining why this is
-the case. If you're not sure if a finding is a false positive, discuss it with the team in Slack.
 
 #### Create the Augmented SBOM File for the Upcoming Release
 


### PR DESCRIPTION
This also adds some links to our internal wiki for more information on handling vulnerabilities in third-party dependencies.