### PR TITLE
mongo-tools evergreen for mongodump passthrough tests

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -697,7 +697,6 @@ post:
         exit 0
   # Extra post steps needed for mongodump passthrough.
   - func: f_resmoke_report_attach
-  - func: f_gotest_report
   - func: "attach artifacts"
   - func: f_mongo_coredumps_save
 
@@ -719,8 +718,6 @@ timeout:
         fi
   # Extra timeout steps needed for mongodump passthrough.
   - func: f_expansions_write
-  # Hang analyzer is used to upload data files after a timed-out resmoke test.
-  - func: "run hang analyzer"
   - func: "wait for resmoke to shutdown"
 
 tasks:

--- a/common.yml
+++ b/common.yml
@@ -1,3 +1,13 @@
+# Support for mongodump+mongorestore passthrough tests.
+
+include:
+  - filename: "mongodump_passthrough/globals.yml"
+  - filename: "mongodump_passthrough/parameters.yml"
+  - filename: "mongodump_passthrough/modules.yml"
+  - filename: "mongodump_passthrough/functions.yml"
+  - filename: "mongodump_passthrough/tasks.yml"
+  - filename: "mongodump_passthrough/variants.yml"
+
 #######################################
 #    Tools Driver Config for MCI      #
 #######################################
@@ -649,6 +659,18 @@ pre:
   - command: expansions.update
     params:
       file: expansions.yml
+  # Extra pre steps needed for mongodump passthrough.
+  - command: expansions.update
+    params:
+      updates:
+        - key: python
+          value: "/opt/mongodbtoolchain/v4/bin/python3"
+        - key: resmoke_dir
+          value: "src/resmoke"
+        - key: resmoke_venv_dir
+          value: "resmoke-venv"
+        - key: mongosync_binary_folder
+          value: "mongosync-coverage-binary"
 
 post:
   # attach.results works for jstests, gotest.parse_files for golang tests
