### PR TITLE
Revert "Use a new S3 bucket instead of `mciuploads` (#900)"

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -265,7 +265,8 @@ functions:
     # upload individual release artifacts to task page
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.deb
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.msi
@@ -274,9 +275,8 @@ functions:
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.zip
         remote_file: mongo-tools/pkgs/${build_id}/
         content_type: application/octet-stream
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
-        visibility: signed
+        bucket: mciuploads
+        permissions: public-read
         display_name: "Release Artifact - "
 
     # pack all release artifacts into a tarball and upload them to one
@@ -291,25 +291,25 @@ functions:
           - mongodb-database-tools*.rpm
           - mongodb-database-tools*.tgz
           - mongodb-database-tools*.zip
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/github.com/mongodb/mongo-tools/upload.tgz
         remote_file: mongo-tools/task/dist/${build_id}/all-release-artifacts.tgz
         content_type: application/x-gzip
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
-        visibility: signed
+        bucket: mciuploads
+        permissions: public-read
         display_name: All Release Artifacts (.tgz)
 
   "fetch dist release artifacts":
     - command: s3.get
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         remote_file: mongo-tools/task/dist/${build_id}/all-release-artifacts.tgz
         extract_to: src/github.com/mongodb/mongo-tools/
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+        bucket: mciuploads
 
   "sign artifacts":
     command: shell.exec
@@ -335,10 +335,10 @@ functions:
         working_dir: src/github.com/mongodb/mongo-tools
         script: |
           rm -rf ./mongorestore/testdata/longcollectionname/
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.sig
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.deb
@@ -347,9 +347,8 @@ functions:
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.tgz
           - src/github.com/mongodb/mongo-tools/mongodb-database-tools*.zip
         remote_file: mongo-tools/task/sign/${build_id}/
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
-        visibility: signed
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/octet-stream
 
   "upload release packages to s3":
@@ -367,17 +366,16 @@ functions:
         script: |
           ${_set_shell_env}
           go run release/release.go upload-json
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/github.com/mongodb/mongo-tools/release.json
         remote_file: mongo-tools/release/${build_id}/
         optional: true
         content_type: application/json
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
-        visibility: signed
+        bucket: mciuploads
+        permissions: public-read
 
   "generate full JSON feed":
     - command: shell.exec

--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -67,7 +67,8 @@ variables:
   f_resmoke_with_binaries_fetch: &f_resmoke_with_binaries_fetch
     command: s3.get
     params:
-      role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
       # Changed for mongodump_passthrough
       remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-with-binaries/${build_id}.tgz
       bucket: mciuploads
@@ -76,19 +77,21 @@ variables:
   f_resmoke_wheelhouse_fetch: &f_resmoke_wheelhouse_fetch
     command: s3.get
     params:
-      role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
       # Changed for mongodump_passthrough
       remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-python-wheelhouse/${build_id}.tgz
-      bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+      bucket: mciuploads
       extract_to: "."
 
   f_migration_verifier_binary_fetch: &f_migration_verifier_binary_fetch
     command: s3.get
     params:
-      role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
       # Changed for mongodump_passthrough
       remote_file: mongo-tools/mongodump_passthrough/${mongosync_compile_build_variant}/${revision}/${version_id}/migration_verifier
-      bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+      bucket: mciuploads
       local_file: src/mongosync/migration_verifier
 
   f_make_migration_verifier_binary_executable:
@@ -110,10 +113,11 @@ variables:
   f_mongosync_binary_fetch: &f_mongosync_binary_fetch
     command: s3.get
     params:
-      role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
       # Changed for mongodump_passthrough
       remote_file: mongo-tools/mongodump_passthrough/${mongosync_compile_build_variant}/${revision}/${version_id}/${mongosync_binary_folder}/${version_id}.tgz
-      bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+      bucket: mciuploads
       extract_to: "src/mongosync"
 
   f_generate_github_access_token: &f_generate_github_access_token
@@ -351,14 +355,14 @@ functions:
           - "./src/**"
           - "./.resmoke_mongo_version.yml"
           - "./.resmoke_mongo_release_values.yml"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: resmoke-with-binaries.tgz
         # Changed for mongodump_passthrough
         remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-with-binaries/${build_id}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+        bucket: mciuploads
         permissions: private
         visibility: signed
         content_type: application/gzip
@@ -371,14 +375,14 @@ functions:
         include:
           - "./wheelhouse/**"
           - "./poetry-requirements.txt"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: resmoke-python-wheelhouse.tgz
         # Changed for mongodump_passthrough
         remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/resmoke-python-wheelhouse/${build_id}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+        bucket: mciuploads
         permissions: private
         visibility: signed
         content_type: application/gzip
@@ -403,17 +407,17 @@ functions:
           PATH=$PATH:$HOME:/opt/golang/go1.23/bin
           GOROOT=/opt/golang/go1.23
           ./build.sh
