### PR TITLE
TOOLS-3931 Revert the revert - fixes a goroutine leak in `DumpIntents`

### DIFF
--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -534,8 +534,6 @@ func (dump *MongoDump) getResettableOutputBuffer() resettableOutputBuffer {
 // DumpIntents iterates through the previously-created intents and
 // dumps all of the found collections.
 func (dump *MongoDump) DumpIntents() error {
-	resultChan := make(chan error)
-
 	jobs := dump.OutputOptions.NumParallelCollections
 	if numIntents := len(dump.manager.Intents()); jobs > numIntents {
 		jobs = numIntents
@@ -547,6 +545,7 @@ func (dump *MongoDump) DumpIntents() error {
 		dump.manager.Finalize(intents.Legacy)
 	}
 
+	resultChan := make(chan error, jobs)
 	log.Logvf(log.Info, "dumping up to %v collections in parallel", jobs)
 
 	// start a goroutine for each job thread


### PR DESCRIPTION
This reverts commit b6e6710b0871cbe49a78b8efd1c0d2ec40943ded.

The contributor has signed the CLA, so we can include this change.