### PR TITLE
TOOLS-4087 / TOOLS-4088 Disable unnecessary tasks in waterfall

### DIFF
--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -30,6 +30,7 @@ tasks:
             echo "Deliberate fail test should give BF on mongodump_passthrough context"
             echo "exit 1"
             exit 1
+    patch_only: true
 
   # For mongodump passthrough, this builds and uploads the mongodump and mongorestore
   # binaries (but without coverage), and uploads them.  The name "compile_coverage"
@@ -69,6 +70,7 @@ tasks:
         params:
           files:
             - src/github.com/mongodb/mongo-tools/manual-tasks.json
+    patch_only: true
 
   # Task dependencies have been changed slightly here, to allow this
   # task to execute concurrently with "compile_coverage".

--- a/mongodump_passthrough/variants.yml
+++ b/mongodump_passthrough/variants.yml
@@ -13,7 +13,6 @@ buildvariants:
     display_name: "# V mongodump_passthru_v (arm64)"
     cron: 0 3 * * *
     tasks:
-      - name: deliberate_fail_to_test_build_baron_context_rules
       - name: compile_coverage
       - name: compile_verifier
       - name: mongodump_suites_up_to_date


### PR DESCRIPTION
This commit disables task `deliberate_fail_to_test_build_baron_context_rules` and `run_manual_generated_tasks` in waterfall.