@@ -673,6 +695,11 @@ post:
           set -v
         rm -rf /data/db/*
         exit 0
+  # Extra post steps needed for mongodump passthrough.
+  - func: f_resmoke_report_attach
+  - func: f_gotest_report
+  - func: "attach artifacts"
+  - func: f_mongo_coredumps_save
 
 timeout:
   - command: shell.exec
@@ -690,6 +717,11 @@ timeout:
           # git the processes a second or two to dump their stacks
           sleep 10
         fi
+  # Extra timeout steps needed for mongodump passthrough.
+  - func: f_expansions_write
+  # Hang analyzer is used to upload data files after a timed-out resmoke test.
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
 
 tasks:
   - name: dist

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -158,7 +158,7 @@ func oplogDocumentValidator(in []byte) error {
 	}
 
 	if ok && nsStr == "admin.system.version" {
-		return fmt.Errorf("cannot dump with oplog if admin.system.version is modified")
+		return fmt.Errorf("cannot dump with oplog if admin.system.version is modified by %v", raw)
 	}
 
 	if _, err := raw.LookupErr("o", "renameCollection"); err == nil {

--- a/mongodump_passthrough/README.md
+++ b/mongodump_passthrough/README.md
@@ -1,0 +1,9 @@
+mongo-tools/mongodump_passthrough contains evergreen .yml files to support resmoke passthrough
+testing of mongodump+mongorestore.
+
+This started out as a copy of the files from mongosync/evergreen, but has minor changes to cope with
+running from mongo-tools, and to avoid conflicts with the mongo-tools/common.yml
+
+These files should be included from mongo-tools/common.yml
+
+We have to be careful to avoid clashes with any task of function names used in common.yml

--- a/mongodump_passthrough/empty.go
+++ b/mongodump_passthrough/empty.go
@@ -1,0 +1,3 @@
+package empty_package_to_satisfy_go_vet
+
+// Empty package so that "go vet" will be happy with this directory.

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -1,0 +1,773 @@
+# Copied from mongosync/evergreen, with slight changes.
+
+# Functions and variables which differ from mongosync/evergreen/functions.yml are
+# marked as
+#   either: "Added for mongodump_passthrough"
+#   or:     "Changed for mongodump_passthrough"
+#
+# The tests are run by loading the mongosync repo as an evergreen module under src/mongosync.
+# The sources for mongodump-suite-gen, mongodump-task-gen, js tests (with slight modifications
+# for mongodump), and the dump_restore.py are all in the mongosync repo.
+#
+# Changes made to these in the mongosync repo will only be picked up when the _mongosync_pin
+# is changed here to point at the new mongosync commit hash.
+
+variables:
+  _migration_verifier_pin: &_migration_verifier_pin 9348607d61c4c865287828ce78b798a0f1b1cb89
+  _resmoke_dir: &_resmoke_dir "src/resmoke"
+  _src_dir: &src_dir src/mongosync
+  # Added for mongodump_passthrough
+  _mongosync_pin: &_mongosync_pin 6b18a97da5aa5a3ede27a2376a1d5c20dcaf986e
+
+  f_expansions_write: &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+  # Changed for mongodump_passthrough
+  f_repo_fetch: &f_repo_fetch
+    command: git.get_project
+    params:
+      directory: src/github.com/mongodb/mongo-tools
+      revisions:
+        mongosync: *_mongosync_pin
+
+  # Added for mongodump_passthrough
+  f_link_to_mongo_tools: &f_link_to_mongo_tools
+    command: shell.exec
+    params:
+      shell: bash
+      script: |
+        ln -s ${workdir}/src/github.com/mongodb/mongo-tools src
+
+  "set up logger credentials": &f_set_up_logger_credentials
+    command: subprocess.exec
+    params:
+      binary: "./src/mongosync/evergreen/logger_credentials_setup.sh"
+      add_expansions_to_env: true
+
+  f_resmoke_wheelhouse_setup: &f_resmoke_wheelhouse_setup
+    command: subprocess.exec
+    params:
+      binary: "./src/mongosync/evergreen/resmoke_wheelhouse_setup.sh"
+      add_expansions_to_env: true
+
+  # Function used to download particular bits of resmoke and binaries uploaded previously.
+  f_resmoke_with_binaries_fetch: &f_resmoke_with_binaries_fetch
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      # Changed for mongodump_passthrough
+      remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-with-binaries/${build_id}.tgz
+      bucket: mciuploads
+      extract_to: *_resmoke_dir
+
+  f_resmoke_wheelhouse_fetch: &f_resmoke_wheelhouse_fetch
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      # Changed for mongodump_passthrough
+      remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-python-wheelhouse/${build_id}.tgz
+      bucket: mciuploads
+      extract_to: "."
+
+  f_migration_verifier_binary_fetch: &f_migration_verifier_binary_fetch
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      # Changed for mongodump_passthrough
+      remote_file: mongo-tools/mongodump_passthrough/${mongosync_compile_build_variant}/${revision}/${version_id}/migration_verifier
+      bucket: mciuploads
+      local_file: src/mongosync/migration_verifier
+
+  f_make_migration_verifier_binary_executable:
+    &f_make_migration_verifier_binary_executable
+    command: shell.exec
+    params:
+      shell: bash
+      working_dir: src/mongosync
+      script: |
+        set -o errexit
+        set -o pipefail
+        set -o xtrace
+
+        chmod +x migration_verifier
+
+  f_mongosync_binary_fetch: &f_mongosync_binary_fetch
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      # Changed for mongodump_passthrough
+      remote_file: mongo-tools/mongodump_passthrough/${mongosync_compile_build_variant}/${revision}/${version_id}/${mongosync_binary_folder}/${version_id}.tgz
+      bucket: mciuploads
+      extract_to: "src/mongosync"
+
+  f_generate_github_access_token: &f_generate_github_access_token
+    command: github.generate_token
+    params:
+      owner: 10gen
+      repo: mongo
+      expansion_name: generated_token_mongo
+      permissions:
+        contents: read
+
+  f_resmoke_jobs_determine: &f_resmoke_jobs_determine
+    command: subprocess.exec
+    params:
+      binary: "./src/mongosync/evergreen/resmoke_jobs_determine.sh"
+      add_expansions_to_env: true
+      env:
+        resmoke_jobs_factor: ${resmoke_jobs_factor|1}
+        resmoke_jobs_max: ${resmoke_jobs_max|12}
+
+  f_resmoke_jobs_expansion_update: &f_resmoke_jobs_expansion_update
+    command: expansions.update
+    params:
+      ignore_missing_file: true
+      file: src/resmoke/resmoke_jobs_expansion.yml
+
+  f_resmoke_tests_execute: &f_resmoke_tests_execute
+    command: subprocess.exec
+    type: test
+    params:
+      binary: "./src/mongosync/evergreen/resmoke_tests_execute.sh"
+      add_expansions_to_env: true
+      env:
+        resmoke_jobs: ${resmoke_jobs|1}
+        should_shuffle: ${should_shuffle|true}
+
+  f_infrastructure_failure_check: &f_infrastructure_failure_check
+    # The existence of the "infrastructure_failure" file indicates this failure isn't
+    # directly actionable. We use type=setup rather than type=system or type=test for this command
+    # because we don't intend for any human to look at this failure.
+    command: subprocess.exec
+    type: setup
+    params:
+      binary: "./src/mongosync/evergreen/infrastructure_failure_check.sh"
+      add_expansions_to_env: true
+
+  "f_archive_credentials_setup_exec": &set_up_archive_credentials
+    command: subprocess.exec
+    params:
+      binary: "./src/mongosync/evergreen/archive_credentials_setup.sh"
+      env:
+        private_key_remote_bash_var: ${private_key_remote}
+      add_expansions_to_env: true
+
+  "get buildnumber": &get_buildnumber
+    command: keyval.inc
+    params:
+      key: "${build_variant}_v70"
+      destination: "builder_num"
+
+functions:
+  # Changed for mongodump_passthrough
+  "fetch source and install go":
+    # This clones mongo-tools and mongosync.
+    - command: git.get_project
+      params:
+        directory: src/github.com/mongodb/mongo-tools
+        revisions:
+          mongosync: *_mongosync_pin
+          migration-verifier: *_migration_verifier_pin
+    # The mongo-tools repo is cloned into src/github.com/mongodb/mongo-tools, but
+    # we also create a symbolic link at src/mongo-tools.
+    - *f_link_to_mongo_tools
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |
+          ls -l src
+    # Make an evergreen expansion file with dynamic values
+    - command: subprocess.exec
+      params:
+        binary: "./src/mongosync/evergreen/generate_mongosync_expansion.sh"
+        add_expansions_to_env: true
+        env:
+          mongosync_dir: "src/mongosync"
+    # Load the expansion file to make an evergreen variable with the current unique version
+    - command: expansions.update
+      params:
+        file: src/mongosync/mongosync_expansion.yml
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: src/mongosync
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+
+          MISE_INSTALL_PATH='${workdir}/.local/bin/mise' sh ./etc/mise.run.sh
+          mise settings experimental=true
+          # We only install Go here in order to get the system to a state where we can run mage. If
+          # more dev tools are needed, those tasks should run "mise install".
+          mise install go
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: src/mongosync
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+
+          mise exec -- go version
+          mise exec -- go env
+
+  "run mise and npm install":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: src/mongosync
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+
+          mise install
+          mise exec -- npm install
+
+  # Added for mongodump_passthrough
+  #
+  # This build the mongo-tools executables, then copies mongogump and mongorestore
+  # into src/mongosync/dist.
+  "build mongodump and mongorestore":
+    - command: shell.exec
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        script: |
+          ${PREPARE_SHELL}
+          PATH=$PATH:$HOME
+          echo $PATH 
+          MISE_INSTALL_PATH='${workdir}/.local/bin/mise' sh ${workdir}/src/mongosync/etc/mise.run.sh
+          mise settings experimental=true
+          mise activate --shims
+          PATH=$HOME/.local/share/mise/shims:$PATH
+          # We only install Go here in order to get the system to a state where we can run mage. If
+          # more dev tools are needed, those tasks should run `mise install`.
+          mise install go
+          mise use -g go@1.24.0
+          mise exec -- go run build.go build
+          # Copy mongodump and mongorestore to mongosync/dist
+          mkdir -p ${workdir}/src/mongosync/dist
+          cp -p bin/mongodump bin/mongorestore ${workdir}/src/mongosync/dist
+
+  "install podman on ubuntu":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: .
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+  f_repo_with_modules_fetch:
+    - command: git.get_project
+      params:
+        directory: src/github.com/mongodb/mongo-tools
+        revisions:
+          migration-verifier: *_migration_verifier_pin
+          mongosync: *_mongosync_pin
+
+  # Under src/mongosync/resmoke we have separate directories "suite-config"
+  # and "mongodump-suite-config". To run mongodump passthrough tests we delete
+  # mongosync-related suites directories and copy the mongodump_suite-config.
+  # This keeps the mongosync suite-config/*/loggers dirs.
+  f_enable_mongodump_suite_config: &f_enable_mongodump_suite_config
+    command: shell.exec
+    params:
+      shell: bash
+      working_dir: src/mongosync/resmoke
+      script: |
+        set -o errexit
+        set -o pipefail
+        set -o xtrace
+
+        rm -rf `find suite-config -name "suites"`
+        cd mongodump-suite-config
+        tar cvf ../suite-config/a.tar .
+        cd ../suite-config
+        tar xvf a.tar
+
+  f_expansions_write:
+    - *f_expansions_write
+
+  f_generate_github_access_token:
+    - *f_generate_github_access_token
+
+  "configure evergreen api credentials": &f_evergreen_credentials_setup
+    command: subprocess.exec
+    params:
+      # The evergreen project variables in mongo-tools are ${evg_key} and ${evg_user}.
+      binary: "./src/mongosync/evergreen/evergreen_credentials_setup.sh"
+      env:
+        evergreen_api_key: ${evg_key}
+        evergreen_api_user: ${evg_user}
+      add_expansions_to_env: true
+
+  # Function used to download Resmoke and compiled mongo* binaries from the server project.
+  f_resmoke_and_binaries_download:
+    - *f_evergreen_credentials_setup
+    - command: subprocess.exec
+      params:
+        binary: "./src/mongosync/evergreen/resmoke_and_binaries_download.sh"
+        add_expansions_to_env: true
+
+  f_resmoke_wheelhouse_setup:
+    - *f_resmoke_wheelhouse_setup
+
+  f_resmoke_archive:
+    - command: archive.targz_pack
+      params:
+        target: resmoke-with-binaries.tgz
+        source_dir: "src/resmoke/${src_mongo_version}_${dst_mongo_version}"
+        include:
+          - "./buildscripts/**"
+          - "./${src_mongo_version}/**"
+          - "./${dst_mongo_version}/**"
+          - "./mongo-for-shell/**"
+          - "./etc/**"
+          - "./jstests/**"
+          - "./src/**"
+          - "./.resmoke_mongo_version.yml"
+          - "./.resmoke_mongo_release_values.yml"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: resmoke-with-binaries.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-with-binaries/${build_id}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: resmoke-with-binaries
+
+    - command: archive.targz_pack
+      params:
+        target: resmoke-python-wheelhouse.tgz
+        source_dir: "."
+        include:
+          - "./wheelhouse/**"
+          - "./poetry-requirements.txt"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: resmoke-python-wheelhouse.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-python-wheelhouse/${build_id}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: resmoke-python-wheelhouse
+
+  f_migration_verifier_compile_and_upload:
+    &f_migration_verifier_compile_and_upload # Compile the migration-verifier:
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: src/migration-verifier
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+
+          # XXX - Since mise is scoped to the Mongosync repo root, we cannot easily use it to build things
+          # outside that root. It'd be nice if the migration-verifier also used mise too, but for now this
+          # works okay.
+          PATH=$PATH:$HOME:/opt/golang/go1.23/bin
+          GOROOT=/opt/golang/go1.23
+          ./build.sh
+    # upload the compiled verifier to S3.
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/migration-verifier/migration_verifier
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/migration_verifier
+        content_type: application/x-executable
+        bucket: mciuploads
+        permissions: public-read
+        display_name: "migration_verifier release artifact (compiled)"
+
+  f_migration_verifier_binary_fetch:
+    - *f_migration_verifier_binary_fetch
+
+  f_make_migration_verifier_binary_executable:
+    - *f_make_migration_verifier_binary_executable
+
+  # This uploads everything in src/mongosync/dist/
+  # For mongodump, we don't need the mongosync bi9naries, but we have
+  # already built the mongodump and mongorestore binaries and copied
+  # them into src/mongosync/dist/
+  f_mongosync_binary_upload: &f_mongosync_binary_upload
+    - command: archive.targz_pack
+      params:
+        target: ${mongosync_binary_folder}.tgz
+        source_dir: "src/mongosync"
+        include:
+          - "./dist/*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: ${mongosync_binary_folder}.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/${mongosync_binary_folder}/${version_id}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: ${mongosync_binary_folder}
+
+  f_mongosync_heap_data_upload: &f_mongosync_heap_data_upload
+    - command: archive.targz_pack
+      params:
+        target: mongosync-heap-data.tgz
+        source_dir: "src/mongosync"
+        include:
+          - "./internal/mongosync/integration/*.heap"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosync-heap-data.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/mongosync-heap-data/${version_id}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: mongosync-heap-data
+
+  "passthrough setup":
+    - *f_repo_fetch
+    # Added for mongodump_passthrough
+    - *f_link_to_mongo_tools
+    - *f_enable_mongodump_suite_config
+    - *f_resmoke_with_binaries_fetch
+    - *f_resmoke_wheelhouse_fetch
+    - *f_mongosync_binary_fetch
+    - *get_buildnumber
+    - *f_set_up_logger_credentials
+
+  "generate resmoke tasks":
+    - *f_expansions_write
+    - *f_evergreen_credentials_setup
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: "./src/mongosync/evergreen/gen_tasks_activate.sh"
+        add_expansions_to_env: true
+
+  "run tests":
+    - command: expansions.update
+      params:
+        updates:
+          - key: aws_key_remote
+            value: ${mongodatafiles_aws_key}
+          - key: aws_profile_remote
+            value: mongodata_aws
+          - key: aws_secret_remote
+            value: ${mongodatafiles_aws_secret}
+    - *f_expansions_write
+    - *set_up_archive_credentials
+    - *f_resmoke_jobs_determine
+    - *f_resmoke_jobs_expansion_update
+    - *f_resmoke_tests_execute
+    - *f_infrastructure_failure_check
+
+  f_resmoke_report_attach:
+    - command: attach.results
+      params:
+        file_location: src/resmoke/report.json
+
+  f_gotest_report:
+    - command: gotest.parse_files
+      params:
+        files:
+          - "src/mongosync/*.suite"
+
+  f_mongo_coredumps_save:
+    - command: subprocess.exec
+      params:
+        binary: "./src/mongosync/evergreen/mongo_coredumps_gather.sh"
+        add_expansions_to_env: true
+    - command: archive.targz_pack
+      params:
+        target: mongo-coredumps.tgz
+        source_dir: *_resmoke_dir
+        include:
+          - "./**.core"
+          - "./**.mdmp" # Windows: minidumps
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-coredumps.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/coredumps/mongo-coredumps-${build_id}-${task_name}-${execution}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Core Dumps - Execution ${execution}
+        optional: true
+
+  "attach artifacts":
+    - command: attach.artifacts
+      params:
+        optional: true
+        files:
+          - src/resmoke/archive.json
+          - src/resmoke/archive-job*.json
+
+    - command: archive.targz_pack
+      params:
+        target: server-logs.tgz
+        source_dir: "src/mongosync/mongosync-testing-server-logs"
+        include:
+          - "./**"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: server-logs.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-logs/mongo-logs-${build_id}-${task_name}-${execution}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Integration Test mongod / mongos logs ${execution}
+        optional: true
+
+    - command: archive.targz_pack
+      params:
+        target: mongo-orchestration-logs.tgz
+        source_dir: "src/mongosync"
+        include:
+          - "out.log"
+          - "server.log"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-orchestration-logs.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-orchestration-logs/mongo-orchestration-logs.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: mongo-orchestration logs
+        optional: true
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_files_include_filter:
+          - src/mongosync/*.suite
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${build_id}/${task_name}/${execution}/go-test-logs/
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+        display_name: "Output from `go test` command"
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongosync/server-binaries.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-binaries/mongo-binaries-${build_id}-${task_name}-${execution}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Failed Integration Test mongod / mongos binaries ${execution}
+        optional: true
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_files_include_filter:
+          - src/mongosync/mongosync-testing-server-data-files/archive/*.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${build_id}/${task_name}/datafiles/
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
+        display_name: Failed Integration Test Data Files ${execution}
+
+    - command: archive.targz_pack
+      params:
+        target: coverage.gz
+        source_dir: "src/mongosync/coverage"
+        include:
+          - "./**"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: coverage.gz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/coverage/${task_name}/coverage.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Coverage statistics
+
+  "setup jstestfuzz":
+    - *f_expansions_write
+    - command: github.generate_token
+      params:
+        owner: 10gen
+        repo: jstestfuzz
+        expansion_name: generated_token_jstestfuzz
+        permissions:
+          contents: read
+    - command: subprocess.exec
+      params:
+        binary: "./src/mongosync/evergreen/setup_jstestfuzz.sh"
+        add_expansions_to_env: true
+
+  "run jstestfuzz":
+    - *f_expansions_write
+    - *f_generate_github_access_token
+    - command: github.generate_token
+      params:
+        owner: 10gen
+        repo: qa
+        expansion_name: generated_token_qa
+        permissions:
+          contents: read
+    - command: subprocess.exec
+      params:
+        binary: "./src/mongosync/evergreen/clone_jstestfuzz_jstest_repos.sh"
+        add_expansions_to_env: true
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: "./src/mongosync/evergreen/run_jstestfuzz.sh"
+        add_expansions_to_env: true
+    - command: archive.targz_pack
+      params:
+        target: "jstests.tgz"
+        source_dir: "src/jstestfuzz"
+        include:
+          - "out/*.js"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: jstests.tgz
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/jstestfuzz/${task_id}-${execution}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: JS Fuzz Tests - Execution ${execution}
+
+  "minimize jstestfuzz":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: "./src/mongosync/evergreen/minimize_jstestfuzz.sh"
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/minimizer-outputs.json
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/artifacts/minimizer-outputs-${build_id}.json
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/json
+        display_name: Minimizer Outputs - Execution ${execution}
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/jstestfuzz/out/minimizer-outputs-minimizedtest.js
+        # Changed for mongodump_passthrough
+        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/artifacts/minimizer-outputs-minimizedtest-${build_id}.js
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: text/javascript
+        display_name: Minimized jstestfuzz Test - Execution ${execution}
+
+  "generate mongodump evergreen tasks":
+    # Note: This assumes you've already called "fetch source and install go", because you can't call
+    # a function from another function.
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: src/mongosync
+        script: |
+          set -o errexit
+          set -o pipefail
+          set -o xtrace
+
+          ${PREPARE_SHELL}
+          export aws_key=${aws_key}
+          export aws_secret=${aws_secret}
+          mise exec -- go run ./cmd/mongodump-task-gen ${generator_args} | tee ${json_filename}
+    - command: generate.tasks
+      params:
+        files:
+          - ${json_filename}
+
+  "run hang analyzer":
+    - *f_expansions_write
+    - command: subprocess.exec
+      display_name: "hang analyzer sh"
+      params:
+        binary: "./src/mongosync/evergreen/hang_analyzer.sh"
+        add_expansions_to_env: true
+
+  "wait for resmoke to shutdown":
+    - command: subprocess.exec
+      display_name: "wait for resmoke to shutdown"
+      params:
+        binary: "./src/mongosync/evergreen/wait_for_resmoke_to_shutdown.sh"
+
+  "coveralls upload report":
+    - command: shell.exec
+      params:
+        working_dir: src/mongosync
+        script: |
+          ${PREPARE_SHELL}
+          mise exec -- go tool covdata textfmt -i=${covdata_path} -o="coverage.lcov"
+    - command: shell.exec
+      params:
+        working_dir: src/mongosync
+        script: |
+          coveralls report coverage.lcov --build-number ${version_id} --repo-token ${coveralls_repo_token}

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -17,7 +17,7 @@ variables:
   _resmoke_dir: &_resmoke_dir "src/resmoke"
   _src_dir: &src_dir src/mongosync
   # Added for mongodump_passthrough
-  _mongosync_pin: &_mongosync_pin 6b18a97da5aa5a3ede27a2376a1d5c20dcaf986e
+  _mongosync_pin: &_mongosync_pin 7f661ae42fb3d03a813c08654283ca51ff8e25f7
 
   f_expansions_write: &f_expansions_write
     command: expansions.write
@@ -97,6 +97,9 @@ variables:
 
         chmod +x migration_verifier
 
+  # This fetches the contents copied from mongosync/dist
+  # We keep the same function name as in mongosync evergreen, but here that
+  # directory contains the mongodump and mongorestore binaries.
   f_mongosync_binary_fetch: &f_mongosync_binary_fetch
     command: s3.get
     params:
@@ -204,8 +207,9 @@ functions:
           set -o xtrace
 
           ${PREPARE_SHELL}
+          source "./etc/functions.sh"
 
-          MISE_INSTALL_PATH='${workdir}/.local/bin/mise' sh ./etc/mise.run.sh
+          MISE_INSTALL_PATH='${workdir}/.local/bin/mise' retry sh ./etc/mise.run.sh
           mise settings experimental=true
           # We only install Go here in order to get the system to a state where we can run mage. If
           # more dev tools are needed, those tasks should run "mise install".
@@ -504,12 +508,6 @@ functions:
       params:
         file_location: src/resmoke/report.json
 
-  f_gotest_report:
-    - command: gotest.parse_files
-      params:
-        files:
-          - "src/mongosync/*.suite"
-
   f_mongo_coredumps_save:
     - command: subprocess.exec
       params:
@@ -744,14 +742,6 @@ functions:
       params:
         files:
           - ${json_filename}
-
-  "run hang analyzer":
-    - *f_expansions_write
-    - command: subprocess.exec
-      display_name: "hang analyzer sh"
-      params:
-        binary: "./src/mongosync/evergreen/hang_analyzer.sh"
-        add_expansions_to_env: true
 
   "wait for resmoke to shutdown":
     - command: subprocess.exec

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -33,6 +33,12 @@ variables:
       revisions:
         mongosync: *_mongosync_pin
 
+  f_set_up_logger_credentials: &f_set_up_logger_credentials
+    command: subprocess.exec
+    params:
+      binary: "./src/mongosync/evergreen/logger_credentials_setup.sh"
+      add_expansions_to_env: true
+
   # Added for mongodump_passthrough
   f_link_to_mongo_tools: &f_link_to_mongo_tools
     command: shell.exec
@@ -40,12 +46,6 @@ variables:
       shell: bash
       script: |
         ln -s ${workdir}/src/github.com/mongodb/mongo-tools src
-
-  "set up logger credentials": &f_set_up_logger_credentials
-    command: subprocess.exec
-    params:
-      binary: "./src/mongosync/evergreen/logger_credentials_setup.sh"
-      add_expansions_to_env: true
 
   f_resmoke_wheelhouse_setup: &f_resmoke_wheelhouse_setup
     command: subprocess.exec
@@ -154,7 +154,7 @@ variables:
       binary: "./src/mongosync/evergreen/infrastructure_failure_check.sh"
       add_expansions_to_env: true
 
-  "f_archive_credentials_setup_exec": &set_up_archive_credentials
+  f_set_up_archive_credentials: &f_set_up_archive_credentials
     command: subprocess.exec
     params:
       binary: "./src/mongosync/evergreen/archive_credentials_setup.sh"
@@ -162,7 +162,7 @@ variables:
         private_key_remote_bash_var: ${private_key_remote}
       add_expansions_to_env: true
 
-  "get buildnumber": &get_buildnumber
+  get_buildnumber: &get_buildnumber
     command: keyval.inc
     params:
       key: "${build_variant}_v70"
@@ -230,21 +230,6 @@ functions:
           mise exec -- go version
           mise exec -- go env
 
-  "run mise and npm install":
-    - command: shell.exec
-      params:
-        shell: bash
-        working_dir: src/mongosync
-        script: |
-          set -o errexit
-          set -o pipefail
-          set -o xtrace
-
-          ${PREPARE_SHELL}
-
-          mise install
-          mise exec -- npm install
-
   # Added for mongodump_passthrough
   #
   # This builds the mongo-tools executables, then copies mongogump and mongorestore
@@ -262,21 +247,6 @@ functions:
           # Copy mongodump and mongorestore to mongosync/dist
           mkdir -p ${workdir}/src/mongosync/dist
           cp -p bin/mongodump bin/mongorestore ${workdir}/src/mongosync/dist
-
-  "install podman on ubuntu":
-    - command: shell.exec
-      params:
-        shell: bash
-        working_dir: .
-        script: |
-          set -o errexit
-          set -o pipefail
-          set -o xtrace
-
-          ${PREPARE_SHELL}
-
-          sudo apt-get update
-          sudo apt-get install -y podman
 
   f_repo_with_modules_fetch:
     - command: git.get_project
@@ -442,25 +412,6 @@ functions:
         content_type: application/gzip
         display_name: ${mongosync_binary_folder}
 
-  f_mongosync_heap_data_upload: &f_mongosync_heap_data_upload
-    - command: archive.targz_pack
-      params:
-        target: mongosync-heap-data.tgz
-        source_dir: "src/mongosync"
-        include:
-          - "./internal/mongosync/integration/*.heap"
-    - command: s3.put
-      params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        local_file: mongosync-heap-data.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/mongosync-heap-data/${version_id}.tgz
-        bucket: mciuploads
-        permissions: public-read
-        content_type: application/gzip
-        display_name: mongosync-heap-data
-
   "passthrough setup":
     - *f_repo_fetch
     # Added for mongodump_passthrough
@@ -471,15 +422,6 @@ functions:
     - *f_mongosync_binary_fetch
     - *get_buildnumber
     - *f_set_up_logger_credentials
-
-  "generate resmoke tasks":
-    - *f_expansions_write
-    - *f_evergreen_credentials_setup
-    - command: subprocess.exec
-      type: test
-      params:
-        binary: "./src/mongosync/evergreen/gen_tasks_activate.sh"
-        add_expansions_to_env: true
 
   "run tests":
     - command: expansions.update
@@ -492,7 +434,7 @@ functions:
           - key: aws_secret_remote
             value: ${mongodatafiles_aws_secret}
     - *f_expansions_write
-    - *set_up_archive_credentials
+    - *f_set_up_archive_credentials
     - *f_resmoke_jobs_determine
     - *f_resmoke_jobs_expansion_update
     - *f_resmoke_tests_execute
@@ -520,8 +462,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongo-coredumps.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/coredumps/mongo-coredumps-${build_id}-${task_name}-${execution}.tgz
+        remote_file: mongosync/${build_variant}/${revision}/coredumps/mongo-coredumps-${build_id}-${task_name}-${execution}.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: application/gzip
@@ -547,8 +488,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: server-logs.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-logs/mongo-logs-${build_id}-${task_name}-${execution}.tgz
+        remote_file: mongosync/${build_variant}/${revision}/mongo-logs/mongo-logs-${build_id}-${task_name}-${execution}.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: application/gzip
@@ -567,8 +507,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongo-orchestration-logs.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-orchestration-logs/mongo-orchestration-logs.tgz
+        remote_file: mongosync/${build_variant}/${revision}/mongo-orchestration-logs/mongo-orchestration-logs.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: application/gzip
@@ -581,8 +520,7 @@ functions:
         aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/mongosync/*.suite
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${build_id}/${task_name}/${execution}/go-test-logs/
+        remote_file: mongosync/${build_variant}/${revision}/${build_id}/${task_name}/${execution}/go-test-logs/
         bucket: mciuploads
         permissions: public-read
         content_type: text/plain
@@ -593,8 +531,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/mongosync/server-binaries.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/mongo-binaries/mongo-binaries-${build_id}-${task_name}-${execution}.tgz
+        remote_file: mongosync/${build_variant}/${revision}/mongo-binaries/mongo-binaries-${build_id}-${task_name}-${execution}.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: application/gzip
@@ -607,8 +544,7 @@ functions:
         aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/mongosync/mongosync-testing-server-data-files/archive/*.tgz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${build_id}/${task_name}/datafiles/
+        remote_file: mongosync/${build_variant}/${revision}/${build_id}/${task_name}/datafiles/
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
@@ -625,8 +561,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: coverage.gz
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/coverage/${task_name}/coverage.gz
+        remote_file: mongosync/${build_variant}/${revision}/coverage/${task_name}/coverage.gz
         bucket: mciuploads
         permissions: public-read
         content_type: application/gzip
@@ -683,39 +618,6 @@ functions:
         visibility: signed
         content_type: application/gzip
         display_name: JS Fuzz Tests - Execution ${execution}
-
-  "minimize jstestfuzz":
-    - *f_expansions_write
-    - command: subprocess.exec
-      type: test
-      params:
-        binary: "./src/mongosync/evergreen/minimize_jstestfuzz.sh"
-    - command: s3.put
-      params:
-        optional: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        local_file: src/minimizer-outputs.json
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/artifacts/minimizer-outputs-${build_id}.json
-        bucket: mciuploads
-        permissions: private
-        visibility: signed
-        content_type: application/json
-        display_name: Minimizer Outputs - Execution ${execution}
-    - command: s3.put
-      params:
-        optional: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        local_file: src/jstestfuzz/out/minimizer-outputs-minimizedtest.js
-        # Changed for mongodump_passthrough
-        remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/artifacts/minimizer-outputs-minimizedtest-${build_id}.js
-        bucket: mciuploads
-        permissions: private
-        visibility: signed
-        content_type: text/javascript
-        display_name: Minimized jstestfuzz Test - Execution ${execution}
 
   "generate mongodump evergreen tasks":
     # Note: This assumes you've already called "fetch source and install go", because you can't call

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -197,6 +197,8 @@ functions:
     - command: expansions.update
       params:
         file: src/mongosync/mongosync_expansion.yml
+    # Tasks/functions that use the mongosync sources should use the same
+    # mise-installed tools as when running from mongo-tools evergreen.
     - command: shell.exec
       params:
         shell: bash
@@ -245,25 +247,18 @@ functions:
 
   # Added for mongodump_passthrough
   #
-  # This build the mongo-tools executables, then copies mongogump and mongorestore
-  # into src/mongosync/dist.
+  # This builds the mongo-tools executables, then copies mongogump and mongorestore
+  # into src/mongosync/dist. We use the same shell setup and go toolchain
+  # as in mongo-tools/common.yml "run make target"
   "build mongodump and mongorestore":
     - command: shell.exec
       params:
         working_dir: src/github.com/mongodb/mongo-tools
         script: |
-          ${PREPARE_SHELL}
+          ${_set_shell_env}
+          ${_maybe_enable_devtoolset_7}
           PATH=$PATH:$HOME
-          echo $PATH 
-          MISE_INSTALL_PATH='${workdir}/.local/bin/mise' sh ${workdir}/src/mongosync/etc/mise.run.sh
-          mise settings experimental=true
-          mise activate --shims
-          PATH=$HOME/.local/share/mise/shims:$PATH
-          # We only install Go here in order to get the system to a state where we can run mage. If
-          # more dev tools are needed, those tasks should run `mise install`.
-          mise install go
-          mise use -g go@1.24.0
-          mise exec -- go run build.go build
+          go run build.go -v build
           # Copy mongodump and mongorestore to mongosync/dist
           mkdir -p ${workdir}/src/mongosync/dist
           cp -p bin/mongodump bin/mongorestore ${workdir}/src/mongosync/dist
@@ -748,16 +743,3 @@ functions:
       display_name: "wait for resmoke to shutdown"
       params:
         binary: "./src/mongosync/evergreen/wait_for_resmoke_to_shutdown.sh"
-
-  "coveralls upload report":
-    - command: shell.exec
-      params:
-        working_dir: src/mongosync
-        script: |
-          ${PREPARE_SHELL}
-          mise exec -- go tool covdata textfmt -i=${covdata_path} -o="coverage.lcov"
-    - command: shell.exec
-      params:
-        working_dir: src/mongosync
-        script: |
-          coveralls report coverage.lcov --build-number ${version_id} --repo-token ${coveralls_repo_token}

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -420,7 +420,7 @@ functions:
     - *f_make_migration_verifier_binary_executable
 
   # This uploads everything in src/mongosync/dist/
-  # For mongodump, we don't need the mongosync bi9naries, but we have
+  # For mongodump, we don't need the mongosync binaries, but we have
   # already built the mongodump and mongorestore binaries and copied
   # them into src/mongosync/dist/
   f_mongosync_binary_upload: &f_mongosync_binary_upload

--- a/mongodump_passthrough/globals.yml
+++ b/mongodump_passthrough/globals.yml
@@ -1,0 +1,3 @@
+# Copied from mongosync/evergreen, with changes to avoid conflicts.
+
+oom_tracker: true

--- a/mongodump_passthrough/modules.yml
+++ b/mongodump_passthrough/modules.yml
@@ -1,0 +1,35 @@
+# Copied from mongosync/evergreen, with mongosync added as a module.
+
+# The file tree looks like this:
+# src
+#  |---- resmoke
+#  |---- migration-verifier
+#  |---- mongosync
+
+# The modules used for performance testing and the migration-verifier are pinned to arbitrary commits.
+# It's okay to update the pins whenever we feel like it as long as tests pass.
+modules:
+  - name: migration-verifier
+    repo: git@github.com:mongodb-labs/migration-verifier.git
+    prefix: ${workdir}/src
+    branch: main
+  # TODO (REP-3977): This is used for the JS unit tests, which load JS code from the mongo repo's
+  # `jstests` dir. The exact revision doesn't matter too much, but once we fully generate the
+  # Evergreen config, we should use one of the pinned revisions we use for cases where we need
+  # something from the mongo repo.
+  - name: mongo
+    repo: git@github.com:10gen/mongo.git
+    prefix: ${workdir}/src
+    branch: v6.0
+  # Passthrough testing of mongodump+mongorestore uses various code in the mongosync repo:
+  #
+  #   - resmoke JS test code with slight tweaks
+  #   - resmoke python code with DumpRestoreFixture
+  #   - Go source code for mongodump-suite-gen
+  #   - Go source code for mongodump-task-gen
+  #
+  # We use git.get_project to load the mongosync as a module when necessary
+  - name: mongosync
+    repo: git@github.com:10gen/mongosync.git
+    prefix: ${workdir}/src
+    branch: rcownie/passthru3

--- a/mongodump_passthrough/parameters.yml
+++ b/mongodump_passthrough/parameters.yml
@@ -1,0 +1,7 @@
+# Copied from mongosync/evergreen, with changes to avoid conflicts.
+
+parameters:
+  - key: src_server_version_for_patch
+    description: "Explicit version of the MongoDB server to use for the source cluster"
+  - key: dst_server_version_for_patch
+    description: "Explicit version of the MongoDB server to use for the destination cluster"

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -113,7 +113,7 @@ tasks:
           generator_args: "mongodump_jstestfuzz"
           json_filename: mongodump_fuzz_tasks.json
 
-  - name: suites-up-to-date
+  - name: mongodump_suites_up_to_date
     commands:
       - func: "fetch source and install go"
       - command: shell.exec
@@ -123,7 +123,6 @@ tasks:
           script: |
             ${PREPARE_SHELL}
             set -ex
-            rm resmoke/mongodump-suite-config/*/suites/*
-            mise install
+            mise install go
             mise exec -- go run ./cmd/mongodump-suite-gen/cmd write --all --quiet
             git diff --name-status --exit-code resmoke/mongodump-suite-config/*/suites

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -123,6 +123,6 @@ tasks:
           script: |
             ${PREPARE_SHELL}
             set -ex
