### PR TITLE
Update the script to create clusters to allow creating the default type of cluster too

### DIFF
--- a/scripts/create-atlas-dev-cluster.sh
+++ b/scripts/create-atlas-dev-cluster.sh
@@ -29,10 +29,14 @@ GROUP_ID="673e58327d4f1a7610a14faf"
 NODE_COUNT="${3:-2}"
 API_CREDENTIALS="$ATLAS_PUBLIC_KEY:$ATLAS_PRIVATE_KEY"
 
+if [ -n "$CLUSTER_TYPE" ]; then
+    TYPE="\"clusterType\": \"$CLUSTER_TYPE\","
+fi
+
 JSON_BODY=$(cat <<EOF
 {
   "name": "$CLUSTER_ID",
-  "clusterType": "$CLUSTER_TYPE",
+  $TYPE
   "replicationSpecs": [
     {
       "regionConfigs": [


### PR DESCRIPTION
This makes it easy to quickly create two clusters in our dev env, one with `recordIdsReplicated` enabled and one without.