### PR TITLE
REP-5475 - mongodump --internalOnlySourceWritesDoneBarrier

### DIFF
--- a/mongodump/barrier.go
+++ b/mongodump/barrier.go
@@ -1,0 +1,44 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+package mongodump
+
+import (
+	"os"
+	"time"
+
+	"github.com/mongodb/mongo-tools/common/log"
+)
+
+// Wait until a file exists and can be opened for reading
+// This is used only for testing mongodump/mongorestore with resmoke
+// test infrastructure.  The tests will create the barrier file when they have
+// finshed writes to the source cluster.
+func waitForSourceWritesDoneBarrier(barrierName string) {
+	log.Logvf(log.Always, "waitForSourceWritesDoneBarrier: %s", barrierName)
+	start := time.Now()
+	logInterval := time.Minute
+	prevLogTime := start
+	for {
+		f, err := os.Open(barrierName)
+		if err == nil {
+			// We opened the file for reading, so it does exist.
+			f.Close()
+			return
+		}
+		if os.IsNotExist(err) {
+			if time.Since(prevLogTime) >= logInterval {
+				prevLogTime = time.Now()
+				log.Logvf(log.Always, "waitForSourceWritesDoneBarrier: waited %.1f secs for %s",
+					prevLogTime.Sub(start).Seconds(),
+					barrierName)
+			}
+			// Poll for existence of the barrier file every 500msec
+			time.Sleep(500 * time.Millisecond)
+		} else {
+			panic(err)
+		}
+	}
+}

