### PR TITLE
TOOLS-4102 Use `mise` to manage our Python install

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -218,6 +218,8 @@ functions:
       working_dir: src/github.com/mongodb/mongo-tools
       args:
         - "./scripts/run_qa.sh"
+      env:
+        EVG_WORKDIR: ${workdir}
       add_expansions_to_env: true
 
   "run native-cert-ssl":
@@ -227,6 +229,8 @@ functions:
       working_dir: src/github.com/mongodb/mongo-tools
       args:
         - "./scripts/run_native_cert_ssl.sh"
+      env:
+        EVG_WORKDIR: ${workdir}
       add_expansions_to_env: true
 
   "run make target":
@@ -738,6 +742,7 @@ functions:
           set -o pipefail
           set -o verbose
 
+          ${_set_shell_env}
           PATH=/opt/mongodbtoolchain/v3/bin/:$PATH
           python="python3"
           if [ "Windows_NT" = "$OS" ]; then
@@ -747,27 +752,9 @@ functions:
           # The aws_e2e_assume_role script requires python3 with boto3.
           # Set up or use an existing python virtualenv for boto3.
           venv='venv'
-          venvNonWindows () { . "$venv"/bin/activate; python -m pip install boto3; }
-          venvWindows () { . "$venv"/Scripts/activate; pip install boto3; }
-
-          if [ -f "$venv"/bin/activate ]; then
-            echo 'activating existing virtualenv'
-            venvNonWindows
-          elif [ -f "$venv"/Scripts/activate ]; then
-            echo 'activating existing virtualenv'
-            dos2unix "$venv"/Scripts/activate
-            venvWindows
-          elif $python -m venv "$venv"; then
-            echo 'creating new virtualenv'
-            if [ -f "$venv"/bin/activate ]; then
-              echo 'activating new virtualenv'
-              venvNonWindows
-            elif [ -f "$venv"/Scripts/activate ]; then
-              echo 'activating new virtualenv'
-              dos2unix "$venv"/Scripts/activate
-              venvWindows
-            fi
-          fi
+          mise exec python -- python3 -m venv "$venv"
+          . "$venv"/bin/activate
+          pip install boto3
 
           $python -m pip list
 
@@ -784,6 +771,7 @@ functions:
           set -o pipefail
           set -o verbose
 
+          # There's no need to use mise here, since this will work with any version of Python.
           PATH=/opt/mongodbtoolchain/v3/bin/:$PATH
           python="python3"
           if [ "Windows_NT" = "$OS" ]; then
@@ -964,8 +952,6 @@ pre:
   - command: expansions.update
     params:
       updates:
