### PR TITLE
TOOLS-4059 / TOOLS-4068 Fix qa-tests-7.0 failure

### DIFF
--- a/test/qa-tests/jstests/files/mongofiles_get.js
+++ b/test/qa-tests/jstests/files/mongofiles_get.js
@@ -54,7 +54,7 @@ var testName = 'mongofiles_get';
       if (isAtLeastVersion(db.version(), "8.0.16")) {
         // no escaping needed
       } else if (!isAtLeastVersion(db.version(), "8.0.0") && isAtLeastVersion(db.version(), "7.0.31")) {
-        // no escaping needed for 7.0.27 & later 7.0 releases
+        // no escaping needed for 7.0.31 & later 7.0 releases
       } else {
         idAsJSON = '"' + idAsJSON.replace(/"/g, '\\"') + '"';
       }

--- a/test/qa-tests/jstests/files/mongofiles_get.js
+++ b/test/qa-tests/jstests/files/mongofiles_get.js
@@ -53,7 +53,7 @@ var testName = 'mongofiles_get';
     if (_isWindows()) {
       if (isAtLeastVersion(db.version(), "8.0.16")) {
         // no escaping needed
-      } else if (!isAtLeastVersion(db.version(), "8.0.0") && isAtLeastVersion(db.version(), "7.0.27")) {
+      } else if (!isAtLeastVersion(db.version(), "8.0.0") && isAtLeastVersion(db.version(), "7.0.31")) {
         // no escaping needed for 7.0.27 & later 7.0 releases
       } else {
         idAsJSON = '"' + idAsJSON.replace(/"/g, '\\"') + '"';


### PR DESCRIPTION
[SERVER-96103](https://jira.mongodb.org/browse/SERVER-96103) is marked as fixed for 7.0.31. This commit fixes a qa BF that happens on 7.0 due to a mismatch in fix version.