-            mise install go
+            mise install
             mise exec -- go run ./cmd/mongodump-suite-gen/cmd write --all --quiet
             git diff --name-status --exit-code resmoke/mongodump-suite-config/*/suites

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -1,0 +1,129 @@
+# Copied from mongosync/evergreen, with changes to fit in mongo-tools.
+
+# Tasks which differ from mongosync/evergreen/functions.yml are
+# marked as
+#   either: "Added for mongodump_passthrough"
+#   or:     "Changed for mongodump_passthrough"
+
+variables:
+  _modules: &_modules
+    - migration-verifier
+    - mongosync
+  _python: &_python /opt/mongodbtoolchain/v4/bin/python3
+  _resmoke_dir: &_resmoke_dir "src/resmoke"
+  _resmoke_venv_dir: &_resmoke_venv_dir "resmoke-venv"
+  _src_dir: &src_dir src/mongosync
+
+tasks:
+  - name: commit-queue-workaround
+    commands:
+      - command: shell.exec
+        params:
+          script: |
+            echo "This task is a no-op to work around evergreen's commit queue behavior"
+
+  # For mongodump passthrough, this builds and uploads the mongodump and mongorestore
+  # binaries (but without coverage), and uploads them.  The name "compile_coverage"
+  # is misleading, but that task name is used in the generated tasks from mongodump-task-gen
+  # so we keep it the same to minimize change.
+  - name: compile_coverage
+    tags: ["git_tag"]
+    commands:
+      - func: "fetch source and install go"
+      # We don't need to build any mongosync binaries, but we put mongodump
+      # and mongorestore in the src/mongosync/dist and upload that dir.
+      - func: "build mongodump and mongorestore"
+      - func: f_mongosync_binary_upload
+        vars:
+          binary_name: "mongosync-coverage-binary"
+
+  - name: compile_verifier
+    tags: ["git_tag"]
+    commands:
+      - func: "fetch source and install go"
+      - func: f_migration_verifier_compile_and_upload
+
+  - name: t_resmoke_setup
+    commands:
+      - func: f_repo_with_modules_fetch
+      - func: f_resmoke_and_binaries_download
+        vars:
+          platform: rhel80
+      - func: f_resmoke_wheelhouse_setup
+      - func: f_resmoke_archive
+
+  # This task is meant for use in patches; you can run the generator, save the
+  # file to mongo-tools/manual-tasks.json, then run this task using evergreen patch.
+  - name: run_manual_generated_tasks
+    tags: ["mongodump_passthrough_task_generator"]
+    commands:
+      - func: "fetch source and install go"
+      - command: generate.tasks
+        params:
+          files:
+            - src/github.com/mongodb/mongo-tools/manual-tasks.json
+
+  # Task dependencies have been changed slightly here, to allow this
+  # task to execute concurrently with "compile_coverage".
+  - name: generate_mongodump_resmoke_build_variants
+    tags: ["mongodump_passthrough_task_generator"]
+    commands:
+      - func: "fetch source and install go"
+      - func: "generate mongodump evergreen tasks"
+        vars:
+          generator_args: "buildvariants"
+          json_filename: mongodump_build_variants.json
+
+  - name: generate_mongodump_passthrough_tasks
+    tags: ["mongodump_passthrough_task_generator"]
+    depends_on:
+      - name: generate_mongodump_resmoke_build_variants
+      - name: compile_coverage
+        variant: rhel80
+    commands:
+      - func: "fetch source and install go"
+      - func: "generate mongodump evergreen tasks"
+        vars:
+          generator_args: "mongodump_passthrough"
+          json_filename: mongodump_passthrough_tasks.json
+
+  - name: generate_mongodump_fsm_tasks
+    tags: ["mongodump_passthrough_task_generator"]
+    depends_on:
+      - name: generate_mongodump_resmoke_build_variants
+      - name: compile_coverage
+        variant: rhel80
+    commands:
+      - func: "fetch source and install go"
+      - func: "generate mongodump evergreen tasks"
+        vars:
+          generator_args: "mongodump_fsm"
+          json_filename: mongodump_fsm_tasks.json
+
+  - name: generate_mongodump_fuzz_tasks
+    tags: ["mongodump_passthrough_task_generator"]
+    depends_on:
+      - name: generate_mongodump_resmoke_build_variants
+      - name: compile_coverage
+        variant: rhel80
+    commands:
+      - func: "fetch source and install go"
+      - func: "generate mongodump evergreen tasks"
+        vars:
+          generator_args: "mongodump_jstestfuzz"
+          json_filename: mongodump_fuzz_tasks.json
+
+  - name: suites-up-to-date
+    commands:
+      - func: "fetch source and install go"
+      - command: shell.exec
+        type: test
+        params:
+          working_dir: src/mongosync
+          script: |
+            ${PREPARE_SHELL}
+            set -ex
+            rm resmoke/mongodump-suite-config/*/suites/*
+            mise install
+            mise exec -- go run ./cmd/mongodump-suite-gen/cmd write --all --quiet
+            git diff --name-status --exit-code resmoke/mongodump-suite-config/*/suites

