### PR TITLE
Update most of our dev tools to their latest versions

### DIFF
--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -34,7 +34,7 @@ const (
 	gosecVersion        = "2.20.0"
 	preciousVersion     = "0.7.3"
 	ubiVersion          = "0.4.2"
-	prettierVersion     = "3.3.1"
+	prettierVersion     = "3.4.2"
 )
 
 func SAInstallDevTools(ctx *task.Context) error {

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	goimportsVersion = "v0.22.0"
+	goimportsVersion = "v0.29.0"
 	goimportsPkg     = "golang.org/x/tools/cmd/goimports@" + goimportsVersion
 
 	// For JS tools like eslint and prettier, these versions need to match the ones in the

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -32,8 +32,8 @@ const (
 	golangCILintVersion = "1.59.1"
 	golinesVersion      = "0.12.2"
 	gosecVersion        = "2.20.0"
-	preciousVersion     = "0.7.2"
-	ubiVersion          = "0.0.18"
+	preciousVersion     = "0.7.3"
+	ubiVersion          = "0.4.2"
 	prettierVersion     = "3.3.1"
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "eslint": "8.57.0",
-        "prettier": "3.3.1"
+        "prettier": "3.4.2"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
-      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "eslint": "8.57.0",
-    "prettier": "3.3.1"
+    "prettier": "3.4.2"
   }
 }


### PR DESCRIPTION
I mostly did this to get a new `ubi` version, since that has a fix for an issue that one of our team members encountered.

This does _not_ upgrade the following:

* `eslint` - would require rewriting our config to a new format
* `golangci-lint` - would require fixing a bunch of new issues it found.
* `gosec` - also finds new issues, all of which appear to be spurious, but this deserves its own PR with a bit more attention.