### PR TITLE
TOOLS-3719: fail if --restoreDbUsersAndRoles used on wrong target

### DIFF
--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -475,6 +475,19 @@ func (restore *MongoRestore) Restore() Result {
 			"remove the 'config' directory from the dump directory first")}
 	}
 
+	// if --restoreDbUsersAndRoles is used then db specific users and roles ($admin.system.users.bson / $admin.system.roles.bson)
+	// should exist in target directory / archive
+	if restore.InputOptions.RestoreDBUsersAndRoles &&
+		restore.ToolOptions.Namespace.DB != "" &&
+		(restore.manager.Users() == nil && restore.manager.Roles() == nil) {
+		return Result{
+			Err: fmt.Errorf(
+				"cannot find users or roles to restore with --restoreDbUsersAndRoles - " +
+					"use the archive or db directory dumped with --dumpDbUsersAndRoles as the target",
+			),
+		}
+	}
+
 	if restore.InputOptions.OplogFile != "" {
 		err = restore.CreateIntentForOplog()
 		if err != nil {

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1052,13 +1052,14 @@ func TestRestoreUsersOrRoles(t *testing.T) {
 			NumInsertionWorkersOption, "1",
 		}
 
-		restore, err := getRestoreWithArgs(args...)
-		So(err, ShouldBeNil)
-		defer restore.Close()
-
-		db := session.Database("admin")
-
 		Convey("Restoring users and roles should drop tempusers and temproles", func() {
+
+			restore, err := getRestoreWithArgs(args...)
+			So(err, ShouldBeNil)
+			defer restore.Close()
+
+			db := session.Database("admin")
+
 			restore.TargetDirectory = "testdata/usersdump"
 			result := restore.Restore()
 			So(result.Err, ShouldBeNil)
@@ -1070,6 +1071,67 @@ func TestRestoreUsersOrRoles(t *testing.T) {
 				So(collName, ShouldNotEqual, "tempusers")
 				So(collName, ShouldNotEqual, "temproles")
 			}
+		})
+
+		Convey("If --dumpUsersAndRoles was not used with the target", func() {
+			expectedError := "cannot find users or roles to restore with --restoreDbUsersAndRoles - " +
+				"use the archive or db directory dumped with --dumpDbUsersAndRoles as the target"
+			Convey("Restoring from db directory should not be allowed", func() {
+				args = append(
+					args,
+					RestoreDBUsersAndRolesOption,
+					DBOption,
+					"db1",
+					"testdata/testdirs/db1",
+				)
+
+				restore, err := getRestoreWithArgs(args...)
+				So(err, ShouldBeNil)
+				defer restore.Close()
+
+				result := restore.Restore()
+				So(result.Err, ShouldNotBeNil)
+				So(result.Err.Error(), ShouldEqual, expectedError)
+			})
+
+			Convey("Restoring from base dump directory should not be allowed", func() {
+				args = append(
+					args,
+					RestoreDBUsersAndRolesOption,
+					DBOption,
+					"db1",
+					"testdata/testdirs",
+				)
+
+				restore, err := getRestoreWithArgs(args...)
+				So(err, ShouldBeNil)
+				defer restore.Close()
+
+				result := restore.Restore()
+				So(result.Err, ShouldNotBeNil)
+				So(result.Err.Error(), ShouldEqual, expectedError)
+			})
+
+			Convey("Restoring from archive of entire dump should not be allowed", func() {
+				withArchiveMongodump(t, func(archive string) {
+					args = append(
+						args,
+						RestoreDBUsersAndRolesOption,
+						DBOption,
+						"db1",
+						ArchiveOption+"="+archive,
+					)
+
+					restore, err := getRestoreWithArgs(args...)
+					So(err, ShouldBeNil)
+					defer restore.Close()
+
+					result := restore.Restore()
+					So(result.Err, ShouldNotBeNil)
+					So(result.Err.Error(), ShouldEqual, expectedError)
+
+				})
+			})
 		})
 	})
 }


### PR DESCRIPTION
If the target was dumped with --dumpDbUsersAndRoles then we would find the db specific users / roles and the intents would not be nil, so we can use that check after the intents have been created to make sure that this option is used correctly.