### PR TITLE
TOOLS-4148 Add a new sharded test type for sharded cluster integration tests

### DIFF
--- a/build.go
+++ b/build.go
@@ -66,6 +66,10 @@ func init() {
 		Description("runs all integration tests").
 		OptionalArgs("pkgs", "ssl", "auth", "kerberos", "topology", "race").
 		Do(buildscript.TestIntegration)
+	taskRegistry.Declare("test:sharded-integration").
+		Description("runs tests requiring a sharded cluster topology").
+		OptionalArgs("pkgs", "ssl", "race").
+		Do(buildscript.TestShardedIntegration)
 	taskRegistry.Declare("test:kerberos").
 		Description("runs all kerberos tests").
 		OptionalArgs("race").

--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -122,6 +122,13 @@ func TestIntegration(ctx *task.Context) error {
 	return runTests(ctx, selectedPkgs(ctx), testtype.IntegrationTestType)
 }
 
+// TestShardedIntegration runs tests that require a sharded cluster (mongos) topology.
+// It sets only ShardedIntegrationTestType, intentionally not setting IntegrationTestType,
+// so regular integration tests (which expect a standalone mongod) are not run against mongos.
+func TestShardedIntegration(ctx *task.Context) error {
+	return runTests(ctx, selectedPkgs(ctx), testtype.ShardedIntegrationTestType)
+}
+
 // TestAWSAuth is an Executor that runs all AWS auth tests for the provided packages.
 func TestAWSAuth(ctx *task.Context) error {
 	return runTests(ctx, selectedPkgs(ctx), testtype.AWSAuthTestType)
@@ -190,6 +197,9 @@ func runTests(ctx *task.Context, pkgs []string, testType string) error {
 		}
 		if ctx.Get("topology") == "replSet" {
 			env = append(env, testtype.ReplSetTestType+"=true")
+		}
+		if ctx.Get("topology") == "sharded" {
+			env = append(env, testtype.ShardedIntegrationTestType+"=true")
 		}
 
 		if ctx.Get("race") == "true" {

--- a/common.yml
+++ b/common.yml
@@ -461,6 +461,33 @@ functions:
           fi;
           ./bin/mongo $MONGO_ARGS --nodb --eval 'assert.soon(function(x){try{var d = new Mongo("localhost:${mongod_port}"); return true} catch(e){return false}}, "timed out connection")'
 
+  "create sharded cluster":
+    - command: shell.exec
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        background: true
+        script: |
+          set -x
+          set -v
+          set -e
+          echo "starting sharded cluster"
+          mkdir -p /data/db/
+          # use jsconfig.json to set baseUrl to find libs
+          mv test/shell_common/jsconfig.json ./
+          if [ -n "${load_libs_version}" ]; then
+            IMPORT_LOAD_LIBS="await import(\"../shell_common/libs/load_libs-${load_libs_version}.js\");"
+          fi
+          PATH=./bin:$PATH ./bin/mongo --port ${mongod_port} --nodb --eval "$IMPORT_LOAD_LIBS; var st = new ShardingTest({name: \"tools_sharded_cluster\", shards: 1, mongos: [{port: ${mongod_port}}], other: {rsOptions: {}, configOptions: {}}}); while(true){sleep(1000);}"
+
+    - command: shell.exec
+      params:
+        working_dir: src/github.com/mongodb/mongo-tools
+        script: |
+          set -x
+          set -v
+          set -e
+          ./bin/mongo --port ${mongod_port} --nodb --eval 'assert.soon(function(x){try{var d = new Mongo("localhost:${mongod_port}"); return true} catch(e){return false}}, "timed out connection")'
+
   "add-aws-auth-variables-to-file":
     - command: shell.exec
       type: test
@@ -1623,6 +1650,140 @@ tasks:
       - func: "run make target"
         vars:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
+
+  - name: integration-4.4-sharded
+    tags: ["4.4", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "4.4"
+      - func: "create sharded cluster"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-5.0-sharded
+    tags: ["5.0", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "5.0"
+      - func: "create sharded cluster"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-6.0-sharded
+    tags: ["6.0", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "6.0"
+      - func: "create sharded cluster"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-7.0-sharded
+    tags: ["7.0", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "7.0"
+      - func: "create sharded cluster"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-8.0-sharded
+    tags: ["8.0", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "8.0"
+      - func: "create sharded cluster"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-8.1-sharded
+    tags: ["8.1", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "8.1.0"
+      - func: "create sharded cluster"
+        vars:
+          load_libs_version: "8.1"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-8.2-sharded
+    tags: ["8.2", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "8.2.0"
+      - func: "create sharded cluster"
+        vars:
+          load_libs_version: "8.2"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
+
+  - name: integration-latest-sharded
+    tags: ["latest", "sharded"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "latest"
+      - func: "create sharded cluster"
+        vars:
+          load_libs_version: *max_server_version
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:sharded-integration ${testArgs}
 
   - name: aws-auth-latest
     tags: ["latest", "aws-auth"]

--- a/common/testtype/types.go
+++ b/common/testtype/types.go
@@ -18,6 +18,9 @@ const (
 	// First checks for a URI for a Mongod in the env variable TOOLS_TESTING_MONGOD. If it does not find it, looks on localhost:33333.
 	IntegrationTestType = "TOOLS_TESTING_INTEGRATION"
 
+	// Testing the tools against a sharded cluster (mongos) topology.
+	ShardedIntegrationTestType = "TOOLS_TESTING_SHARDED_INTEGRATION"
+
 	// Unit tests don't require a real mongod. They may still do file I/O.
 	UnitTestType = "TOOLS_TESTING_UNIT"
 

--- a/precious.toml
+++ b/precious.toml
@@ -6,7 +6,10 @@
 # for example from editors on save. Slower tidiers should only be invoked manually, either by
 # running the relevant mage command or by explicitly running `precious` from the CLI.
 
-exclude = "vendor/**/*"
+exclude = [
+  ".ai-plans/**/*",
+  "vendor/**/*",
+]
 
 [commands.golangci-lint]
 type = "both"
@@ -96,6 +99,7 @@ invoke = "once"
 working-dir = "root"
 path-args = "file"
 include = [ "*.md" ]
+exclude = [ "docs/superpowers/**/*.md" ]
 cmd = [
     "$PRECIOUS_ROOT/node_modules/.bin/prettier",
     "--print-width", "100",


### PR DESCRIPTION
This adds a new `TOOLS_TESTING_SHARDED_INTEGRATION` test type, wires it up in the build script via -topology=sharded, adds a "create sharded cluster" Evergreen function (mirroring "create repl_set" but using ShardingTest), and adds integration-X.Y-sharded tasks for all server versions that have cluster tasks (4.4 through latest).

This will be used as I convert JS tests to Go. Some of those tests are specific to sharded clusters, so we need a way to write Go tests against sharded clusters too.

This PR also includes the plan that Claude created for the conversion of all JS tests.