### PR TITLE
Centralize the connection logic for tests in one place and fix it for Atlas clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+!/RELEASE.md
+!**/testdata/**
+!test/shell_common/jsconfig.json
 /*.cdx.json
 /data
 /deb_build
@@ -11,7 +14,9 @@
 /rpm_build
 /silkbomb.env
 /temp*
+/mongodump/*/mongodump_test_db
 /mongorestore/testdata/txntest/oplog.bson
+/mongorestore/testdata/index_collation/test/*
 *.bson
 *.deb
 *.dump
@@ -35,11 +40,8 @@ bin/
 node_modules
 tags
 testing_output/
-!/RELEASE.md
 vendor/pkg
-!**/testdata/**
 test/**/*.json
-!test/shell_common/jsconfig.json
 test/qa-tests/[0-9]*
 test/qa-tests/install_compass
 test/qa-tests/mongo*

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -60,7 +60,9 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 
 	ctx := context.Background()
 
-	md := simpleMongoDumpInstance()
+	md, err := simpleMongoDumpInstance()
+	require.NoError(t, err)
+
 	md.ToolOptions.DB = ""
 	md.OutputOptions.Oplog = true
 	md.OutputOptions.Out = "vectored_inserts"

--- a/mongodump/prepare_test.go
+++ b/mongodump/prepare_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/dumprestore"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSkipCollection(t *testing.T) {
@@ -200,7 +201,8 @@ func TestShouldSkipSystemNamespace(t *testing.T) {
 		})
 	}
 
-	md := simpleMongoDumpInstance()
+	md, err := simpleMongoDumpInstance()
+	require.NoError(t, err)
 
 	for _, testVals := range tests {
 		md.ToolOptions.DB = testVals.dbOption


### PR DESCRIPTION
This makes it possible to run tests against an Atlas cluster. As the code was before, this just didn't work.