### PR TITLE
TOOLS-3799: Use // operator correctly to set empty when generating sbom

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -586,19 +586,6 @@
       "version": "v1.0.1"
     },
     {
-      "bom-ref": "pkg:golang/github.com/mongodb/mongo-tools",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mongodb/mongo-tools"
-        }
-      ],
-      "group": "github.com/mongodb",
-      "name": "mongo-tools",
-      "purl": "pkg:golang/github.com/mongodb/mongo-tools",
-      "type": "library"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1",
       "externalReferences": [
         {
@@ -1375,9 +1362,6 @@
       "ref": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1"
     },
     {
-      "ref": "pkg:golang/github.com/mongodb/mongo-tools"
-    },
-    {
       "ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1"
     },
     {
@@ -1469,7 +1453,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-03-26T19:47:21.554404+00:00",
+    "timestamp": "2025-04-04T01:59:26.580220+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1513,7 +1497,7 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 25,
+  "version": 26,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/scripts/regenerate-sbom-lite.sh
+++ b/scripts/regenerate-sbom-lite.sh
@@ -7,7 +7,7 @@ set -x
 # a purl (https://github.com/package-url/purl-spec), one per line. This is
 # used as input for the `silkbomb` tool to generate an SBOM.
 go list -json -mod=mod all |
-    jq -r '.Module // empty | "pkg:golang/" + .Path + "@" + .Version // empty' |
+  jq -r '.Module // empty | "pkg:golang/" + (.Path // empty) + "@" + (.Version // empty)' |
     sort -u >purls.txt
 go version |
     sed 's|^go version \([^ ]*\) *.*|pkg:golang/std@\1|' >>purls.txt

--- a/ssdlc/100.12.0.bom.json
+++ b/ssdlc/100.12.0.bom.json
@@ -586,19 +586,6 @@
       "version": "v1.0.1"
     },
     {
-      "bom-ref": "pkg:golang/github.com/mongodb/mongo-tools",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mongodb/mongo-tools"
-        }
-      ],
-      "group": "github.com/mongodb",
-      "name": "mongo-tools",
-      "purl": "pkg:golang/github.com/mongodb/mongo-tools",
-      "type": "library"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1",
       "externalReferences": [
         {
@@ -1375,9 +1362,6 @@
       "ref": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1"
     },
     {
-      "ref": "pkg:golang/github.com/mongodb/mongo-tools"
-    },
-    {
       "ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1"
     },
     {
@@ -1469,7 +1453,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-03-31T21:02:00.179239+00:00",
+    "timestamp": "2025-04-04T01:59:26.580220+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1514,48 +1498,8 @@
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
   "version": 26,
-  "vulnerabilities": [
-    {
-      "affects": [
-        {
-          "ref": "pkg:golang/github.com/mongodb/mongo-tools"
-        }
-      ],
-      "analysis": {
-        "state": "in_triage"
-      },
-      "bom-ref": "679943c11241b228cf6f5d95",
-      "cwes": [
-        295
-      ],
-      "description": "Improper Certificate Validation - Please see 'source' and 'references' for additional information",
-      "id": "mongo-tools___CVE-2020-7924",
-      "ratings": [
-        {
-          "method": "CVSSv3",
-          "score": 6.0,
-          "severity": "medium"
-        }
-      ],
-      "references": [
-        {
-          "id": "679943c11241b228cf6f5d95",
-          "source": {
-            "name": "Kondukto",
-            "url": "https://arcticglow.kondukto.io/projects/67990793f5bd68edc6c5e900/vulns/appsec?page=1&perPage=15&id=eq:679943c11241b228cf6f5d95"
-          }
-        },
-        {
-          "id": "VULN-387",
-          "source": {
-            "name": "Jira",
-            "url": "https://jira.mongodb.org/browse/VULN-387"
-          }
-        }
-      ]
-    }
-  ],
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5"
+  "specVersion": "1.5",
+  "vulnerabilities": []
 }

--- a/ssdlc/100.12.0.bom.json
+++ b/ssdlc/100.12.0.bom.json
@@ -1453,7 +1453,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-04-04T01:59:26.580220+00:00",
+    "timestamp": "2025-04-04T15:59:36.025190+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1497,9 +1497,50 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 26,
+  "version": 27,
+  "vulnerabilities": [
+    {
+      "affects": [
+        {
+          "ref": "pkg:golang/github.com/mongodb/mongo-tools"
+        }
+      ],
+      "analysis": {
+        "detail": "[justification value]",
+        "state": "false_positive"
+      },
+      "bom-ref": "679943c11241b228cf6f5d95",
+      "cwes": [
+        295
+      ],
+      "description": "Improper Certificate Validation - Please see 'source' and 'references' for additional information",
+      "id": "mongo-tools___CVE-2020-7924",
+      "ratings": [
+        {
+          "method": "CVSSv3",
+          "score": 6.0,
+          "severity": "medium"
+        }
+      ],
+      "references": [
+        {
+          "id": "679943c11241b228cf6f5d95",
+          "source": {
+            "name": "Kondukto",
+            "url": "https://arcticglow.kondukto.io/projects/67990793f5bd68edc6c5e900/vulns/appsec?page=1&perPage=15&id=eq:679943c11241b228cf6f5d95"
+          }
+        },
+        {
+          "id": "VULN-387",
+          "source": {
+            "name": "Jira",
+            "url": "https://jira.mongodb.org/browse/VULN-387"
+          }
+        }
+      ]
+    }
+  ],
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "vulnerabilities": []
+  "specVersion": "1.5"
 }


### PR DESCRIPTION
The left side of the alternative operator (//) in jq will not be empty in this case because of the string being appended. This causes "pkg:golang/github.com/mongodb/mongo-tools@" to get included in the list of dependencies for mongo-tools, without the version after "@", even though the `go list -json` output for mongo-tools does not contain a .Module.Version field for mongo-tools.

Compared against the old file this script generates to sends to silkbomb and the only thing removed was
"pkg:golang/github.com/mongodb/mongo-tools@"

Including the new sbom and augmented sbom in this commit.