### PR TITLE
fix Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1529,7 +1529,15 @@ func untargz(src, dst string) {
 
 		check(err, "read from tar file")
 
-		path := filepath.Join(dst, header.Name)
+		cleanedName := filepath.Clean(header.Name)
+		if strings.HasPrefix(cleanedName, "..") || filepath.IsAbs(cleanedName) {
+			log.Fatalf("invalid file path in tar archive: %v", header.Name)
+		}
+
+		path := filepath.Join(dst, cleanedName)
+		if !strings.HasPrefix(path, filepath.Clean(dst)+string(os.PathSeparator)) {
+			log.Fatalf("extraction path escapes destination directory: %v", path)
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
https://github.com/mongodb/mongo-tools/blob/f76a3ae4029780f61c49cbd39b7336f8d9c30ed0/release/release.go#L1527-L1532

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths.

Fix the issue need to validate the `header.Name` field to ensure it does not contain directory traversal elements (`..`) or absolute paths. This can be achieved by:
1. Using `filepath.Clean` to normalize the path.
2. Verifying that the resulting path is within the intended destination directory (`dst`).

The fix involves:
- Cleaning the `header.Name` using `filepath.Clean`.
- Constructing the full path (`path`) and ensuring it is within the `dst` directory by checking that the cleaned path starts with the `dst` prefix.


[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
