### PR TITLE
TOOLS-3903 Always include all deps for all platforms in SBOM and only include deps for released binaries

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -101,106 +101,6 @@
       "version": "v1.3.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.53.11",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/aws/aws-sdk-go"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.53.11"
-        }
-      ],
-      "group": "github.com/aws",
-      "licenses": [
-        {
-          "license": {
-            "name": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "aws-sdk-go",
-      "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.53.11",
-      "type": "library",
-      "version": "v1.53.11"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/cpuguy83/go-md2man"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/cpuguy83/go-md2man/v2@v2.0.4"
-        }
-      ],
-      "group": "github.com/cpuguy83/go-md2man",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "v2",
-      "purl": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.4",
-      "type": "library",
-      "version": "v2.0.4"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/craiggwilson/goke@v0.0.0-20240206162536-b1c58122d943",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/craiggwilson/goke"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/craiggwilson/goke@v0.0.0-20240206162536-b1c58122d943"
-        }
-      ],
-      "group": "github.com/craiggwilson",
-      "licenses": [
-        {
-          "license": {
-            "name": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "goke",
-      "purl": "pkg:golang/github.com/craiggwilson/goke@v0.0.0-20240206162536-b1c58122d943",
-      "type": "library",
-      "version": "v0.0.0-20240206162536-b1c58122d943"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/davecgh/go-spew"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/davecgh/go-spew@v1.1.1"
-        }
-      ],
-      "group": "github.com/davecgh",
-      "licenses": [
-        {
-          "license": {
-            "name": "ISC"
-          }
-        }
-      ],
-      "name": "go-spew",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "type": "library",
-      "version": "v1.1.1"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/deckarep/golang-set/v2@v2.6.0",
       "externalReferences": [
         {
@@ -276,31 +176,6 @@
       "version": "v5.2.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/google/go-cmp"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/google/go-cmp@v0.6.0"
-        }
-      ],
-      "group": "github.com/google",
-      "licenses": [
-        {
-          "license": {
-            "name": "BSD-3-Clause"
-          }
-        }
-      ],
-      "name": "go-cmp",
-      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
-      "type": "library",
-      "version": "v0.6.0"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0",
       "externalReferences": [
         {
@@ -349,56 +224,6 @@
       "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
       "type": "library",
       "version": "v1.5.0"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/jmespath/go-jmespath"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/jmespath/go-jmespath@v0.4.0"
-        }
-      ],
-      "group": "github.com/jmespath",
-      "licenses": [
-        {
-          "license": {
-            "name": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "go-jmespath",
-      "purl": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-      "type": "library",
-      "version": "v0.4.0"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/jtolds/gls"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/jtolds/gls@v4.20.0+incompatible"
-        }
-      ],
-      "group": "github.com/jtolds",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "gls",
-      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "type": "library",
-      "version": "v4.20.0+incompatible"
     },
     {
       "bom-ref": "pkg:golang/github.com/klauspost/compress@v1.17.8",
@@ -461,56 +286,6 @@
       "version": "v1.1.0"
     },
     {
-      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/mattn/go-colorable"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mattn/go-colorable@v0.1.13"
-        }
-      ],
-      "group": "github.com/mattn",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "go-colorable",
-      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
-      "type": "library",
-      "version": "v0.1.13"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.20",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/mattn/go-isatty"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mattn/go-isatty@v0.0.20"
-        }
-      ],
-      "group": "github.com/mattn",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "go-isatty",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.20",
-      "type": "library",
-      "version": "v0.0.20"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
       "externalReferences": [
         {
@@ -536,54 +311,17 @@
       "version": "v0.0.15"
     },
     {
-      "bom-ref": "pkg:golang/github.com/mgutz/ansi@v0.0.0-20200706080929-d51e80ef957d",
+      "bom-ref": "pkg:golang/github.com/mongodb/mongo-tools",
       "externalReferences": [
         {
-          "type": "vcs",
-          "url": "https://github.com/mgutz/ansi"
-        },
-        {
           "type": "website",
-          "url": "https://pkg.go.dev/github.com/mgutz/ansi@v0.0.0-20200706080929-d51e80ef957d"
+          "url": "https://pkg.go.dev/github.com/mongodb/mongo-tools"
         }
       ],
-      "group": "github.com/mgutz",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "ansi",
-      "purl": "pkg:golang/github.com/mgutz/ansi@v0.0.0-20200706080929-d51e80ef957d",
-      "type": "library",
-      "version": "v0.0.0-20200706080929-d51e80ef957d"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/mitchellh/go-wordwrap"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mitchellh/go-wordwrap@v1.0.1"
-        }
-      ],
-      "group": "github.com/mitchellh",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "go-wordwrap",
-      "purl": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1",
-      "type": "library",
-      "version": "v1.0.1"
+      "group": "github.com/mongodb",
+      "name": "mongo-tools",
+      "purl": "pkg:golang/github.com/mongodb/mongo-tools",
+      "type": "library"
     },
     {
       "bom-ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1",
@@ -686,31 +424,6 @@
       "version": "v0.9.1"
     },
     {
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/pmezard/go-difflib"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/pmezard/go-difflib@v1.0.0"
-        }
-      ],
-      "group": "github.com/pmezard",
-      "licenses": [
-        {
-          "license": {
-            "name": "BSD-3-Clause"
-          }
-        }
-      ],
-      "name": "go-difflib",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "type": "library",
-      "version": "v1.0.0"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
       "externalReferences": [
         {
@@ -736,31 +449,6 @@
       "version": "v0.4.7"
     },
     {
-      "bom-ref": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/russross/blackfriday"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/russross/blackfriday/v2@v2.1.0"
-        }
-      ],
-      "group": "github.com/russross/blackfriday",
-      "licenses": [
-        {
-          "license": {
-            "name": "BSD-2-Clause"
-          }
-        }
-      ],
-      "name": "v2",
-      "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-      "type": "library",
-      "version": "v2.1.0"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/samber/lo@v1.49.1",
       "externalReferences": [
         {
@@ -784,106 +472,6 @@
       "purl": "pkg:golang/github.com/samber/lo@v1.49.1",
       "type": "library",
       "version": "v1.49.1"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/smarty/assertions@v1.15.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/smarty/assertions"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/smarty/assertions@v1.15.0"
-        }
-      ],
-      "group": "github.com/smarty",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "assertions",
-      "purl": "pkg:golang/github.com/smarty/assertions@v1.15.0",
-      "type": "library",
-      "version": "v1.15.0"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.8.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/smartystreets/goconvey"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/smartystreets/goconvey@v1.8.1"
-        }
-      ],
-      "group": "github.com/smartystreets",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "goconvey",
-      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.8.1",
-      "type": "library",
-      "version": "v1.8.1"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.10.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/stretchr/testify"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/stretchr/testify@v1.10.0"
-        }
-      ],
-      "group": "github.com/stretchr",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "testify",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.10.0",
-      "type": "library",
-      "version": "v1.10.0"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/urfave/cli/v2@v2.27.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/urfave/cli"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/urfave/cli/v2@v2.27.2"
-        }
-      ],
-      "group": "github.com/urfave/cli",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "v2",
-      "purl": "pkg:golang/github.com/urfave/cli/v2@v2.27.2",
-      "type": "library",
-      "version": "v2.27.2"
     },
     {
       "bom-ref": "pkg:golang/github.com/xdg-go/pbkdf2@v1.0.0",
@@ -959,31 +547,6 @@
       "purl": "pkg:golang/github.com/xdg-go/stringprep@v1.0.4",
       "type": "library",
       "version": "v1.0.4"
-    },
-    {
-      "bom-ref": "pkg:golang/github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/xrash/smetrics"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1"
-        }
-      ],
-      "group": "github.com/xrash",
-      "licenses": [
-        {
-          "license": {
-            "name": "MIT"
-          }
-        }
-      ],
-      "name": "smetrics",
-      "purl": "pkg:golang/github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1",
-      "type": "library",
-      "version": "v0.0.0-20240521201337-686a1a2994c1"
     },
     {
       "bom-ref": "pkg:golang/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78",
@@ -1084,31 +647,6 @@
       "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20250128182459-e0ece0dbea4c",
       "type": "library",
       "version": "v0.0.0-20250128182459-e0ece0dbea4c"
-    },
-    {
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.22.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://go.googlesource.com/mod"
-        },
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/golang.org/x/mod@v0.22.0"
-        }
-      ],
-      "group": "golang.org/x",
-      "licenses": [
-        {
-          "license": {
-            "name": "BSD-3-Clause"
-          }
-        }
-      ],
-      "name": "mod",
-      "purl": "pkg:golang/golang.org/x/mod@v0.22.0",
-      "type": "library",
-      "version": "v0.22.0"
     },
     {
       "bom-ref": "pkg:golang/golang.org/x/net@v0.40.0",
@@ -1239,11 +777,22 @@
       "bom-ref": "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
       "externalReferences": [
         {
+          "type": "vcs",
+          "url": "https://gopkg.in/tomb.v2"
+        },
+        {
           "type": "website",
           "url": "https://pkg.go.dev/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637"
         }
       ],
       "group": "gopkg.in",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
       "name": "tomb.v2",
       "purl": "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
       "type": "library",
@@ -1262,20 +811,6 @@
       "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
       "type": "library",
       "version": "v2.4.0"
-    },
-    {
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/gopkg.in/yaml.v3@v3.0.1"
-        }
-      ],
-      "group": "gopkg.in",
-      "name": "yaml.v3",
-      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "type": "library",
-      "version": "v3.0.1"
     },
     {
       "bom-ref": "pkg:golang/std@go1.23.8",
@@ -1305,18 +840,6 @@
       "ref": "pkg:golang/github.com/AzureAD/microsoft-authentication-library-for-go@v1.3.2"
     },
     {
-      "ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.53.11"
-    },
-    {
-      "ref": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.4"
-    },
-    {
-      "ref": "pkg:golang/github.com/craiggwilson/goke@v0.0.0-20240206162536-b1c58122d943"
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
       "ref": "pkg:golang/github.com/deckarep/golang-set/v2@v2.6.0"
     },
     {
@@ -1326,19 +849,10 @@
       "ref": "pkg:golang/github.com/golang/snappy@v0.0.4"
     },
     {
-      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0"
-    },
-    {
       "ref": "pkg:golang/github.com/google/uuid@v1.6.0"
     },
     {
       "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
-    },
-    {
-      "ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0"
-    },
-    {
-      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
     },
     {
       "ref": "pkg:golang/github.com/klauspost/compress@v1.17.8"
@@ -1347,19 +861,10 @@
       "ref": "pkg:golang/github.com/kylelemons/godebug@v1.1.0"
     },
     {
-      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13"
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.20"
-    },
-    {
       "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15"
     },
     {
-      "ref": "pkg:golang/github.com/mgutz/ansi@v0.0.0-20200706080929-d51e80ef957d"
-    },
-    {
-      "ref": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1"
+      "ref": "pkg:golang/github.com/mongodb/mongo-tools"
     },
     {
       "ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1"
@@ -1374,28 +879,10 @@
       "ref": "pkg:golang/github.com/pkg/errors@v0.9.1"
     },
     {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
       "ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7"
     },
     {
-      "ref": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0"
-    },
-    {
       "ref": "pkg:golang/github.com/samber/lo@v1.49.1"
-    },
-    {
-      "ref": "pkg:golang/github.com/smarty/assertions@v1.15.0"
-    },
-    {
-      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.8.1"
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.10.0"
-    },
-    {
-      "ref": "pkg:golang/github.com/urfave/cli/v2@v2.27.2"
     },
     {
       "ref": "pkg:golang/github.com/xdg-go/pbkdf2@v1.0.0"
@@ -1405,9 +892,6 @@
     },
     {
       "ref": "pkg:golang/github.com/xdg-go/stringprep@v1.0.4"
-    },
-    {
-      "ref": "pkg:golang/github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1"
     },
     {
       "ref": "pkg:golang/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78"
@@ -1420,9 +904,6 @@
     },
     {
       "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20250128182459-e0ece0dbea4c"
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.22.0"
     },
     {
       "ref": "pkg:golang/golang.org/x/net@v0.40.0"
@@ -1446,14 +927,11 @@
       "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
     },
     {
-      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-    },
-    {
       "ref": "pkg:golang/std@go1.23.8"
     }
   ],
   "metadata": {
-    "timestamp": "2025-05-16T16:02:27.215705+00:00",
+    "timestamp": "2025-06-11T18:43:33.990772+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -1497,7 +975,7 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 28,
+  "version": 31,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/release/platform/platform.go
+++ b/release/platform/platform.go
@@ -25,6 +25,15 @@ const (
 	OSMac     OS = "mac"
 )
 
+func (o OS) GoOS() string {
+	switch o {
+	case OSMac:
+		return "darwin"
+	default:
+		return string(o)
+	}
+}
+
 type Pkg string
 
 const (
@@ -51,6 +60,18 @@ const (
 	ArchPpc64le Arch = "ppc64le"
 	ArchX86_64  Arch = "x86_64"
 )
+
+// GoArch returns the GOARCH value for a given architecture.
+func (a Arch) GoArch() string {
+	switch a {
+	case ArchAarch64:
+		return "arm64"
+	case ArchX86_64:
+		return "amd64"
+	default:
+		return string(a)
+	}
+}
 
 // Platform represents a platform (a combination of OS, distro,
 // version, and architecture) on which we may build/test the tools.

--- a/release/release.go
+++ b/release/release.go
@@ -19,11 +19,13 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/mongodb/mongo-tools/release/aws"
 	"github.com/mongodb/mongo-tools/release/download"
 	"github.com/mongodb/mongo-tools/release/env"
@@ -146,6 +148,22 @@ func main() {
 					&cli.StringFlag{
 						Name: "server-version",
 					},
+				},
+			},
+			{
+				Name: "print-binary-paths",
+				Action: func(cCtx *cli.Context) error {
+					for _, b := range binaries {
+						fmt.Printf("./%s\n", b)
+					}
+					return nil
+				},
+			},
+			{
+				Name: "print-os-arch-combos",
+				Action: func(cCtx *cli.Context) error {
+					printOsArchCombos()
+					return nil
 				},
 			},
 		},
