### PR TITLE
upgrade toolchain from go1.23.7 to go1.23.8

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -1278,17 +1278,17 @@
       "version": "v3.0.1"
     },
     {
-      "bom-ref": "pkg:golang/std@go1.23.7",
+      "bom-ref": "pkg:golang/std@go1.23.8",
       "externalReferences": [
         {
           "type": "website",
-          "url": "https://pkg.go.dev/None/std@go1.23.7"
+          "url": "https://pkg.go.dev/None/std@go1.23.8"
         }
       ],
       "name": "std",
-      "purl": "pkg:golang/std@go1.23.7",
+      "purl": "pkg:golang/std@go1.23.8",
       "type": "library",
-      "version": "go1.23.7"
+      "version": "go1.23.8"
     }
   ],
   "dependencies": [
@@ -1449,11 +1449,11 @@
       "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
     },
     {
-      "ref": "pkg:golang/std@go1.23.7"
+      "ref": "pkg:golang/std@go1.23.8"
     }
   ],
   "metadata": {
-    "timestamp": "2025-04-04T01:59:26.580220+00:00",
+    "timestamp": "2025-04-17T18:49:29.565558+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1497,7 +1497,7 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 26,
+  "version": 27,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mongodb/mongo-tools
 
 go 1.23.0
 
-toolchain go1.23.7
+toolchain go1.23.8
 
 require (
 	github.com/aws/aws-sdk-go v1.53.11


### PR DESCRIPTION
Toolchain version change needed to pass static tests on rhel80.

Splitting this off from the mongo-tools evergreen changes.