--- a/mongodump/barrier.go
+++ b/mongodump/barrier.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-tools/common/log"
-    "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 // Wait until a file exists and can be opened for reading
@@ -18,7 +18,11 @@ import (
 // test infrastructure.  The tests will create the barrier file when they have
 // finshed writes to the source cluster.
 func waitForSourceWritesDoneBarrier(barrierName string) {
-	log.Logvf(log.DebugHigh, "waitForSourceWritesDoneBarrier: initial check for existence of file %s", barrierName)
+	log.Logvf(
+		log.DebugHigh,
+		"waitForSourceWritesDoneBarrier: initial check for existence of file %s",
+		barrierName,
+	)
 	start := time.Now()
 	logInterval := time.Minute
 	prevLogTime := start
@@ -27,15 +31,22 @@ func waitForSourceWritesDoneBarrier(barrierName string) {
 		if err == nil {
 			// We opened the file for reading, so it does exist.
 			f.Close()
-	        log.Logvf(log.DebugHigh, "waitForSourceWritesDoneBarrier: barrier file %s exists - proceed past the barrier", barrierName)
+			log.Logvf(
+				log.DebugHigh,
+				"waitForSourceWritesDoneBarrier: barrier file %s exists - proceed past the barrier",
+				barrierName,
+			)
 			return
 		}
 		if os.IsNotExist(err) {
 			if time.Since(prevLogTime) >= logInterval {
 				prevLogTime = time.Now()
-				log.Logvf(log.DebugHigh, "waitForSourceWritesDoneBarrier: still waiting for existence of file %s after %.1f sec",
+				log.Logvf(
+					log.DebugHigh,
+					"waitForSourceWritesDoneBarrier: still waiting for existence of file %s after %.1f sec",
 					barrierName,
-					prevLogTime.Sub(start).Seconds())
+					prevLogTime.Sub(start).Seconds(),
+				)
 			}
 			// Poll for existence of the barrier file every 500msec
 			time.Sleep(500 * time.Millisecond)

--- a/mongodump/barrier.go
+++ b/mongodump/barrier.go
@@ -55,7 +55,7 @@ func waitForSourceWritesDoneBarrier(barrierName string) error {
 			time.Sleep(500 * time.Millisecond)
 		} else {
 			// Any other error implies that the resmoke test environment is
-			// irretrievably confused, so it is appropriate to panic here.
+			// irretrievably confused.  The caller must check the error.
 			return errors.Wrapf(err, "failed to open barrier file %#q", barrierName)
 		}
 	}

--- a/mongodump/barrier.go
+++ b/mongodump/barrier.go
@@ -17,7 +17,7 @@ import (
 // This is used only for testing mongodump/mongorestore with resmoke
 // test infrastructure.  The tests will create the barrier file when they have
 // finshed writes to the source cluster.
-func waitForSourceWritesDoneBarrier(barrierName string) {
+func waitForSourceWritesDoneBarrier(barrierName string) error {
 	// This code should only run in the resmoke testing environment. It's harmless and
 	// possibly useful to have verbose logging for testing; and if it accidentally runs
 	// in production, we want to see that in the logs so it's good to be verbose.
@@ -39,7 +39,7 @@ func waitForSourceWritesDoneBarrier(barrierName string) {
 				"waitForSourceWritesDoneBarrier: barrier file %#q exists - proceed past the barrier",
 				barrierName,
 			)
-			return
+			return nil
 		}
 		if os.IsNotExist(err) {
 			if time.Since(prevLogTime) >= logInterval {
@@ -56,7 +56,7 @@ func waitForSourceWritesDoneBarrier(barrierName string) {
 		} else {
 			// Any other error implies that the resmoke test environment is
 			// irretrievably confused, so it is appropriate to panic here.
-			panic(errors.Wrapf(err, "failed to open barrier file %#q", barrierName))
+			return errors.Wrapf(err, "failed to open barrier file %#q", barrierName)
 		}
 	}
 }

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -223,7 +223,10 @@ func (dump *MongoDump) Dump() (err error) {
 		// state of the source cluster.  Events that occur before the barrier file is created will
 		// definitely be captured in the dumped collections.  Events that occur after the barrier
 		// file is created may not be captured.
-		waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
+		barrier := dump.InputOptions.SourceWritesDoneBarrier
+		if err = waitForSourceWritesDoneBarrier(barrier); err != nil {
+			return err
+		}
 	}
 
 	// A test with the combination of
@@ -452,7 +455,10 @@ func (dump *MongoDump) Dump() (err error) {
 			// state of the source cluster.  Events that occur before the barrier file is created will
 			// definitely be captured either in the dumped collections, or the dumped oplog.
 			// Events that occur after the barrier file is created may not be captured.
-			waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
+			barrier := dump.InputOptions.SourceWritesDoneBarrier
+			if err = waitForSourceWritesDoneBarrier(barrier); err != nil {
+				return err
+			}
 		}
 		dump.oplogEnd, err = dump.getCurrentOplogTime()
 		if err != nil {

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -227,7 +227,12 @@ func (dump *MongoDump) Dump() (err error) {
 	}
 
 	if !dump.OutputOptions.Oplog && (dump.InputOptions.SourceWritesDoneBarrier != "") {
-		// Wait for tests to stop writes before dumping any collections
+		// Wait for tests to stop writes before dumping any collections.
+		//
+		// In resmoke testing, the barrier is used to ensure that mongodump captures the correct
+		// state of the source cluster.  Events that occur before the barrier file is created will 
+		// definitely be captured in the dumped collections.  Events that occur after the barrier 
+		// file is created may not be captured.
 		waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
 	}
 
@@ -436,7 +441,12 @@ func (dump *MongoDump) Dump() (err error) {
 	// we started still exist, so we know we haven't lost data)
 	if dump.OutputOptions.Oplog {
 		if dump.InputOptions.SourceWritesDoneBarrier != "" {
-			// Wait for tests to stop writes before choosing the oplogEnd time
+			// Wait for tests to stop writes before choosing the oplogEnd time.
+			//
+			// In resmoke testing, the barrier is used to ensure that mongodump captures the correct
+			// state of the source cluster.  Events that occur before the barrier file is created will 
+			// definitely be captured either in the dumped collections, or the dumped oplog.
+			// Events that occur after the barrier file is created may not be captured.
 			waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
 		}
 		dump.oplogEnd, err = dump.getCurrentOplogTime()

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -230,8 +230,8 @@ func (dump *MongoDump) Dump() (err error) {
 		// Wait for tests to stop writes before dumping any collections.
 		//
 		// In resmoke testing, the barrier is used to ensure that mongodump captures the correct
-		// state of the source cluster.  Events that occur before the barrier file is created will 
-		// definitely be captured in the dumped collections.  Events that occur after the barrier 
+		// state of the source cluster.  Events that occur before the barrier file is created will
+		// definitely be captured in the dumped collections.  Events that occur after the barrier
 		// file is created may not be captured.
 		waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
 	}
@@ -444,7 +444,7 @@ func (dump *MongoDump) Dump() (err error) {
 			// Wait for tests to stop writes before choosing the oplogEnd time.
 			//
 			// In resmoke testing, the barrier is used to ensure that mongodump captures the correct
-			// state of the source cluster.  Events that occur before the barrier file is created will 
+			// state of the source cluster.  Events that occur before the barrier file is created will
 			// definitely be captured either in the dumped collections, or the dumped oplog.
 			// Events that occur after the barrier file is created may not be captured.
 			waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -226,6 +226,11 @@ func (dump *MongoDump) Dump() (err error) {
 		return nil
 	}
 
+	if !dump.OutputOptions.Oplog && (dump.InputOptions.SourceWritesDoneBarrier != "") {
+		// Wait for tests to stop writes before dumping any collections
+		waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
+	}
+
 	log.Logvf(log.DebugHigh, "starting Dump()")
 
 	dump.shutdownIntentsNotifier = newNotifier()
@@ -430,6 +435,10 @@ func (dump *MongoDump) Dump() (err error) {
 	// we check to see if the oplog has rolled over (i.e. the most recent entry when
 	// we started still exist, so we know we haven't lost data)
 	if dump.OutputOptions.Oplog {
+		if dump.InputOptions.SourceWritesDoneBarrier != "" {
+			// Wait for tests to stop writes before choosing the oplogEnd time
+			waitForSourceWritesDoneBarrier(dump.InputOptions.SourceWritesDoneBarrier)
+		}
 		dump.oplogEnd, err = dump.getCurrentOplogTime()
 		if err != nil {
 			return fmt.Errorf("error getting oplog end: %v", err)

--- a/mongodump/options.go
+++ b/mongodump/options.go
@@ -25,10 +25,11 @@ See http://docs.mongodb.com/database-tools/mongodump/ for more information.`
 
 // InputOptions defines the set of options to use in retrieving data from the server.
 type InputOptions struct {
-	Query          string `long:"query" short:"q" description:"query filter, as a v2 Extended JSON string, e.g., '{\"x\":{\"$gt\":1}}'"`
-	QueryFile      string `long:"queryFile" description:"path to a file containing a query filter (v2 Extended JSON)"`
-	ReadPreference string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: \"nearest\", tagSets: [{a: \"b\"}], maxStalenessSeconds: 123}')"`
-	TableScan      bool   `long:"forceTableScan" description:"force a table scan (do not use $snapshot or hint _id). Deprecated since this is default behavior on WiredTiger"`
+	Query                   string `long:"query" short:"q" description:"query filter, as a v2 Extended JSON string, e.g., '{\"x\":{\"$gt\":1}}'"`
+	QueryFile               string `long:"queryFile" description:"path to a file containing a query filter (v2 Extended JSON)"`
+	ReadPreference          string `long:"readPreference" value-name:"<string>|<json>" description:"specify either a preference mode (e.g. 'nearest') or a preference json object (e.g. '{mode: \"nearest\", tagSets: [{a: \"b\"}], maxStalenessSeconds: 123}')"`
+	TableScan               bool   `long:"forceTableScan" description:"force a table scan (do not use $snapshot or hint _id). Deprecated since this is default behavior on WiredTiger"`
+	SourceWritesDoneBarrier string `long:"internalOnlySourceWritesDoneBarrier" hidden:"true"`
 }
 
 // Name returns a human-readable group name for input options.


### PR DESCRIPTION
REP-5475 - Changes required for the mongodump passthrough testing

New mongodump option --internalOnlySourceWritesDoneBarrier to synchronize with resmoke tests

mongodump/barrier.go implements the wait-until-named-file-exists barrier
