### PR TITLE
Update golangci-lint to latest version.

### DIFF
--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -29,7 +29,7 @@ const (
 	// This is the latest version to support a YAML config file. Updating to
 	// the new config file syntax did not seem trivial.
 	eslintVersion       = "8.57.0"
-	golangCILintVersion = "1.63.4"
+	golangCILintVersion = "1.64.5"
 	golinesVersion      = "0.12.2"
 	gosecVersion        = "2.20.0"
 	preciousVersion     = "0.7.3"

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -29,7 +29,7 @@ const (
 	// This is the latest version to support a YAML config file. Updating to
 	// the new config file syntax did not seem trivial.
 	eslintVersion       = "8.57.0"
-	golangCILintVersion = "1.59.1"
+	golangCILintVersion = "1.63.4"
 	golinesVersion      = "0.12.2"
 	gosecVersion        = "2.20.0"
 	preciousVersion     = "0.7.3"

--- a/common/bsonutil/converter.go
+++ b/common/bsonutil/converter.go
@@ -301,6 +301,8 @@ func GetBSONValueAsLegacyExtJSON(x interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		//nolint:errcheck
 		return MarshalD(out.(bson.D)), nil
 	case []interface{}: // array
 		out := []interface{}{}

--- a/common/bsonutil/converter_test.go
+++ b/common/bsonutil/converter_test.go
@@ -336,7 +336,11 @@ func TestJSCodeBSONToJSON(t *testing.T) {
 				So(err, ShouldBeNil)
 				jObj, ok := _jObj.(json.JavaScript)
 				So(ok, ShouldBeTrue)
-				So(jObj.Scope.(bson.M)["x"], ShouldEqual, 2)
+
+				scopeMap, ok := jObj.Scope.(bson.M)
+				So(ok, ShouldBeTrue)
+
+				So(scopeMap["x"], ShouldEqual, 2)
 				So(jObj.Code, ShouldEqual, "function() { return x; }")
 			})
 		})

--- a/common/bsonutil/marshal_d_test.go
+++ b/common/bsonutil/marshal_d_test.go
@@ -51,8 +51,12 @@ func TestMarshalDMarshalJSON(t *testing.T) {
 					So(asMap["aaa"], ShouldEqual, 543.2)
 					So(asMap["I"], ShouldEqual, 0)
 					So(asMap["E"], ShouldEqual, 0)
-					So(asMap["map"].(map[string]interface{})["1"], ShouldEqual, 1)
-					So(asMap["map"].(map[string]interface{})["2"], ShouldEqual, "two")
+
+					asMapMap, ok := asMap["map"].(map[string]any)
+					So(ok, ShouldBeTrue)
+
+					So(asMapMap["1"], ShouldEqual, 1)
+					So(asMapMap["2"], ShouldEqual, "two")
 				})
 			})
 

--- a/common/bsonutil/timestamp_test.go
+++ b/common/bsonutil/timestamp_test.go
@@ -45,7 +45,11 @@ func TestTimestampValue(t *testing.T) {
 
 				bsonMap, err := ConvertLegacyExtJSONValueToBSON(jsonMap)
 				So(err, ShouldBeNil)
-				So(bsonMap.(map[string]interface{})["ts"], ShouldEqual, testTS)
+
+				realMap, ok := bsonMap.(map[string]interface{})
+				So(ok, ShouldBeTrue)
+
+				So(realMap["ts"], ShouldEqual, testTS)
 			})
 		})
 	})

--- a/common/intents/intent_prioritizer.go
+++ b/common/intents/intent_prioritizer.go
@@ -253,6 +253,7 @@ func (dbh DBHeap) Less(i, j int) bool {
 }
 
 func (dbh *DBHeap) Push(x interface{}) {
+	//nolint:errcheck
 	*dbh = append(*dbh, x.(*dbCounter))
 }
 