-        - key: python
-          value: "/opt/mongodbtoolchain/v4/bin/python3"
         - key: resmoke_dir
           value: "src/resmoke"
         - key: resmoke_venv_dir

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,9 @@ node = { version = "22.22.0", postinstall = "$MISE_TOOL_INSTALL_PATH/bin/npm ins
 "npm:github-codeowners" = "0.2.1"
 "npm:oxfmt" = "0.52.0"
 
+# Python
+python = "3.12.9"
+
 [settings]
 # This prevents us from upgrading to anything that was released less than 7 days ago. It gives us a
 # bit of protection against supply-chain attacks.
@@ -32,3 +35,10 @@ minimum_release_age = "7d"
 # We turn off GPG verification for node because it has been flaky in CI, and also requires a local
 # GPG public key.
 gpg_verify = false
+
+[settings.python]
+# We turn off GitHub artifact attestation verification for python because it fails on our RHEL 8
+# CI hosts: mise can't parse the Rekor transparency-log public key there ("Ecdsa-P256 from der
+# bytes to public key failed: unknown/unsupported algorithm OID"), which blocks installation
+# entirely.
+github_attestations = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+pymongo==3.12.1
+pywin32; sys_platform == "win32"
+pyyaml

--- a/scripts/run_native_cert_ssl.sh
+++ b/scripts/run_native_cert_ssl.sh
@@ -4,6 +4,9 @@ set -x
 set -v
 set -e
 
+export PATH="${EVG_WORKDIR:?}/.local/bin:$PATH"
+export MISE_DATA_DIR="${EVG_WORKDIR:?}/.local/share/mise"
+
 chmod +x bin/*
 mv bin/* test/qa-tests/
 cd test/qa-tests
@@ -15,16 +18,17 @@ if [[ $OSTYPE == "darwin"* ]]; then
     sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain jstests/libs/trusted-ca.pem
 fi
 
-PATH=/opt/mongodbtoolchain/v3/bin/:$PATH
-python="${python_binary:-python3}"
+mise exec python -- python3 -m venv venv
+# shellcheck disable=SC1091 # this will exist in CI when we run this script
+. venv/bin/activate
+pip install -r ../../requirements.txt
 
-$python -m venv venv
-$python -m pip install pymongo==3.12.1 pyyaml
-if [ "Windows_NT" = "$OS" ]; then
-    $python -m pip install pywin32
-fi
 # shellcheck disable=SC2154 # resmoke_args and excludes are Evergreen expansions
 # shellcheck disable=SC2086 # resmoke_args is a space-separated list of extra flags that must be
 # word-split, not a single value; quoting it would pass it (or, if empty, an empty string) as one
 # argument instead of zero or more separate ones.
-$python buildscripts/resmoke.py --suite=native_cert_ssl --continueOnFailure --log=buildlogger --reportFile=../../report.json ${resmoke_args} --excludeWithAnyTags="${excludes}"
+# `mise exec python --` alone would re-prepend mise's own python bin dir onto PATH ahead of the
+# activated venv, so a bare `python3` would resolve to mise's interpreter instead of the venv's,
+# missing the packages we just pip installed. Pointing it at the venv's own python3 directly
+# avoids that, while still going through mise exec so the pinned python tool stays installed.
+mise exec python -- "$PWD/venv/bin/python3" buildscripts/resmoke.py --suite=native_cert_ssl --continueOnFailure --log=buildlogger --reportFile=../../report.json ${resmoke_args} --excludeWithAnyTags="${excludes}"

--- a/scripts/run_qa.sh
+++ b/scripts/run_qa.sh
@@ -4,21 +4,25 @@ set -x
 set -v
 set -e
 
+export PATH="${EVG_WORKDIR:?}/.local/bin:$PATH"
+export MISE_DATA_DIR="${EVG_WORKDIR:?}/.local/share/mise"
+
 chmod +x bin/*
 mv bin/* test/qa-tests/
 cd test/qa-tests
 chmod 400 jstests/libs/key*
 
-PATH=/opt/mongodbtoolchain/v3/bin/:$PATH
-python="${python_binary:-python3}"
+mise exec python -- python3 -m venv venv
+# shellcheck disable=SC1091 # this will exist in CI when we run this script
+. venv/bin/activate
+pip install -r ../../requirements.txt
 
-$python -m venv venv
-$python -m pip install pymongo==3.12.1 pyyaml
-if [ "Windows_NT" = "$OS" ]; then
-    $python -m pip install pywin32
-fi
 # shellcheck disable=SC2154 # resmoke_suite, resmoke_args, and excludes are Evergreen expansions
 # shellcheck disable=SC2086 # resmoke_args is a space-separated list of extra flags that must be
 # word-split, not a single value; quoting it would pass it (or, if empty, an empty string) as one
 # argument instead of zero or more separate ones.
-$python buildscripts/resmoke.py --suite="${resmoke_suite}" --continueOnFailure --log=buildlogger --reportFile=../../report.json ${resmoke_args} --excludeWithAnyTags="${excludes}"
+# `mise exec python --` alone would re-prepend mise's own python bin dir onto PATH ahead of the
+# activated venv, so a bare `python3` would resolve to mise's interpreter instead of the venv's,
+# missing the packages we just pip installed. Pointing it at the venv's own python3 directly
+# avoids that, while still going through mise exec so the pinned python tool stays installed.
+mise exec python -- "$PWD/venv/bin/python3" buildscripts/resmoke.py --suite=${resmoke_suite} --continueOnFailure --log=buildlogger --reportFile=../../report.json ${resmoke_args} --excludeWithAnyTags="${excludes}"


### PR DESCRIPTION
This also adds a `requirements.txt` file with the Python packages we need.