### PR TITLE
TOOLS-4073 Support dump/restore between a cluster with replicated record IDs and one without

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -151,11 +151,11 @@ func (sp *SessionProvider) GetNodeType() (NodeType, error) {
 		&bson.M{"ismaster": 1},
 	)
 	if result.Err() != nil {
-		return Unknown, result.Err()
+		return Unknown, fmt.Errorf("running `ismaster` command: %w", result.Err())
 	}
 	err = result.Decode(&masterDoc)
 	if err != nil {
-		return Unknown, err
+		return Unknown, fmt.Errorf("decoding `ismaster` response: %w", err)
 	}
 	if masterDoc.SetName != nil || masterDoc.Hosts != nil {
 		return ReplSet, nil
@@ -181,7 +181,7 @@ func (sp *SessionProvider) IsReplicaSet() (bool, error) {
 func (sp *SessionProvider) IsMongos() (bool, error) {
 	nodeType, err := sp.GetNodeType()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("getting node type: %w", err)
 	}
 	return nodeType == Mongos, nil
 }

--- a/manual-tests/record-ids-replicated/main.go
+++ b/manual-tests/record-ids-replicated/main.go
@@ -1,10 +1,7 @@
 // This tool tests the ability of mongodump and mongorestore to move data between clusters with and
 // without replicated record IDs enabled.
 //
-// It performs a full dump/restore cycle between two clusters. When both clusters are of the same
-// type (both with or both without recordIdsReplicated), it verifies the data matches after
-// restore. When the clusters differ (one with and one without recordIdsReplicated), it verifies
-// that mongorestore fails when --oplogReplay is used.
+// It performs a full dump/restore cycle between two clusters and verifies the data matches.
 //
 // Usage:
 //
@@ -20,7 +17,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -49,16 +45,13 @@ type collectionSpec struct {
 
 // testContext holds the state needed throughout the test.
 type testContext struct {
-	srcURI                        string
-	dstURI                        string
-	keepDump                      bool
-	srcClient                     *mongo.Client
-	dstClient                     *mongo.Client
-	dumpDir                       string
-	simpleDumpDir                 string
-	barrierFile                   string
-	srcRecordIdsReplicatedEnabled bool
-	dstRecordIdsReplicatedEnabled bool
+	srcURI      string
+	dstURI      string
+	keepDump    bool
+	srcClient   *mongo.Client
+	dstClient   *mongo.Client
+	dumpDir     string
+	barrierFile string
 }
 
 func main() {
@@ -125,42 +118,12 @@ func run(srcURI, dstURI string, keepDump bool) error {
 		return err
 	}
 
-	if tc.srcRecordIdsReplicatedEnabled != tc.dstRecordIdsReplicatedEnabled {
-		// Cycle 1: with oplog replay — expect failure due to cluster type mismatch.
-		log.Println(
-			"Source and destination clusters differ in recordIdsReplicated support; verifying that mongorestore fails with --oplogReplay...",
-		)
-		if err := tc.runRestoreExpectingFailure(); err != nil {
-			return err
-		}
+	if err := tc.runRestore(); err != nil {
+		return err
+	}
 
-		// Cycle 2: without oplog replay — expect success.
-		log.Println("Verifying that mongorestore succeeds without --oplogReplay...")
-		if err := tc.cleanTestDBs(ctx); err != nil {
-			return err
-		}
-		if err := tc.runDumpWithoutOplog(); err != nil {
-			return err
-		}
-		defer tc.removeSimpleDumpDir()
-
-		if err := tc.removeSystemDBsFromSimpleDump(); err != nil {
-			return err
-		}
-		if err := tc.runRestoreWithoutOplog(); err != nil {
-			return err
-		}
-		if err := tc.verifyClustersMatch(ctx); err != nil {
-			return err
-		}
-	} else {
-		if err := tc.runRestore(); err != nil {
-			return err
-		}
-
-		if err := tc.verifyClustersMatch(ctx); err != nil {
-			return err
-		}
+	if err := tc.verifyClustersMatch(ctx); err != nil {
+		return err
 	}
 
 	return nil
@@ -202,53 +165,7 @@ func (tc *testContext) connectToClusters(ctx context.Context) error {
 	tc.dstClient = dstClient
 	log.Println("✅ Connected to destination cluster")
 
-	tc.srcRecordIdsReplicatedEnabled, err = hasRecordIdsReplicated(ctx, srcClient)
-	if err != nil {
-		return fmt.Errorf("checking recordIdsReplicated on source: %w", err)
-	}
-	log.Printf("Source cluster recordIdsReplicated: %t\n", tc.srcRecordIdsReplicatedEnabled)
-
-	tc.dstRecordIdsReplicatedEnabled, err = hasRecordIdsReplicated(ctx, dstClient)
-	if err != nil {
-		return fmt.Errorf("failed to check recordIdsReplicated on destination: %w", err)
-	}
-	log.Printf("Destination cluster recordIdsReplicated: %t\n", tc.dstRecordIdsReplicatedEnabled)
-
 	return nil
-}
-
-// hasRecordIdsReplicated checks whether the given cluster has the featureFlagRecordIdsReplicated
-// parameter enabled.
-func hasRecordIdsReplicated(ctx context.Context, client *mongo.Client) (bool, error) {
-	result := client.Database("admin").RunCommand(
-		ctx,
-		bson.D{
-			{"getParameter", 1},
-			{"featureFlagRecordIdsReplicated", 1},
-		},
-	)
-	if result.Err() != nil {
-		// This is what we get when the parameter name isn't recognized by the Server.
-		const invalidOptionsErrorCode = 72
-		if slices.Contains(mongo.ErrorCodes(result.Err()), invalidOptionsErrorCode) {
-			// If the command fails, the feature flag doesn't exist or isn't enabled. Or maybe something
-			// is totally broken, in which case we will find that out when we attempt other DB
-			// operations.
-			return false, nil
-		}
-		return false, result.Err()
-	}
-
-	var doc struct {
-		FeatureFlagRecordIdsReplicated struct {
-			Value bool `bson:"value"`
-		} `bson:"featureFlagRecordIdsReplicated"`
-	}
-	if err := result.Decode(&doc); err != nil {
-		return false, nil
-	}
-
-	return doc.FeatureFlagRecordIdsReplicated.Value, nil
 }
 
 func (tc *testContext) disconnectClients(ctx context.Context) {
@@ -420,74 +337,6 @@ func (tc *testContext) removeDumpDir() {
 	os.RemoveAll(tc.dumpDir)
 }
 
-func (tc *testContext) runDumpWithoutOplog() error {
-	tempDir, err := os.MkdirTemp("", "rir-test-simple-")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory for simple dump: %w", err)
-	}
-	tc.simpleDumpDir = filepath.Join(tempDir, "dump")
-	if err = os.MkdirAll(tc.simpleDumpDir, 0755); err != nil {
-		return fmt.Errorf("failed to create simple dump directory: %w", err)
-	}
-	if tc.keepDump {
-		log.Printf("Simple dump temp directory will be kept for inspection: %s", tempDir)
-	}
-
-	log.Println("Starting mongodump without --oplog...")
-	dumpCmd := exec.Command(
-		"./bin/mongodump",
-		"-vvvv",
-		"--uri", tc.srcURI,
-		"--out", tc.simpleDumpDir,
-	)
-	dumpCmd.Dir = repoRoot()
-	dumpCmd.Stdout = os.Stdout
-	dumpCmd.Stderr = os.Stderr
-	if err := dumpCmd.Run(); err != nil {
-		return fmt.Errorf("mongodump (no oplog) failed: %w", err)
-	}
-	log.Println("✅ mongodump (no oplog) completed")
-	return nil
-}
-
-func (tc *testContext) removeSimpleDumpDir() {
-	if tc.keepDump || tc.simpleDumpDir == "" {
-		return
-	}
-	log.Printf("Removing simple dump directory: %s", tc.simpleDumpDir)
-	os.RemoveAll(filepath.Dir(tc.simpleDumpDir))
-}
-
-func (tc *testContext) removeSystemDBsFromSimpleDump() error {
-	for _, dbName := range []string{"admin", "config"} {
-		p := filepath.Join(tc.simpleDumpDir, dbName)
-		if err := os.RemoveAll(p); err != nil {
-			return fmt.Errorf("failed to remove directory %#q: %w", p, err)
-		}
-	}
-	log.Println("✅ removed system data directories from simple dump")
-	return nil
-}
-
-func (tc *testContext) runRestoreWithoutOplog() error {
-	log.Println("Running mongorestore without --oplogReplay --drop...")
-	restoreCmd := exec.Command(
-		"./bin/mongorestore",
-		"-vvvv",
-		"--uri", tc.dstURI,
-		"--drop",
-		tc.simpleDumpDir,
-	)
-	restoreCmd.Dir = repoRoot()
-	restoreCmd.Stdout = os.Stdout
-	restoreCmd.Stderr = os.Stderr
-	if err := restoreCmd.Run(); err != nil {
-		return fmt.Errorf("mongorestore (no oplog replay) failed: %w", err)
-	}
-	log.Println("✅ mongorestore (no oplog replay) completed")
-	return nil
-}
-
 func (tc *testContext) runDumpWithConcurrentOps(ctx context.Context) error {
 	log.Println("Starting mongodump with --oplog...")
 	dumpCmd := exec.Command(
@@ -596,31 +445,6 @@ func (tc *testContext) runRestore() error {
 		return fmt.Errorf("mongorestore failed: %w", err)
 	}
 	log.Println("✅ mongorestore completed")
-	return nil
-}
-
-func (tc *testContext) runRestoreExpectingFailure() error {
-	log.Println(
-		"Running mongorestore with --oplogReplay --drop (expecting failure due to recordIdsReplicated mismatch)...",
-	)
-	restoreCmd := exec.Command(
-		"./bin/mongorestore",
-		"-vvvv",
-		"--uri", tc.dstURI,
-		"--oplogReplay",
-		"--drop",
-		tc.dumpDir,
-	)
-	restoreCmd.Dir = repoRoot()
-	restoreCmd.Stdout = os.Stdout
-	restoreCmd.Stderr = os.Stderr
-
-	if err := restoreCmd.Run(); err == nil {
-		return fmt.Errorf(
-			"mongorestore succeeded but should have failed: clusters differ in recordIdsReplicated support",
-		)
-	}
-	log.Println("✅ mongorestore failed as expected")
 	return nil
 }
 

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1005,7 +1005,7 @@ func testPreludeMetadata(md *MongoDump, dir string, serverVersion string) {
 	}
 	contents, err := io.ReadAll(reader)
 	So(err, ShouldBeNil)
-	var jsonResult map[string]string
+	var jsonResult map[string]any
 	err = json.Unmarshal(contents, &jsonResult)
 	So(err, ShouldBeNil)
 	So(jsonResult["ServerVersion"], ShouldEqual, serverVersion)

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/idx"
 	"github.com/mongodb/mongo-tools/common/intents"
@@ -310,6 +311,7 @@ func (restore *MongoRestore) createCollectionWithCommand(
 	options bson.D,
 ) error {
 	options = restore.UpdateAutoIndexId(options)
+	options = removeCollectionOption(options, "recordIdsReplicated")
 
 	command := createCollectionCommand(intent, options)
 
@@ -340,6 +342,7 @@ func (restore *MongoRestore) createCollectionWithApplyOps(
 	uuidHex string,
 ) error {
 	options = restore.UpdateAutoIndexId(options)
+	options = removeCollectionOption(options, "recordIdsReplicated")
 
 	command := createCollectionCommand(intent, options)
 	uuid, err := hex.DecodeString(uuidHex)
@@ -359,6 +362,13 @@ func (restore *MongoRestore) createCollectionWithApplyOps(
 
 func createCollectionCommand(intent *intents.Intent, options bson.D) bson.D {
 	return append(bson.D{{"create", intent.C}}, options...)
+}
+
+// removeCollectionOption removes a key from a collection-options bson.D,
+// returning the (possibly modified) slice.
+func removeCollectionOption(options bson.D, key string) bson.D {
+	_, _ = bsonutil.RemoveKey(key, &options)
+	return options
 }
 
 // RestoreUsersOrRoles accepts a users intent and a roles intent, and restores

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -107,12 +107,12 @@ type collectionIndexes map[string][]*idx.IndexDocument
 func New(opts Options) (*MongoRestore, error) {
 	provider, err := db.NewSessionProvider(*opts.ToolOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to host: %v", err)
+		return nil, fmt.Errorf("error connecting to host: %w", err)
 	}
 
 	serverVersion, err := provider.ServerVersionArray()
 	if err != nil {
-		return nil, fmt.Errorf("error getting server version: %v", err)
+		return nil, fmt.Errorf("error getting server version: %w", err)
 	}
 
 	// start up the progress bar manager
@@ -138,7 +138,7 @@ func New(opts Options) (*MongoRestore, error) {
 
 	restore.isMongos, err = restore.SessionProvider.IsMongos()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error checking whether we are talking to mongos: %w", err)
 	}
 	if restore.isMongos {
 		log.Logv(log.DebugLow, "restoring to a sharded system")
@@ -735,14 +735,16 @@ func (restore *MongoRestore) ReadPreludeMetadata(target archive.DirLike) (bool, 
 		return true, fmt.Errorf("failed to read prelude metadata from %#q: %w", filePath, err)
 	}
 
-	var prelude map[string]string
+	var prelude struct {
+		ServerVersion string `json:"ServerVersion"`
+	}
 	err = json.Unmarshal(bytes, &prelude)
 	if err != nil {
 		return true, fmt.Errorf("failed to unmarshal prelude metadata from %#q: %w", filePath, err)
 	}
 
-	dumpVersion, ok := prelude["ServerVersion"]
-	if !ok {
+	dumpVersion := prelude.ServerVersion
+	if dumpVersion == "" {
 		return true, fmt.Errorf("ServerVersion key not found in %#q", filePath)
 	}
 

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -162,6 +162,12 @@ func (restore *MongoRestore) HandleOp(oplogCtx *oplogContext, op db.Oplog) error
 		return nil
 	}
 
+	// These ops are seen when replicated record IDs are enabled. They are related to internal
+	// bookkeeping for the cluster and do not need to be replicated on restore.
+	if op.Operation == "cd" || op.Operation == "ci" || op.Operation == "km" {
+		return nil
+	}
+
 	if op.Operation == "c" && len(op.Object) > 0 {
 		entryName := op.Object[0].Key
 		if entryName == "startIndexBuild" || entryName == "abortIndexBuild" {
@@ -207,6 +213,8 @@ func (restore *MongoRestore) HandleNonTxnOp(oplogCtx *oplogContext, op db.Oplog)
 	if err != nil {
 		return fmt.Errorf("error filtering UUIDs from oplog: %v", err)
 	}
+
+	op = restore.filterRecordIdsReplicated(op)
 
 	if op.Operation == "c" {
 		if len(op.Object) == 0 {
@@ -538,6 +546,19 @@ func (restore *MongoRestore) filterUUIDs(op db.Oplog) (db.Oplog, error) {
 	}
 
 	return op, nil
+}
+
+// filterRecordIdsReplicated removes the 'recordIdsReplicated' collection option from command
+// objects.
+func (restore *MongoRestore) filterRecordIdsReplicated(op db.Oplog) db.Oplog {
+	// Remove recordIdsReplicated option from command objects (e.g. create commands).  This allows
+	// oplog replay across cluster types regardless of whether the source cluster had the
+	// `replicatedRecordIds` feature enabled.
+	if op.Operation == "c" && len(op.Object) > 0 && op.Object[0].Key == "create" {
+		_, _ = bsonutil.RemoveKey("recordIdsReplicated", &op.Object)
+	}
+
+	return op
 }
 
 // convertCreateIndexToIndexInsert converts from new-style create indexes


### PR DESCRIPTION
This was written by Copilot using Claude Opus and reviewed by me. I also made some additional changes based on issues I saw when testing these changes.

There are a few things this does:

- Removes the `recordIdsReplicated` collection option when restoring collections. This option will be removed in a near-future Server version anyway, as it's an internal detail.
- Removes the record ID field from oplog entries (`rid`) when restoring them. Per discussion with Server folks working on this, the cluster will handle assigning record IDs and does not need this information.
- Skips `ci`, `cd`, and `km` ops when restoring from the oplog. These are new ops specific to replicated record IDs and index creation and deletion. They are internal operations that do not need to be replicated when restoring. The cluster will always manage indexes appropriately.

This also undoes some changes to the manual test code from a previous PR. That previous PR changed this code to expect `mongorestore` to fail when trying to run with `--oplogReplay` when going restoring a dump from a cluster with replicated record IDs to one without, as well as the inverse. We now expect this to work.