### PR TITLE
TOOLS-3964: omit the main module from go list for sbom generation

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -311,19 +311,6 @@
       "version": "v0.0.15"
     },
     {
-      "bom-ref": "pkg:golang/github.com/mongodb/mongo-tools",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://pkg.go.dev/github.com/mongodb/mongo-tools"
-        }
-      ],
-      "group": "github.com/mongodb",
-      "name": "mongo-tools",
-      "purl": "pkg:golang/github.com/mongodb/mongo-tools",
-      "type": "library"
-    },
-    {
       "bom-ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1",
       "externalReferences": [
         {
@@ -813,17 +800,17 @@
       "version": "v2.4.0"
     },
     {
-      "bom-ref": "pkg:golang/std@go1.23.12",
+      "bom-ref": "pkg:golang/std@go1.23.8",
       "externalReferences": [
         {
           "type": "website",
-          "url": "https://pkg.go.dev/None/std@go1.23.12"
+          "url": "https://pkg.go.dev/None/std@go1.23.8"
         }
       ],
       "name": "std",
-      "purl": "pkg:golang/std@go1.23.12",
+      "purl": "pkg:golang/std@go1.23.8",
       "type": "library",
-      "version": "go1.23.12"
+      "version": "go1.23.8"
     }
   ],
   "dependencies": [
@@ -862,9 +849,6 @@
     },
     {
       "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15"
-    },
-    {
-      "ref": "pkg:golang/github.com/mongodb/mongo-tools"
     },
     {
       "ref": "pkg:golang/github.com/montanaflynn/stats@v0.7.1"
@@ -927,11 +911,11 @@
       "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
     },
     {
-      "ref": "pkg:golang/std@go1.23.12"
+      "ref": "pkg:golang/std@go1.23.8"
     }
   ],
   "metadata": {
-    "timestamp": "2025-07-18T17:11:37.182995+00:00",
+    "timestamp": "2025-08-26T21:16:45.957053+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -975,7 +959,7 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 33,
+  "version": 34,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/scripts/regenerate-sbom-lite.sh
+++ b/scripts/regenerate-sbom-lite.sh
@@ -13,6 +13,8 @@ OS_ARCH_COMBOS="$( go run release/release.go print-os-arch-combos )"
 # (https://github.com/package-url/purl-spec), one per line. This is used as input for the `silkbomb`
 # tool to generate an SBOM. We do this for each OS/architecture combination we support to make sure
 # this is the superset of all our dependencies.
+# We skip the mongo-tools module in the jq query so that it's not listed as a
+# dependency of itself (.Module.Main is set to true for mongo-tools)
 #
 # shellcheck disable=SC2086 # we intentionally don't quote `$OS_ARCH_COMBOS` so we split on the
 # whitespace.

--- a/scripts/regenerate-sbom-lite.sh
+++ b/scripts/regenerate-sbom-lite.sh
@@ -21,7 +21,7 @@ for c in $OS_ARCH_COMBOS; do
     arch="$(echo $c | cut -f2 -d/)"
     # shellcheck disable=SC2086 # we don't want to quote `$BINARY_DIRS` for the same reason.
     GOOS="$os" GOARCH="$arch" go list -json -mod=mod -deps $BINARY_DIRS |
-        jq -r '.Module // empty | "pkg:golang/" + .Path + "@" + .Version // empty' >> \
+        jq -r '.Module // empty | select((.Main // false) == false) | "pkg:golang/" + .Path + "@" + .Version // empty' >> \
             purls.txt
 done
 


### PR DESCRIPTION
We fixed this earlier by omitting the `.Module` structs that didn't contain `.Path`, but that was removed by mistake in #810. 
Rather than add it back and depend on `.Path` being empty, I'm adding a filter to remove the main module. This is indicated in the go list json by `.Main` being set to true in the `.Module` struct.