### PR TITLE
Fix some Evergreen config and release code

### DIFF
--- a/SARIF.json
+++ b/SARIF.json
@@ -12,13 +12,13 @@
 								},
 								"region": {
 									"endColumn": 17,
-									"endLine": 520,
+									"endLine": 518,
 									"snippet": {
 										"text": "tlsConfig := \u0026tls.Config{}"
 									},
 									"sourceLanguage": "go",
 									"startColumn": 17,
-									"startLine": 520
+									"startLine": 518
 								}
 							}
 						}

--- a/common.yml
+++ b/common.yml
@@ -568,19 +568,6 @@ functions:
         ${_set_shell_env}
         ./scripts/regenerate-and-diff-sarif-report.sh
 
-  "generate gosec SARIF report":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src/github.com/mongodb/mongo-tools
-        script: |
-          ${_set_shell_env}
-          set -x
-          set -v
-          set -e
-          GOSEC_SARIF_REPORT=1 ./dev-bin/precious lint --all --command gosec
-          cat SARIF.json
-
   "create evergreen config file":
     - command: shell.exec
       type: test
@@ -782,21 +769,6 @@ tasks:
           version: ${release_tag}
           filenames:
             - "./src/github.com/mongodb/mongo-tools/mongodb-database-tools*"
-
-  - name: check-SARIF-report
-    tags: ["git_tag"]
-    commands:
-      - func: "fetch source"
-      - command: expansions.update
-      - func: "run make target"
-        vars:
-          target: sa:installdevtools
-      - command: shell.exec
-        params:
-          working_dir: src/github.com/mongodb/mongo-tools
-          script: |
-            ${_set_shell_env}
-            ./scripts/regenerate-and-diff-sarif-report.sh
 
   - name: check-augmented-sbom
     tags: ["git_tag"]
@@ -2039,6 +2011,9 @@ tasks:
   - name: check-sarif-report
     commands:
       - func: "fetch source"
+      - func: "run make target"
+        vars:
+          target: sa:installdevtools
       - func: "check sarif report"
 
 buildvariants:
@@ -2059,7 +2034,7 @@ buildvariants:
       - name: vet
       - name: check-third-party-notices
       - name: check-sbom-lite
-      - name: gosec-SARIF-report
+      - name: check-sarif-report
 
   #######################################
   #     Release Manager Buildvariant    #

--- a/release/notarize/notarize.go
+++ b/release/notarize/notarize.go
@@ -70,7 +70,7 @@ func FindInvalidNotarizations(zipPath string) ([]string, error) {
 		}
 
 		cmdPieces := []string{
-			"spctl",
+			"/usr/sbin/spctl",
 			"-vvvvv",
 			"--assess",
 			"--type", "install",

--- a/release/release.go
+++ b/release/release.go
@@ -1223,13 +1223,13 @@ func uploadRelease(v version.Version) {
 					"    uploading to https://s3.amazonaws.com/downloads.mongodb.org/tools/db/%s\n",
 					stableFile,
 				)
-				err = awsClient.UploadFile("downloads.mongodb.org", "/tools/db", stableFile)
+				err = awsClient.UploadFile("downloads.mongodb.org", "tools/db", stableFile)
 				check(err, "uploading %q file to S3", stableFile)
 				log.Printf(
 					"    uploading to https://s3.amazonaws.com/downloads.mongodb.org/tools/db/%s\n",
 					latestStableFile,
 				)
-				err = awsClient.UploadFile("downloads.mongodb.org", "/tools/db", latestStableFile)
+				err = awsClient.UploadFile("downloads.mongodb.org", "tools/db", latestStableFile)
 				check(err, "uploading %q file to S3", latestStableFile)
 			}
 		}

--- a/ssdlc/100.13.0.sarif.json
+++ b/ssdlc/100.13.0.sarif.json
@@ -12,13 +12,13 @@
 								},
 								"region": {
 									"endColumn": 17,
-									"endLine": 520,
+									"endLine": 518,
 									"snippet": {
 										"text": "tlsConfig := \u0026tls.Config{}"
 									},
 									"sourceLanguage": "go",
 									"startColumn": 17,
-									"startLine": 520
+									"startLine": 518
 								}
 							}
 						}


### PR DESCRIPTION
This includes a grab bag of fixes for issues discovered while trying to release 100.13.0:

* Removed leading slashes from the S3 release paths. The new version of the AWS SDK Go library is pickier about paths.
* The `spctl` program is not in the default path on the Evergreen macOS hosts, so we call it with the fully-qualified path, `/usr/sbin/spctl`.
* The Evergreen config to check the SARIF report was not correct.
* The SARIF report was out of date and needed to be updated for 100.13.0.
