### PR TITLE
Delete 4.4 from releases.

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1196,7 +1196,6 @@ type LinuxRepo struct {
 }
 
 var linuxRepoVersionsStable = []LinuxRepo{
-	{"4.4", "4.4.0"}, // any 4.4 stable release version will send the package to the "4.4" repo
 	{"5.0", "5.0.0"}, // any 5.0 stable release version will send the package to the "5.0" repo
 	{"6.0", "6.0.0"}, // any 6.0 stable release version will send the package to the "6.0" repo
 	{"7.0", "7.0.0"}, // any 7.0 stable release version will send the package to the "7.0" repo


### PR DESCRIPTION
4.4 is EOL, so we can’t push it for server releases anymore. (This is blocking the next release.)