--- a/common/intents/intent_prioritizer_test.go
+++ b/common/intents/intent_prioritizer_test.go
@@ -203,13 +203,21 @@ func TestSimulatedMultiDBJob(t *testing.T) {
 						So(i3.DB, ShouldEqual, "db1")
 
 						Convey("which means that there should be two active db1 jobs", func() {
-							counter := prioritizer.(*multiDatabaseLTFPrioritizer).counterMap["db1"]
+							prioConcrete, ok := prioritizer.(*multiDatabaseLTFPrioritizer)
+							So(ok, ShouldBeTrue)
+
+							counter, ok := prioConcrete.counterMap["db1"]
+							So(ok, ShouldBeTrue)
+
 							So(counter.active, ShouldEqual, 2)
 						})
 					})
 
 					Convey("the heap should now be empty", func() {
-						So(prioritizer.(*multiDatabaseLTFPrioritizer).dbHeap.Len(), ShouldEqual, 0)
+						prioConcrete, ok := prioritizer.(*multiDatabaseLTFPrioritizer)
+						So(ok, ShouldBeTrue)
+
+						So(prioConcrete.dbHeap.Len(), ShouldEqual, 0)
 					})
 				})
 			})

--- a/common/json/bindata.go
+++ b/common/json/bindata.go
@@ -59,13 +59,29 @@ func (d *decodeState) getBinData() interface{} {
 	if err := ctorNumArgsMismatch("BinData", 2, len(args)); err != nil {
 		d.error(err)
 	}
-	arg0, err := args[0].(Number).Uint8()
+
+	arg0Num, ok := args[0].(Number)
+	if !ok {
+		d.error(
+			fmt.Errorf(
+				"expected number (not %T) for first argument of BinData constructor",
+				args[0],
+			),
+		)
+	}
+
+	arg0, err := arg0Num.Uint8()
 	if err != nil {
 		d.error(fmt.Errorf("expected byte for first argument of BinData constructor"))
 	}
 	arg1, ok := args[1].(string)
 	if !ok {
-		d.error(fmt.Errorf("expected string for second argument of BinData constructor"))
+		d.error(
+			fmt.Errorf(
+				"expected string (not %T) for second argument of BinData constructor",
+				args[1],
+			),
+		)
 	}
 
 	d.useNumber = useNumber

--- a/common/json/date.go
+++ b/common/json/date.go
@@ -69,13 +69,19 @@ func (d *decodeState) getDate() interface{} {
 	}
 	arg0num, isNumber := args[0].(Number)
 	if !isNumber {
+		arg0str, isString := args[0].(string)
+		if !isString {
+			d.error(fmt.Errorf("expected number or string for first argument of Date constructor"))
+		}
+
 		// validate the date format of the string
-		_, err := util.FormatDate(args[0].(string))
+		_, err := util.FormatDate(arg0str)
 		if err != nil {
 			d.error(fmt.Errorf("unexpected ISODate format"))
 		}
 		d.useNumber = useNumber
-		return ISODate(args[0].(string))
+
+		return ISODate(arg0str)
 	}
 	arg0, err := arg0num.Int64()
 	if err != nil {

--- a/common/json/encode.go
+++ b/common/json/encode.go
@@ -372,7 +372,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 		return marshalerEncoder
 	}
 	if t.Kind() != reflect.Ptr && allowAddr {
-		if reflect.PtrTo(t).Implements(marshalerType) {
+		if reflect.PointerTo(t).Implements(marshalerType) {
 			return newCondAddrEncoder(addrMarshalerEncoder, newTypeEncoder(t, false))
 		}
 	}
@@ -381,7 +381,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 		return textMarshalerEncoder
 	}
 	if t.Kind() != reflect.Ptr && allowAddr {
-		if reflect.PtrTo(t).Implements(textMarshalerType) {
+		if reflect.PointerTo(t).Implements(textMarshalerType) {
 			return newCondAddrEncoder(addrTextMarshalerEncoder, newTypeEncoder(t, false))
 		}
 	}

--- a/common/json/tagkey_test.go
+++ b/common/json/tagkey_test.go
@@ -106,7 +106,12 @@ func TestStructTagObjectKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unmarshal(%#q) failed: %v", b, err)
 		}
-		for i, v := range f.(map[string]interface{}) {
+
+		fMap, isMap := f.(map[string]any)
+		if !isMap {
+			t.Fatalf("Expected map but got %T", f)
+		}
+		for i, v := range fMap {
 			switch i {
 			case tt.key:
 				if s, ok := v.(string); !ok || s != tt.value {

--- a/common/json/timestamp.go
+++ b/common/json/timestamp.go
@@ -59,11 +59,33 @@ func (d *decodeState) getTimestamp() interface{} {
 	if err := ctorNumArgsMismatch("Timestamp", 2, len(args)); err != nil {
 		d.error(err)
 	}
-	arg0, err := args[0].(Number).Uint32()
+
+	arg0Num, ok := args[0].(Number)
+	if !ok {
+		d.error(
+			fmt.Errorf(
+				"expected number (not %T) for first argument of Timestamp constructor",
+				args[0],
+			),
+		)
+	}
+
+	arg0, err := arg0Num.Uint32()
 	if err != nil {
 		d.error(fmt.Errorf("expected uint32 for first argument of Timestamp constructor"))
 	}
-	arg1, err := args[1].(Number).Uint32()
+
+	arg1Num, ok := args[1].(Number)
+	if !ok {
+		d.error(
+			fmt.Errorf(
+				"expected number (not %T) for second argument of Timestamp constructor",
+				args[1],
+			),
+		)
+	}
+
+	arg1, err := arg1Num.Uint32()
 	if err != nil {
 		d.error(fmt.Errorf("expected uint32 for second argument of Timestamp constructor"))
 	}

--- a/common/util/math.go
+++ b/common/util/math.go
@@ -52,8 +52,8 @@ func ToUInt32(number interface{}) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	// no check for "ok" here, since we know it will work
-	return asInterface.(uint32), nil
+
+	return convert[uint32](asInterface)
 }
 
 var intConverter = newNumberConverter(reflect.TypeOf(int(0)))
@@ -66,8 +66,8 @@ func ToInt(number interface{}) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	// no check for "ok" here, since we know it will work
-	return asInterface.(int), nil
+
+	return convert[int](asInterface)
 }
 
 var float64Converter = newNumberConverter(reflect.TypeOf(float64(0)))
@@ -79,6 +79,15 @@ func ToFloat64(number interface{}) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// no check for "ok" here, since we know it will work
-	return asInterface.(float64), nil
+
+	return convert[float64](asInterface)
+}
+
+func convert[T any](val any) (T, error) {
+	converted, ok := val.(T)
+	if !ok {
+		return *new(T), fmt.Errorf("Expected %+v (%T) to be float64", val, val)
+	}
+
+	return converted, nil
 }

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1075,7 +1075,11 @@ func TestMongoDumpMetaData(t *testing.T) {
 							uuid, ok := jsonResult["uuid"]
 							So(ok, ShouldBeTrue)
 							checkUUID := regexp.MustCompile(`(?i)^[a-z0-9]{32}$`)
-							So(checkUUID.MatchString(uuid.(string)), ShouldBeTrue)
+
+							uuidStr, ok := uuid.(string)
+							So(ok, ShouldBeTrue)
+
+							So(checkUUID.MatchString(uuidStr), ShouldBeTrue)
 							// XXX useless -- xdg, 2018-09-21
 							So(err, ShouldBeNil)
 						})
@@ -2367,7 +2371,10 @@ func TestMongoDumpColumnstoreIndexes(t *testing.T) {
 		require.True(t, ok)
 		count := 0
 
-		for _, index := range indexes.([]interface{}) {
+		indexesSlice, ok := indexes.([]any)
+		require.True(t, ok)
+
+		for _, index := range indexesSlice {
 			indexMap, ok := index.(map[string]interface{})
 			require.True(t, ok)
 

--- a/mongoexport/csv.go
+++ b/mongoexport/csv.go
@@ -128,6 +128,7 @@ func extractFieldByName(fieldName string, document interface{}) interface{} {
 		} else if docKind == reflect.Slice {
 			if docType == marshalDType {
 				// dive into a D as a document
+				//nolint:errcheck
 				asD := bson.D(subdoc.(bsonutil.MarshalD))
 				var err error
 				subdoc, err = bsonutil.FindValueByKey(path, &asD)

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -243,7 +243,11 @@ func TestSetNestedDocumentValue(t *testing.T) {
 			newDocument := *testDocument
 			So(len(newDocument), ShouldEqual, 3)
 			So(newDocument[2].Key, ShouldResemble, "c")
-			So(*newDocument[2].Value.(*bson.D), ShouldResemble, expectedDocument)
+
+			valMap, ok := newDocument[2].Value.(*bson.D)
+			So(ok, ShouldBeTrue)
+
+			So(*valMap, ShouldResemble, expectedDocument)
 		})
 		Convey("ensure existing nested level fields are set and others, unchanged", func() {
 			testDocument := &currentDocument
@@ -253,7 +257,11 @@ func TestSetNestedDocumentValue(t *testing.T) {
 			newDocument := *testDocument
 			So(len(newDocument), ShouldEqual, 2)
 			So(newDocument[1].Key, ShouldResemble, "b")
-			So(*newDocument[1].Value.(*bson.D), ShouldResemble, expectedDocument)
+
+			valMap, ok := newDocument[1].Value.(*bson.D)
+			So(ok, ShouldBeTrue)
+
+			So(*valMap, ShouldResemble, expectedDocument)
 		})
 		Convey("ensure subsequent calls update fields accordingly", func() {
 			testDocument := &currentDocument
@@ -264,7 +272,11 @@ func TestSetNestedDocumentValue(t *testing.T) {
 			newDocument := *testDocument
 			So(len(newDocument), ShouldEqual, 2)
 			So(newDocument[1].Key, ShouldResemble, "b")
-			So(*newDocument[1].Value.(*bson.D), ShouldResemble, expectedDocumentOne)
+
+			valDoc, ok := newDocument[1].Value.(*bson.D)
+			So(ok, ShouldBeTrue)
+
+			So(*valDoc, ShouldResemble, expectedDocumentOne)
 			err = setNestedDocumentValue([]string{"f"}, 23, testDocument, false)
 			So(err, ShouldBeNil)
 			newDocument = *testDocument
@@ -383,7 +395,11 @@ func TestTokensToBSON(t *testing.T) {
 			So(expectedDocument[1].Key, ShouldResemble, bsonD[1].Key)
 			So(expectedDocument[1].Value, ShouldResemble, bsonD[1].Value)
 			So(expectedDocument[2].Key, ShouldResemble, bsonD[2].Key)
-			So(expectedDocument[2].Value, ShouldResemble, *bsonD[2].Value.(*bson.D))
+
+			valueD, ok := bsonD[2].Value.(*bson.D)
+			So(ok, ShouldBeTrue)
+
+			So(expectedDocument[2].Value, ShouldResemble, *valueD)
 		})
 	})
 }

--- a/mongoimport/csv_test.go
+++ b/mongoimport/csv_test.go
@@ -166,7 +166,11 @@ func TestCSVStreamDocument(t *testing.T) {
 			readDocument := <-docChan
 			So(readDocument[0], ShouldResemble, expectedRead[0])
 			So(readDocument[1].Key, ShouldResemble, expectedRead[1].Key)
-			So(*readDocument[1].Value.(*bson.D), ShouldResemble, expectedRead[1].Value)
+
+			valueD, ok := readDocument[1].Value.(*bson.D)
+			So(ok, ShouldBeTrue)
+
+			So(*valueD, ShouldResemble, expectedRead[1].Value)
 			So(readDocument[2], ShouldResemble, expectedRead[2])
 			So(readDocument[3], ShouldResemble, expectedRead[3])
 		})

--- a/mongoimport/typed_fields_test.go
+++ b/mongoimport/typed_fields_test.go
@@ -110,47 +110,54 @@ func TestAutoHeaderParser(t *testing.T) {
 	})
 }
 
+func cast[T any](val any) T {
+	converted, ok := val.(T)
+	So(ok, ShouldBeTrue)
+
+	return converted
+}
+
 func TestFieldParsers(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Using FieldAutoParser", t, func() {
 		var p, _ = NewFieldParser(ctAuto, "")
-		var value interface{}
+		var value any
 		var err error
 
 		Convey("parses integers when it can", func() {
 			value, err = p.Parse("2147483648")
-			So(value.(int64), ShouldEqual, int64(2147483648))
+			So(cast[int64](value), ShouldEqual, int64(2147483648))
 			So(err, ShouldBeNil)
 			value, err = p.Parse("42")
-			So(value.(int32), ShouldEqual, 42)
+			So(cast[int32](value), ShouldEqual, 42)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-2147483649")
-			So(value.(int64), ShouldEqual, int64(-2147483649))
+			So(cast[int64](value), ShouldEqual, int64(-2147483649))
 		})
 		Convey("parses decimals when it can", func() {
 			value, err = p.Parse("3.14159265")
-			So(value.(float64), ShouldEqual, 3.14159265)
+			So(cast[float64](value), ShouldEqual, 3.14159265)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("0.123123")
-			So(value.(float64), ShouldEqual, 0.123123)
+			So(cast[float64](value), ShouldEqual, 0.123123)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-123456.789")
-			So(value.(float64), ShouldEqual, -123456.789)
+			So(cast[float64](value), ShouldEqual, -123456.789)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-1.")
-			So(value.(float64), ShouldEqual, -1.0)
+			So(cast[float64](value), ShouldEqual, -1.0)
 			So(err, ShouldBeNil)
 		})
 		Convey("leaves everything else as a string", func() {
 			value, err = p.Parse("12345-6789")
-			So(value.(string), ShouldEqual, "12345-6789")
+			So(cast[string](value), ShouldEqual, "12345-6789")
 			So(err, ShouldBeNil)
 			value, err = p.Parse("06/02/1997")
-			So(value.(string), ShouldEqual, "06/02/1997")
+			So(cast[string](value), ShouldEqual, "06/02/1997")
 			So(err, ShouldBeNil)
 			value, err = p.Parse("")
-			So(value.(string), ShouldEqual, "")
+			So(cast[string](value), ShouldEqual, "")
 			So(err, ShouldBeNil)
 		})
 	})
@@ -162,24 +169,24 @@ func TestFieldParsers(t *testing.T) {
 
 		Convey("parses representations of true correctly", func() {
 			value, err = p.Parse("true")
-			So(value.(bool), ShouldBeTrue)
+			So(cast[bool](value), ShouldBeTrue)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("TrUe")
-			So(value.(bool), ShouldBeTrue)
+			So(cast[bool](value), ShouldBeTrue)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("1")
-			So(value.(bool), ShouldBeTrue)
+			So(cast[bool](value), ShouldBeTrue)
 			So(err, ShouldBeNil)
 		})
 		Convey("parses representations of false correctly", func() {
 			value, err = p.Parse("false")
-			So(value.(bool), ShouldBeFalse)
+			So(cast[bool](value), ShouldBeFalse)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("FaLsE")
-			So(value.(bool), ShouldBeFalse)
+			So(cast[bool](value), ShouldBeFalse)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("0")
-			So(value.(bool), ShouldBeFalse)
+			So(cast[bool](value), ShouldBeFalse)
 			So(err, ShouldBeNil)
 		})
 		Convey("does not parse other boolean representations", func() {
@@ -204,16 +211,16 @@ func TestFieldParsers(t *testing.T) {
 			var p, _ = NewFieldParser(ctBinary, "hex")
 			Convey("parses valid hex values correctly", func() {
 				value, err = p.Parse("400a11")
-				So(value.([]byte), ShouldResemble, []byte{64, 10, 17})
+				So(cast[[]byte](value), ShouldResemble, []byte{64, 10, 17})
 				So(err, ShouldBeNil)
 				value, err = p.Parse("400A11")
-				So(value.([]byte), ShouldResemble, []byte{64, 10, 17})
+				So(cast[[]byte](value), ShouldResemble, []byte{64, 10, 17})
 				So(err, ShouldBeNil)
 				value, err = p.Parse("0b400A11")
-				So(value.([]byte), ShouldResemble, []byte{11, 64, 10, 17})
+				So(cast[[]byte](value), ShouldResemble, []byte{11, 64, 10, 17})
 				So(err, ShouldBeNil)
 				value, err = p.Parse("")
-				So(value.([]byte), ShouldResemble, []byte{})
+				So(cast[[]byte](value), ShouldResemble, []byte{})
 				So(err, ShouldBeNil)
 			})
 		})
@@ -221,10 +228,10 @@ func TestFieldParsers(t *testing.T) {
 			var p, _ = NewFieldParser(ctBinary, "base32")
 			Convey("parses valid base32 values correctly", func() {
 				value, err = p.Parse("")
-				So(value.([]uint8), ShouldResemble, []uint8{})
+				So(cast[[]uint8](value), ShouldResemble, []uint8{})
 				So(err, ShouldBeNil)
 				value, err = p.Parse("MZXW6YTBOI======")
-				So(value.([]uint8), ShouldResemble, []uint8{102, 111, 111, 98, 97, 114})
+				So(cast[[]uint8](value), ShouldResemble, []uint8{102, 111, 111, 98, 97, 114})
 				So(err, ShouldBeNil)
 			})
 		})
@@ -232,10 +239,10 @@ func TestFieldParsers(t *testing.T) {
 			var p, _ = NewFieldParser(ctBinary, "base64")
 			Convey("parses valid base64 values correctly", func() {
 				value, err = p.Parse("")
-				So(value.([]uint8), ShouldResemble, []uint8{})
+				So(cast[[]uint8](value), ShouldResemble, []uint8{})
 				So(err, ShouldBeNil)
 				value, err = p.Parse("Zm9vYmFy")
-				So(value.([]uint8), ShouldResemble, []uint8{102, 111, 111, 98, 97, 114})
+				So(cast[[]uint8](value), ShouldResemble, []uint8{102, 111, 111, 98, 97, 114})
 				So(err, ShouldBeNil)
 			})
 		})
@@ -250,7 +257,7 @@ func TestFieldParsers(t *testing.T) {
 			Convey("parses valid timestamps correctly", func() {
 				value, err = p.Parse("01/04/2000 5:38:10pm UTC")
 				So(
-					value.(time.Time),
+					cast[time.Time](value),
 					ShouldResemble,
 					time.Date(2000, 1, 4, 17, 38, 10, 0, time.UTC),
 				)
@@ -270,7 +277,7 @@ func TestFieldParsers(t *testing.T) {
 			Convey("parses valid timestamps correctly", func() {
 				value, err = p.Parse("01/04/2000 5:38:10PM")
 				So(
-					value.(time.Time),
+					cast[time.Time](value),
 					ShouldResemble,
 					time.Date(2000, 1, 4, 17, 38, 10, 0, time.UTC),
 				)
@@ -292,7 +299,7 @@ func TestFieldParsers(t *testing.T) {
 			Convey("parses valid timestamps correctly", func() {
 				value, err = p.Parse("01/04/2000 05:38:10PM")
 				So(
-					value.(time.Time),
+					cast[time.Time](value),
 					ShouldResemble,
 					time.Date(2000, 1, 4, 17, 38, 10, 0, time.UTC),
 				)
@@ -318,16 +325,16 @@ func TestFieldParsers(t *testing.T) {
 
 		Convey("parses valid decimal values correctly", func() {
 			value, err = p.Parse("3.14159265")
-			So(value.(float64), ShouldEqual, 3.14159265)
+			So(cast[float64](value), ShouldEqual, 3.14159265)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("0.123123")
-			So(value.(float64), ShouldEqual, 0.123123)
+			So(cast[float64](value), ShouldEqual, 0.123123)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-123456.789")
-			So(value.(float64), ShouldEqual, -123456.789)
+			So(cast[float64](value), ShouldEqual, -123456.789)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-1.")
-			So(value.(float64), ShouldEqual, -1.0)
+			So(cast[float64](value), ShouldEqual, -1.0)
 			So(err, ShouldBeNil)
 		})
 		Convey("does not parse invalid numbers", func() {
@@ -349,13 +356,13 @@ func TestFieldParsers(t *testing.T) {
 
 		Convey("parses valid integer values correctly", func() {
 			value, err = p.Parse("2147483647")
-			So(value.(int32), ShouldEqual, 2147483647)
+			So(cast[int32](value), ShouldEqual, 2147483647)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("42")
-			So(value.(int32), ShouldEqual, 42)
+			So(cast[int32](value), ShouldEqual, 42)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-2147483648")
-			So(value.(int32), ShouldEqual, -2147483648)
+			So(cast[int32](value), ShouldEqual, -2147483648)
 		})
 		Convey("does not parse invalid numbers", func() {
 			_, err = p.Parse("")
@@ -380,13 +387,13 @@ func TestFieldParsers(t *testing.T) {
 
 		Convey("parses valid integer values correctly", func() {
 			value, err = p.Parse("2147483648")
-			So(value.(int64), ShouldEqual, int64(2147483648))
+			So(cast[int64](value), ShouldEqual, int64(2147483648))
 			So(err, ShouldBeNil)
 			value, err = p.Parse("42")
-			So(value.(int64), ShouldEqual, 42)
+			So(cast[int64](value), ShouldEqual, 42)
 			So(err, ShouldBeNil)
 			value, err = p.Parse("-2147483649")
-			So(value.(int64), ShouldEqual, int64(-2147483649))
+			So(cast[int64](value), ShouldEqual, int64(-2147483649))
 		})
 		Convey("does not parse invalid numbers", func() {
 			_, err = p.Parse("")
@@ -411,7 +418,7 @@ func TestFieldParsers(t *testing.T) {
 				parsedValue, err := p.Parse(ts)
 				So(err, ShouldBeNil)
 
-				So(testVal, ShouldResemble, parsedValue.(primitive.Decimal128))
+				So(testVal, ShouldResemble, cast[primitive.Decimal128](parsedValue))
 			}
 		})
 		Convey("does not parse invalid decimal values", func() {
@@ -429,13 +436,13 @@ func TestFieldParsers(t *testing.T) {
 
 		Convey("parses strings as strings only", func() {
 			value, err = p.Parse("42")
-			So(value.(string), ShouldEqual, "42")
+			So(cast[string](value), ShouldEqual, "42")
 			So(err, ShouldBeNil)
 			value, err = p.Parse("true")
-			So(value.(string), ShouldEqual, "true")
+			So(cast[string](value), ShouldEqual, "true")
 			So(err, ShouldBeNil)
 			value, err = p.Parse("")
-			So(value.(string), ShouldEqual, "")
+			So(cast[string](value), ShouldEqual, "")
 			So(err, ShouldBeNil)
 		})
 	})

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -173,7 +173,17 @@ func (restore *MongoRestore) CreateIndexes(
 						"namespace is too long (max size is 127 bytes)", fullIndexName)
 			}
 		}
-		indexNames = append(indexNames, index.Options["name"].(string))
+
+		nameStr, isString := index.Options["name"].(string)
+		if !isString {
+			return fmt.Errorf(
+				"expected name (%T: %v) to be a string",
+				index.Options["name"],
+				index.Options["name"],
+			)
+		}
+
+		indexNames = append(indexNames, nameStr)
 
 		// remove the index version, forcing an update,
 		// unless we specifically want to keep it

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -2838,15 +2838,19 @@ func clusteredIndexInfo(t *testing.T, options bson.M) indexInfo {
 	require.True(t, found, "index has a key named 'key'")
 	require.IsType(t, bson.M{}, keys, "key value is a bson.M")
 
-	//nolint:errcheck
-	keysM := keys.(bson.M)
+	keysM, ok := keys.(bson.M)
+	require.True(t, ok)
+
 	var keyNames []string
 	for k := range keysM {
 		keyNames = append(keyNames, k)
 	}
 
+	nameStr, ok := name.(string)
+	require.True(t, ok)
+
 	return indexInfo{
-		name: name.(string),
+		name: nameStr,
 		keys: keyNames,
 	}
 }

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -8,6 +8,7 @@ package mongorestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -175,7 +176,7 @@ func postImageCheck(client *mongo.Client, c *txnTestDataCase) error {
 			return fmt.Errorf("got unexpected document with _id '%d'", id)
 		}
 		if diff := cmp.Diff(got, want); diff != "" {
-			return fmt.Errorf(diff)
+			return errors.New(diff)
 		}
 		delete(expected, id)
 	}

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -162,7 +162,7 @@ func (restore *MongoRestore) RestoreIndexesForNamespace(namespace *options.Names
 					log.Logvf(
 						log.Info,
 						"index %#q (%v) lacks %#q; inferring %#q",
-						index.Options["name"].(string),
+						index.Options["name"],
 						index.Key,
 						optName,
 						addedOpts[optName],

--- a/release/release.go
+++ b/release/release.go
@@ -163,7 +163,12 @@ func check(err error, format ...interface{}) {
 	}
 	msg := err.Error()
 	if len(format) != 0 {
-		task := fmt.Sprintf(format[0].(string), format[1:]...)
+		formatStr, ok := format[0].(string)
+		if !ok {
+			log.Fatal("format should be a string, not %T", format[0])
+		}
+
+		task := fmt.Sprintf(formatStr, format[1:]...)
 		msg = fmt.Sprintf("'%s' failed: %v", task, err)
 	}
 	log.Fatal(msg)

--- a/release/release.go
+++ b/release/release.go
@@ -157,7 +157,7 @@ func main() {
 
 }
 
-func check(err error, format ...interface{}) {
+func check(err error, format ...any) {
 	if err == nil {
 		return
 	}
@@ -165,7 +165,7 @@ func check(err error, format ...interface{}) {
 	if len(format) != 0 {
 		formatStr, ok := format[0].(string)
 		if !ok {
-			log.Fatal("format should be a string, not %T", format[0])
+			log.Fatalf("format should be a string, not %T", format[0])
 		}
 
 		task := fmt.Sprintf(formatStr, format[1:]...)


### PR DESCRIPTION
This required adding error-checks to many type assertions. (Curiously, the prior golangci-lint _was_ configured to check those!)

A couple spots have no avenue for returning errors, so they’re left as-is with `//nolint` annotations.