--- a/mongodump_passthrough/variants.yml
+++ b/mongodump_passthrough/variants.yml
@@ -10,6 +10,7 @@ buildvariants:
     tasks:
       - name: compile_coverage
       - name: compile_verifier
+      - name: mongodump_suites_up_to_date
       - name: .mongodump_passthrough_task_generator
     run_on:
       - rhel80-xlarge

--- a/mongodump_passthrough/variants.yml
+++ b/mongodump_passthrough/variants.yml
@@ -1,0 +1,20 @@
+# buildvariant "rhel80" is used only for mongodump passthrough testing
+#
+# This is the same variant name used for mongosync passthrough testing,
+# and we try to set it up the same way.
+
+buildvariants:
+  - name: rhel80
+    # Use this name to get it sorted near the top of the list in spruce UI.
+    display_name: "# RHEL 8.x (mongodump passthrough)"
+    tasks:
+      - name: compile_coverage
+      - name: compile_verifier
+      - name: .mongodump_passthrough_task_generator
+    run_on:
+      - rhel80-xlarge
+    expansions:
+      python_override: /opt/mongodbtoolchain/v4/bin/python3
+    modules:
+      - migration-verifier
+      - mongosync

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -483,6 +483,24 @@ var platforms = []Platform{
 		MaxLinuxServerVersion: &version.Version{Major: 7, Minor: 0, Patch: 0},
 	},
 	{
+		// Same variant name as mongosync passthrough tests to minimize
+		// changes in mongodump-task-gen for mongodump passthrough tests.
+		Name:            "rhel80",
+		Arch:            ArchX86_64,
+		OS:              OSLinux,
+		Pkg:             PkgRPM,
+		Repos:           []Repo{RepoOrg, RepoEnterprise},
+		BuildTags:       defaultBuildTags,
+		SkipForJSONFeed: true,
+		// Using server rhel 80 builds because "enterprise-rhel-80-64-bit" is not available for all server versions.
+		// NB: Older builds are “rhel-80”, while newer ones are just “rhel-8”.
+		ServerVariantNames: mapset.NewSet(
+			"enterprise-rhel-80-64-bit",
+			"enterprise-rhel-8-64-bit",
+		),
+		ServerPlatform: "rhel80",
+	},
+	{
 		Name:      "rhel81",
 		Arch:      ArchPpc64le,
 		OS:        OSLinux,

--- a/release/platform/platform_test.go
+++ b/release/platform/platform_test.go
@@ -40,7 +40,9 @@ func TestPlatformsMatchCI(t *testing.T) {
 	}
 
 	for _, v := range config.Variants {
-		if v.Name == "release" || v.Name == "static" || v.Name == "rhel88-race" {
+		// Variant "rhel80" has been added to support mongodump passthrough testing.
+		if v.Name == "release" || v.Name == "static" || v.Name == "rhel80" ||
+			v.Name == "rhel88-race" {
 			continue
 		}
 


### PR DESCRIPTION
1. Evergreen tasks and functions are ported from mongosync/evergreen into mongo-tools/mongodump_passthrough
2. Various changes are needed to match the different directory structure and evergreen environment
3. Slight changes to mongodump/mongorestore to help with debugging passthrough failures
4. New buildvariant "rhel80" used for mongodump passthrough testing only