@@ -1703,4 +1721,17 @@ func mostRecentAugmentedSBOM(repoRoot string) string {
 	}
 
 	return mostRecentFile
+}
+
+func printOsArchCombos() {
+	combos := mapset.NewSet[string]()
+	for _, p := range platform.Platforms() {
+		combos.Add(fmt.Sprintf("%s/%s", p.OS.GoOS(), p.Arch.GoArch()))
+	}
+	slice := combos.ToSlice()
+	slices.Sort(slice)
+
+	for _, c := range slice {
+		fmt.Println(c)
+	}
 }

--- a/scripts/regenerate-sbom-lite.sh
+++ b/scripts/regenerate-sbom-lite.sh
@@ -1,22 +1,46 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 set -x
 
-# This set of piped commands generates a file that contains each dependency as
-# a purl (https://github.com/package-url/purl-spec), one per line. This is
-# used as input for the `silkbomb` tool to generate an SBOM.
-go list -json -mod=mod all |
-  jq -r '.Module // empty | "pkg:golang/" + (.Path // empty) + "@" + (.Version // empty)' |
-    sort -u >purls.txt
+rm -f purls.txt
+
+BINARY_DIRS="$( go run release/release.go print-binary-paths )"
+OS_ARCH_COMBOS="$( go run release/release.go print-os-arch-combos )"
+
+# This set of piped commands generates a file that contains each dependency as a purl
+# (https://github.com/package-url/purl-spec), one per line. This is used as input for the `silkbomb`
+# tool to generate an SBOM. We do this for each OS/architecture combination we support to make sure
+# this is the superset of all our dependencies.
+#
+# shellcheck disable=SC2086 # we intentionally don't quote `$OS_ARCH_COMBOS` so we split on the
+# whitespace.
+for c in $OS_ARCH_COMBOS; do
+    os="$(echo $c | cut -f1 -d/)"
+    arch="$(echo $c | cut -f2 -d/)"
+    # shellcheck disable=SC2086 # we don't want to quote `$BINARY_DIRS` for the same reason.
+    GOOS="$os" GOARCH="$arch" go list -json -mod=mod -deps $BINARY_DIRS |
+        jq -r '.Module // empty | "pkg:golang/" + .Path + "@" + .Version // empty' >> \
+            purls.txt
+done
+
+sort -u -o purls.txt purls.txt
+
+if [ ! -s purls.txt ]; then
+    echo 'The purls.txt file generated from the "go list" output is empty!'
+    exit 1
+fi
+
 go version |
     sed 's|^go version \([^ ]*\) *.*|pkg:golang/std@\1|' >>purls.txt
+
 # The arguments to the silkbomb program start at "update".
 #
-# shellcheck disable=SC2068 # we don't want to quote `$@`
+# shellcheck disable=SC2068 # we don't want to quote `$@`.
 podman run \
-    -it \
     --rm \
+    --platform linux/amd64 \
     -v "${PWD}":/pwd \
     artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
     update \


### PR DESCRIPTION
Previously, the SBOM would only contain dependencies that were used in the platform on which we generated the SBOM Lite file. We didn't notice this because we did not have any platform-conditional dependencies, but Jane was working on a PR that did add such a dep.

This changes the code that generates the SBOM Lite to get a list of deps for each of our supported platforms.

This _also_ changes the SBOM generation to only look at dependencies of the code for each of the release binaries. Previously, we included all the deps for everything in the repo. There were a huge number of packages that were only used by dev tooling, but not in the released tools.