### PR TITLE
Update mongosync branch and pins for passthrough tests

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,3 +1,13 @@
+# Support for mongodump+mongorestore passthrough tests.
+
+include:
+  - filename: "mongodump_passthrough/globals.yml"
+  - filename: "mongodump_passthrough/parameters.yml"
+  - filename: "mongodump_passthrough/modules.yml"
+  - filename: "mongodump_passthrough/functions.yml"
+  - filename: "mongodump_passthrough/tasks.yml"
+  - filename: "mongodump_passthrough/variants.yml"
+
 #######################################
 #    Tools Driver Config for MCI      #
 #######################################
@@ -680,6 +690,10 @@ post:
           set -v
         rm -rf /data/db/*
         exit 0
+  # Extra post steps needed for mongodump passthrough.
+  - func: f_resmoke_report_attach
+  - func: "attach artifacts"
+  - func: f_mongo_coredumps_save
 
 timeout:
   - command: shell.exec
@@ -697,6 +711,9 @@ timeout:
           # git the processes a second or two to dump their stacks
           sleep 10
         fi
+  # Extra timeout steps needed for mongodump passthrough.
+  - func: f_expansions_write
+  - func: "wait for resmoke to shutdown"
 
 tasks:
   - name: dist

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -27,7 +27,7 @@ variables:
   # And when you change the _mongosync_pin, you also need to update other pins
   # which get passed as environment variables to scripts in mongosync/evergreen/scripts.
   #
-  _mongosync_pin: &_mongosync_pin "7126c03d3f87950824b393b5b1157065767c6d44"
+  _mongosync_pin: &_mongosync_pin "e000f89b29ab012835465a6f8b462b2b6035639c"
 
   f_expansions_write: &f_expansions_write
     command: expansions.write

--- a/mongodump_passthrough/modules.yml
+++ b/mongodump_passthrough/modules.yml
@@ -32,4 +32,4 @@ modules:
   - name: mongosync
     repo: git@github.com:10gen/mongosync.git
     prefix: ${workdir}/src
-    branch: rcownie/md_passthru6
+    branch: md_passthru8


### PR DESCRIPTION
The resmoke setup was failing because it was using outdated server pins. This commit updates the pinned mongosync repo so that the passthrough tests can download the most recent server pins. 