-
     # upload the compiled verifier to S3.
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/migration-verifier/migration_verifier
         # Changed for mongodump_passthrough
         remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/migration_verifier
         content_type: application/x-executable
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         display_name: "migration_verifier release artifact (compiled)"
 
   f_migration_verifier_binary_fetch:
@@ -433,15 +437,15 @@ functions:
         source_dir: "src/mongosync"
         include:
           - "./dist/*"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: ${mongosync_binary_folder}.tgz
         # Changed for mongodump_passthrough
         remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/${version_id}/${mongosync_binary_folder}/${version_id}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: ${mongosync_binary_folder}
 
@@ -483,7 +487,6 @@ functions:
       params:
         binary: "./src/mongosync/evergreen/scripts/mongo_coredumps_gather.sh"
         add_expansions_to_env: true
-
     - command: archive.targz_pack
       params:
         target: mongo-coredumps.tgz
@@ -491,14 +494,14 @@ functions:
         include:
           - "./**.core"
           - "./**.mdmp" # Windows: minidumps
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: mongo-coredumps.tgz
         remote_file: mongosync/${build_variant}/${revision}/coredumps/mongo-coredumps-${build_id}-${task_name}-${execution}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: Core Dumps - Execution ${execution}
         optional: true
@@ -517,14 +520,14 @@ functions:
         source_dir: "src/mongosync/mongosync-testing-server-logs"
         include:
           - "./**"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: server-logs.tgz
         remote_file: mongosync/${build_variant}/${revision}/mongo-logs/mongo-logs-${build_id}-${task_name}-${execution}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: Integration Test mongod / mongos logs ${execution}
         optional: true
@@ -536,48 +539,51 @@ functions:
         include:
           - "out.log"
           - "server.log"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: mongo-orchestration-logs.tgz
         remote_file: mongosync/${build_variant}/${revision}/mongo-orchestration-logs/mongo-orchestration-logs.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: mongo-orchestration logs
         optional: true
 
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/mongosync/*.suite
         remote_file: mongosync/${build_variant}/${revision}/${build_id}/${task_name}/${execution}/go-test-logs/
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: text/plain
         display_name: "Output from `go test` command"
 
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/mongosync/server-binaries.tgz
         remote_file: mongosync/${build_variant}/${revision}/mongo-binaries/mongo-binaries-${build_id}-${task_name}-${execution}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: Failed Integration Test mongod / mongos binaries ${execution}
         optional: true
 
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_files_include_filter:
           - src/mongosync/mongosync-testing-server-data-files/archive/*.tgz
         remote_file: mongosync/${build_variant}/${revision}/${build_id}/${task_name}/datafiles/
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/octet-stream
         display_name: Failed Integration Test Data Files ${execution}
 
@@ -587,14 +593,14 @@ functions:
         source_dir: "src/mongosync/coverage"
         include:
           - "./**"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: coverage.gz
         remote_file: mongosync/${build_variant}/${revision}/coverage/${task_name}/coverage.gz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: Coverage statistics
 
@@ -604,14 +610,14 @@ functions:
         source_dir: "src/resmoke/tools_output"
         include:
           - "**"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: tools_output.tgz
         remote_file: mongo-tools/${build_variant}/${revision}/tools_output/${task_name}/${build_id}/tools_output.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
-        permissions: private
+        bucket: mciuploads
+        permissions: public-read
         content_type: application/gzip
         display_name: Tools Output
 
@@ -632,7 +638,6 @@ functions:
   "run jstestfuzz":
     - *f_expansions_write
     - *f_generate_github_access_token
-
     - command: github.generate_token
       params:
         owner: 10gen
@@ -640,32 +645,29 @@ functions:
         expansion_name: generated_token_qa
         permissions:
           contents: read
-
     - command: subprocess.exec
       params:
         binary: "./src/mongosync/evergreen/scripts/clone_jstestfuzz_jstest_repos.sh"
         add_expansions_to_env: true
-
     - command: subprocess.exec
       type: test
       params:
         binary: "./src/mongosync/evergreen/scripts/run_jstestfuzz.sh"
         add_expansions_to_env: true
-
     - command: archive.targz_pack
       params:
         target: "jstests.tgz"
         source_dir: "src/jstestfuzz"
         include:
           - "out/*.js"
-
     - command: s3.put
       params:
-        role_arn: arn:aws:iam::391144487543:role/evergreen-project-mongo-tools
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: jstests.tgz
         # Changed for mongodump_passthrough
         remote_file: mongo-tools/mongodump_passthrough/${build_variant}/${revision}/jstestfuzz/${task_id}-${execution}.tgz
-        bucket: evergreen-project-mongo-tools-i6qg5nn6nbm
+        bucket: mciuploads
         permissions: private
         visibility: signed
         content_type: application/gzip


### PR DESCRIPTION
This reverts commit 5745e79a76da72e2d4ee3d3f4ea514c98048982b.

I realized that this may break the release process. It's not clear to me that using this new bucket will work for that case. We don't have any good way to test the release process, so I'll just revert this for now.