### PR TITLE
TOOLS-4073 Simplify `MongoRestore.ApplyOps` method

### DIFF
--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -339,19 +339,14 @@ func (restore *MongoRestore) createCollectionWithApplyOps(
 		return fmt.Errorf("Couldn't restore UUID because UUID was invalid: %s", err)
 	}
 
-	createOp := struct {
-		Operation string            `bson:"op"`
-		Namespace string            `bson:"ns"`
-		Object    bson.D            `bson:"o"`
-		UI        *primitive.Binary `bson:"ui,omitempty"`
-	}{
+	createOp := db.Oplog{
 		Operation: "c",
 		Namespace: intent.DB + ".$cmd",
 		Object:    command,
 		UI:        &primitive.Binary{Subtype: 0x04, Data: uuid},
 	}
 
-	return restore.ApplyOps(session, []interface{}{createOp})
+	return restore.ApplyOp(session, createOp)
 }
 
 func createCollectionCommand(intent *intents.Intent, options bson.D) bson.D {


### PR DESCRIPTION
This method was accepting ops as a `[]any` slice, even though it was only ever called with a single value, and that single value can (and should) always be a `db.Oplog` struct. I changed the code to work this way, which simplifies adding some new logging in this method.