### PR TITLE
TOOLS-4148 Annotate JS tests with SKIP, EXTEND, or NEW after auditing to figure out which ones need to be converted to Go

### DIFF
--- a/.ai-plans/2026-03-13/js-to-go-test-migration/plan.md
+++ b/.ai-plans/2026-03-13/js-to-go-test-migration/plan.md
@@ -90,102 +90,59 @@ Each batch extends or creates test files in these locations:
 | `jstests/files/*.js` | `mongofiles/mongofiles_test.go` | Extend existing file |
 | `jstests/stat/*.js` | `mongostat/mongostat_test.go` | Extend existing file |
 | `jstests/top/*.js` | `mongotop/mongotop_test.go` | New file; currently only `options_test.go` exists |
-| `jstests/ssl/*.js` | `mongoexport/mongoexport_test.go` | Under `testtype.SSLTestType` |
-| `jstests/tls/*.js` | `mongoexport/mongoexport_test.go` | Under `testtype.SSLTestType` |
-| `test/legacy42/jstests/tool/*.js` | Various (see Batch 10) | Audit first; most are duplicates |
+| `jstests/ssl/*.js` | new SSL integration test | Under `testtype.SSLTestType` |
+| `jstests/tls/*.js` | new TLS integration test | Under `testtype.SSLTestType` |
+| `test/legacy42/jstests/tool/*.js` | Various (see Task 13) | Audit complete; most are duplicates |
 
 ---
 
 ## Chunk 1: Audit + bsondump
 
-### Task 0: Add ShardedTestType infrastructure
+### Task 0: Add ShardedIntegrationTestType infrastructure — COMPLETED
 
-Several JS tests require a sharded cluster (mongos). Rather than skipping them, we introduce a new `ShardedTestType` parallel to the existing `ReplSetTestType`.
+> **COMPLETED** — committed as 5b34c02b. All steps done.
 
-**Files to modify:**
-- `common/testtype/types.go` — add the constant
-- `common.yml` — add a sharded build variant that sets `TOOLS_TESTING_SHARDED=1` and starts a mongos
+Several JS tests require a sharded cluster (mongos). Rather than skipping them, we introduced a new `ShardedIntegrationTestType` parallel to the existing `ReplSetTestType`.
 
-- [ ] **Step 1: Add the constant to `common/testtype/types.go`**
+- [x] **Step 1: Add the constant to `common/testtype/types.go`**
 
-Add after the `ReplSetTestType` constant:
+Added `ShardedIntegrationTestType = "TOOLS_TESTING_SHARDED_INTEGRATION"` after the `ReplSetTestType` constant.
 
-```go
-// Testing the tools against a sharded cluster (mongos) topology.
-ShardedTestType = "TOOLS_TESTING_SHARDED_INTEGRATION"
-```
-
-- [ ] **Step 2: Verify it compiles**
+- [x] **Step 2: Verify it compiles**
 
 ```bash
 go build ./common/testtype/...
 ```
 
-Expected: no errors.
+- [x] **Step 3: Add `topology=sharded` support to `buildscript/build.go`**
 
-- [ ] **Step 3: Add a sharded build variant to `common.yml`**
+Added `topology=sharded` as a recognized topology value in the build script.
 
-Find the existing `integration-X.Y-cluster` task family (replica set topology tasks) and add a new family of tasks for sharded topologies. The pattern to follow is the same as the existing `integration-X.Y-auth` tasks: a new expansion variable that is set in the build variant and consumed by the test runner.
+- [x] **Step 4: Add `"create sharded cluster"` function and `integration-X.Y-sharded` tasks to `common.yml`**
 
-The key expansion to add in the new build variant:
+Added new tasks and a function that starts a `ShardingTest` cluster for sharded topology variants.
 
-```yaml
-expansions:
-  test_flags: "TOOLS_TESTING_SHARDED=1"
-  topology: sharded
-```
-
-And the `start-mongod` function (or equivalent) for that variant must start a sharded cluster instead of a standalone. Follow the pattern already used for the `cluster` variants — those already start a replica set via `ReplSetTest`; the sharded variant should start a `ShardingTest` instead.
-
-After editing `common.yml`, regenerate and validate:
+- [x] **Step 5: Commit**
 
 ```bash
-go run build.go sa:evgvalidate
-```
-
-Expected: validation passes.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add common/testtype/types.go common.yml
-git commit -m "testtype: add ShardedTestType for sharded cluster integration tests"
+git commit -m "testtype: add ShardedIntegrationTestType for sharded cluster integration tests"
 ```
 
 ---
 
-### Task 1: Audit all JS tests against existing Go tests
+### Task 1: Audit all JS tests against existing Go tests — COMPLETED
 
-Before converting anything, map each JS test file to: **SKIP** (already covered in Go), **EXTEND** (partial coverage, add cases), or **NEW** (no coverage).
+> **COMPLETED** — committed as 53346f4c. All JS files annotated. Final counts: 21 SKIP, 111 NEW, 47 EXTEND.
 
-**Files to audit:**
-- All files in `test/qa-tests/jstests/bson/`, `dump/`, `export/`, `import/`, `restore/`, `files/`, `stat/`, `top/`, `ssl/`, `tls/`, `txn/`
-- All files in `test/legacy42/jstests/tool/`
+- [x] **Step 1: Read every JS test file** for each tool area. Checked corresponding Go test files for equivalent coverage.
 
-**Files to read for comparison:**
-- `bsondump/bsondump_test.go`
-- `mongodump/mongodump_test.go` (2537 lines)
-- `mongorestore/mongorestore_test.go` (3879 lines), `mongorestore/oplog_test.go`, `mongorestore/dumprestore_auth_test.go`
-- `mongoexport/mongoexport_test.go`, `mongoexport/csv_test.go`, `mongoexport/json_test.go`
-- `mongoimport/mongoimport_test.go`, `mongoimport/csv_test.go`, `mongoimport/json_test.go`, `mongoimport/tsv_test.go`
-- `mongofiles/mongofiles_test.go`
-- `mongostat/mongostat_test.go`
+- [x] **Step 2: Record the triage result** by adding a `// MIGRATION:` comment on line 1 of each JS file (SKIP / EXTEND / NEW with rationale).
 
-- [ ] **Step 1: Read every JS test file** for each tool area. For each file, check the corresponding Go test file for equivalent coverage.
-
-- [ ] **Step 2: Record the triage result** by adding a comment at the top of each JS file:
-
-```js
-// MIGRATION: SKIP — covered by TestMongoDumpBSON in mongodump/mongodump_test.go
-// MIGRATION: EXTEND — add sub-case to TestMongoDumpViews
-// MIGRATION: NEW — no Go coverage exists
-```
-
-- [ ] **Step 3: Commit the triage annotations**
+- [x] **Step 3: Commit the triage annotations**
 
 ```bash
 git add test/
-git commit -m "migration: annotate JS tests with Go coverage triage"
+git commit -m "migration: annotate JS tests with verified Go coverage triage"
 ```
 
 ---
@@ -195,23 +152,32 @@ git commit -m "migration: annotate JS tests with Go coverage triage"
 **JS files:** `test/qa-tests/jstests/bson/` (7 files)
 **Go target:** `bsondump/bsondump_test.go`
 
+Audit results from the annotations:
+- `all_types.js` — NEW
+- `all_types_json.js` — NEW
+- `bad_files.js` — EXTEND
+- `bsondump_broken_pipe.js` — SKIP (OS-signal-level, not testable in Go)
+- `bsondump_options.js` — EXTEND
+- `deep_nested.js` — NEW
+- `output_file.js` — SKIP (already covered by `TestBsondump`)
+
 First, read `bsondump/bsondump_test.go` in full to understand existing coverage.
 
-The bsondump JS tests primarily test: correct output format for all BSON types (debug and JSON modes), error handling for malformed input, option validation, broken pipe, deep nesting, and output file writing. The tool is invoked as: `bsondump [options] <file>` — call the library: `bsondump.New(opts)` / `bsondump.Dump(writer)`.
+The bsondump tool is invoked as: `bsondump [options] <file>` — call the library: `bsondump.New(opts)` / `bsondump.Dump(writer)`.
 
-- [ ] **Step 1: Convert `all_types.js`** — Add `TestBSONDumpAllTypesDebug` if not covered. Insert a document with every BSON type into a collection, dump it to a temp file, run bsondump on it, verify output contains the correct debug-format type labels.
+- [ ] **Step 1: Convert `all_types.js`** (NEW) — Add `TestBSONDumpAllTypesDebug`. Insert a document with every BSON type into a collection, dump it to a temp file, run bsondump on it, verify output contains the correct `--type=debug` format type labels and BSON type numbers.
 
-- [ ] **Step 2: Convert `all_types_json.js`** — Add `TestBSONDumpAllTypesJSON` if not covered. Same setup, verify JSON output mode produces correct Extended JSON.
+- [ ] **Step 2: Convert `all_types_json.js`** (NEW) — Add `TestBSONDumpAllTypesJSON`. Same setup, verify JSON output mode produces correct Extended JSON for all types including binary, regex, decimal128, etc.
 
-- [ ] **Step 3: Convert `bad_files.js`** — Add `TestBSONDumpBadInput`. Write temp files containing: random bytes, truncated BSON, bad cstring, unsupported type byte. Verify bsondump returns an error or continues with `--objcheck` as appropriate.
+- [ ] **Step 3: Convert `bad_files.js`** (EXTEND) — Add sub-cases to `TestBsondump` in `bsondump_test.go`. Write temp files containing: random bytes, truncated BSON, bad cstring, unsupported type byte. Verify bsondump returns an error or continues with `--objcheck` as appropriate.
 
-- [ ] **Step 4: Convert `deep_nested.js`** — Add `TestBSONDumpDeepNested`. Create a deeply nested document (100+ levels), dump it, bsondump it, verify no stack overflow or error.
+- [ ] **Step 4: Convert `deep_nested.js`** (NEW) — Add `TestBSONDumpDeepNested`. Create a deeply nested document (100+ levels), dump it, bsondump it, verify no stack overflow or error.
 
-- [ ] **Step 5: Convert `output_file.js`** — Add `TestBSONDumpOutputFile`. Run bsondump with `--out=<tmpfile>`, verify the file is created and contains expected output.
+- [ ] **Step 5: Convert `bsondump_options.js`** (EXTEND) — Add cases to `TestBsondump`. Verify invalid flag combinations return errors; `--type`, `--help`, `--version` flags behave as expected.
 
-- [ ] **Step 6: Convert `bsondump_options.js`** — Add cases to `TestBSONDumpOptions` or a new `TestBSONDumpOptionValidation`. Verify invalid flag combinations return errors; `--type`, `--help`, `--version` flags behave as expected.
+- [ ] **Step 6: Skip `output_file.js`** — Already covered by `TestBsondump` (file output variants).
 
-- [ ] **Step 7: Skip `bsondump_broken_pipe.js`** — Broken pipe behavior is OS-signal-level and untestable in Go unit/integration tests without significant complexity. Add a `// MIGRATION: SKIP — broken pipe is OS-level, not testable in Go` comment and leave it out.
+- [ ] **Step 7: Skip `bsondump_broken_pipe.js`** — Broken pipe is OS-signal-level, not testable in Go.
 
 - [ ] **Step 8: Run the new tests**
 
@@ -228,9 +194,8 @@ rm test/qa-tests/jstests/bson/all_types.js
 rm test/qa-tests/jstests/bson/all_types_json.js
 rm test/qa-tests/jstests/bson/bad_files.js
 rm test/qa-tests/jstests/bson/deep_nested.js
-rm test/qa-tests/jstests/bson/output_file.js
 rm test/qa-tests/jstests/bson/bsondump_options.js
-# Leave bsondump_broken_pipe.js with a SKIP comment, or delete it too
+rm test/qa-tests/jstests/bson/output_file.js
 rm test/qa-tests/jstests/bson/bsondump_broken_pipe.js
 ```
 
@@ -247,49 +212,73 @@ git commit -m "migration: convert bsondump JS tests to Go"
 
 ### Task 3: Convert mongoexport JS tests
 
-**JS files:** `test/qa-tests/jstests/export/` (~20 files)
+**JS files:** `test/qa-tests/jstests/export/` (19 files)
 **Go target:** `mongoexport/mongoexport_test.go`
+
+Audit results from the annotations:
+- `basic_data.js` — NEW (end-to-end export-then-import round-trip)
+- `data_types.js` — NEW (round-trip of diverse BSON types)
+- `export_broken_pipe.js` — SKIP (OS-signal-level)
+- `export_views.js` — NEW (no Go test creates or exports from a MongoDB view)
+- `field_file.js` — NEW
+- `fields_csv.js` — EXTEND (csv_test.go covers unit-level CSV but no end-to-end `--fields` with `--csv` against a real server)
+- `fields_json.js` — NEW (no Go test verifies `--fields` limits JSON output)
+- `force_table_scan.js` — NEW
+- `json_array.js` — EXTEND (json_test.go covers basic jsonArray format but not round-trip or import-without-flag failure)
+- `limit.js` — NEW (no Go test exercises `--limit`)
+- `namespace_validation.js` — NEW
+- `nested_fields_csv.js` — EXTEND (add to csv_test.go for nested field handling)
+- `no_data.js` — EXTEND (TestMongoExportTOOLS2174 covers empty collection but not `--assertExists`)
+- `pretty.js` — NEW
+- `query.js` — NEW (no Go test verifies `--query` or `--queryFile` filter export output)
+- `slave_ok.js` — NEW (ReplSetTestType)
+- `sort_and_skip.js` — NEW (no Go test verifies `--sort` and `--skip`)
+- `stdout.js` — NEW (no Go test verifies export writes to stdout)
+- `type_case.js` — NEW
 
 Read the existing `mongoexport_test.go` (331 lines — relatively short), `csv_test.go`, and `json_test.go` before starting.
 
-The JS tests cover: basic data roundtrip, data types, broken pipe, views, field selection (JSON and CSV), force table scan, JSON array output, `--limit`, namespace validation, nested CSV fields, pretty output, `--query`, `--slaveOk`, sort/skip, stdout output, and type case handling.
-
 The mongoexport library API: create `mongoexport.MongoExport{Options: opts}`, then call `export.ExpManager.Open()` and `export.Export(writer)`.
 
-- [ ] **Step 1: For each JS file, check triage annotation** from Task 1. Only convert NEW or EXTEND files.
+- [ ] **Step 1: Convert `basic_data.js`** (NEW) — `TestExportImportBasicRoundtrip`: insert documents, export to buffer, import back, verify document count and values match.
 
-- [ ] **Step 2: Convert `basic_data.js`** — `TestExportImportBasicRoundtrip`: insert documents, export to buffer, import back, verify document count and values match.
+- [ ] **Step 2: Convert `data_types.js`** (NEW) — `TestExportDataTypes`: insert documents with int, float, string, subdoc, array, BinData, ISODate, Timestamp, Regex; verify export contains correct Extended JSON representations.
 
-- [ ] **Step 3: Convert `data_types.js`** — `TestExportDataTypes`: insert documents with ObjectId, Date, NumberLong, NumberInt, Decimal128, BinData, Regex, verify export output contains correct Extended JSON representations.
+- [ ] **Step 3: Convert `export_views.js`** (NEW) — `TestExportViews`: create a MongoDB view with a pipeline, export it, verify exported data matches the view's pipeline output.
 
-- [ ] **Step 4: Convert `field_file.js` and `fields_json.js` and `fields_csv.js`** — `TestExportFieldSelection`: verify `--fields` limits output to named fields in both JSON and CSV modes.
+- [ ] **Step 4: Convert `field_file.js`** (NEW) — `TestExportFieldFile`: verify `--fieldFile` reads field names from a file and limits export output accordingly.
 
-- [ ] **Step 5: Convert `nested_fields_csv.js`** — `TestExportNestedFieldsCSV`: export with dotted field paths in `--fields`, verify CSV flattening.
+- [ ] **Step 5: Convert `fields_json.js`** (NEW) — `TestExportFieldsJSON`: verify `--fields` limits which fields appear in JSON export output.
 
-- [ ] **Step 6: Convert `json_array.js`** — `TestExportJSONArray`: verify `--jsonArray` flag wraps output in `[...]`.
+- [ ] **Step 6: Convert `fields_csv.js`** (EXTEND) — Add end-to-end case to `mongoexport_test.go`: insert docs, export with `--fields` and `--csv` against a real server, verify only the specified fields appear in CSV output.
 
-- [ ] **Step 7: Convert `query.js`** — `TestExportQuery`: insert 10 docs, export with `--query '{"x": {"$gt": 5}}'`, verify only matching docs appear.
+- [ ] **Step 7: Convert `nested_fields_csv.js`** (EXTEND) — Add to `csv_test.go`: export with dotted field paths in `--fields`, verify CSV flattening behavior.
 
-- [ ] **Step 8: Convert `sort_and_skip.js`** — `TestExportSortAndSkip`: insert ordered docs, export with `--sort` and `--skip`, verify ordering.
+- [ ] **Step 8: Convert `json_array.js`** (EXTEND) — Add to `mongoexport_test.go`: verify `--jsonArray` wraps output in `[...]`, and that importing without `--jsonArray` fails on that output.
 
-- [ ] **Step 9: Convert `limit.js`** — `TestExportLimit`: insert 20 docs, export with `--limit 5`, verify exactly 5 docs in output.
+- [ ] **Step 9: Convert `force_table_scan.js`** (NEW) — `TestExportForceTableScan`: verify `--forceTableScan` flag doesn't break basic export.
 
-- [ ] **Step 10: Convert `pretty.js`** — `TestExportPretty`: verify `--pretty` flag produces indented JSON output.
+- [ ] **Step 10: Convert `limit.js`** (NEW) — `TestExportLimit`: insert 20 docs, export with `--limit 5`, verify exactly 5 docs in output.
 
-- [ ] **Step 11: Convert `no_data.js`** — `TestExportNoData`: export an empty collection, verify empty output (not an error).
+- [ ] **Step 11: Convert `namespace_validation.js`** (NEW) — `TestExportNamespaceValidation`: verify that invalid namespace combinations (no `--db`, `--collection` without `--db`, etc.) return appropriate errors.
 
-- [ ] **Step 12: Convert `export_views.js`** — `TestExportViews`: create a view, export it, verify exported data matches the view's pipeline output.
+- [ ] **Step 12: Convert `no_data.js`** (EXTEND) — Add to `TestMongoExportTOOLS2174` or a new case: verify `--assertExists` flag returns an error for a collection that does not exist.
 
-- [ ] **Step 13: Convert `namespace_validation.js`** — `TestExportNamespaceValidation`: verify that invalid namespace combinations (no `--db`, `--collection` without `--db`, etc.) return appropriate errors.
+- [ ] **Step 13: Convert `pretty.js`** (NEW) — `TestExportPretty`: verify `--pretty` flag produces indented JSON output.
 
-- [ ] **Step 14: Convert remaining files** (`stdout.js`, `type_case.js`, `force_table_scan.js`, `slave_ok.js`):
-  - `TestExportStdout`: verify export to stdout (write to `os.Stdout` or a pipe).
-  - `TestExportTypeCase`: verify type name case insensitivity.
-  - `TestExportForceTableScan`: verify `--forceTableScan` flag doesn't break basic export.
-  - Skip `slave_ok.js` — `--slaveOk` is deprecated/removed; add a `// MIGRATION: SKIP` comment.
-  - Skip `export_broken_pipe.js` — same rationale as bsondump broken pipe.
+- [ ] **Step 14: Convert `query.js`** (NEW) — `TestExportQuery`: insert 10 docs, export with `--query '{"x": {"$gt": 5}}'` and with `--queryFile`, verify only matching docs appear.
 
-- [ ] **Step 15: Run the new tests**
+- [ ] **Step 15: Convert `sort_and_skip.js`** (NEW) — `TestExportSortAndSkip`: insert ordered docs, export with `--sort` and `--skip`, verify ordering and offset.
+
+- [ ] **Step 16: Convert `stdout.js`** (NEW) — `TestExportStdout`: verify export writes correct JSON to stdout when no `--out` is specified.
+
+- [ ] **Step 17: Convert `type_case.js`** (NEW) — `TestExportTypeCase`: verify type name case insensitivity in export output format selection.
+
+- [ ] **Step 18: Convert `slave_ok.js`** (NEW) — `TestExportSlaveOk`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Verify export works against a replica set with secondary read preference.
+
+- [ ] **Step 19: Skip `export_broken_pipe.js`** — OS-signal-level, not testable in Go.
+
+- [ ] **Step 20: Run the new tests**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongoexport/... -v -count=1
@@ -297,7 +286,7 @@ TOOLS_TESTING_TYPE=integration go test ./mongoexport/... -v -count=1
 
 Expected: all PASS.
 
-- [ ] **Step 16: Delete the JS files, commit**
+- [ ] **Step 21: Delete the JS files, commit**
 
 ```bash
 rm -r test/qa-tests/jstests/export/
@@ -309,48 +298,72 @@ git commit -m "migration: convert mongoexport JS tests to Go"
 
 ### Task 4: Convert mongoimport JS tests
 
-**JS files:** `test/qa-tests/jstests/import/` (~19 files)
+**JS files:** `test/qa-tests/jstests/import/` (20 files)
 **Go target:** `mongoimport/mongoimport_test.go`
+
+Audit results from the annotations:
+- `all_primaries_down_error_code.js` — NEW (ShardedIntegrationTestType)
+- `boolean_type.js` — NEW (Boolean() objects round-trip)
+- `collections.js` — EXTEND (basic file-to-collection derivation covered but not multi-dot filenames, positional args, or `--db` with positional arg)
+- `decimal128.js` — NEW (no Go test verifies Decimal128 round-trip through Extended JSON)
+- `drop.js` — SKIP (covered by `mongoimport_test.go`)
+- `fields.js` — EXTEND (covers `--fields` and `--ignoreBlanks` for CSV but not `--fieldFile`, nested dotted field names, or extra fields beyond header end-to-end)
+- `import_document_validation.js` — NEW (no Go test for validated collection + import rejection + `--bypassDocumentValidation`)
+- `import_types.js` — NEW (no Go test imports legacy Extended JSON with all BSON types and verifies `$type`)
+- `import_write_concern.js` — NEW (ReplSetTestType)
+- `import_write_concern_mongos.js` — NEW (ShardedIntegrationTestType)
+- `mode.js` — EXTEND (upsert and delete covered but not merge, compound `--upsertFields`, or legacy `--upsert` flag)
+- `mode_upsert_id_subdoc.js` — EXTEND (add upsert-with-ID-in-subdoc case to `mongoimport_test.go`)
+- `no_primary_error_code.js` — NEW (ShardedIntegrationTestType)
+- `options.js` — EXTEND (some option validation covered but not invalid DB/collection names, `--jsonArray` with non-array input, type mismatches, or conflicting positional args)
+- `parse_grace.js` — NEW
+- `replset.js` — NEW (ReplSetTestType)
+- `stoponerror.js` — SKIP (covered by `mongoimport_test.go`)
+- `type_case.js` — NEW
+- `typed_fields.js` — EXTEND (typed_fields_test.go covers header parsing at unit level but no end-to-end `--columnsHaveTypes` verifying actual database contents)
+- `types.js` — NEW (round-trip of all BSON types including BinData, Boolean, Array, NumberLong, MinKey, MaxKey, ISODate, DBRef, etc.)
 
 Read `mongoimport_test.go` (1525 lines), `csv_test.go`, `json_test.go`, `tsv_test.go`, and `typed_fields_test.go` before starting.
 
-The JS tests cover: write concerns (standalone and mongos), `--drop` flag, `--fields`, document validation, type preservation, `--mode` (upsert/insert/merge/delete), upsert with subdocument IDs, parse grace, replica set behavior, `--stopOnError`, error codes for no-primary, boolean types, Decimal128, typed fields.
-
 The mongoimport API: `mongoimport.MongoImport{ToolOptions: opts, IngestOptions: ingestOpts, InputOptions: inputOpts}`, then `mi.ImportDocuments()`.
 
-- [ ] **Step 1: Triage** — check which JS tests have Go equivalents in `mongoimport_test.go`.
+- [ ] **Step 1: Convert `boolean_type.js`** (NEW) — `TestImportBooleanType`: import a JSON file with `Boolean()` objects, verify they round-trip as BSON booleans.
 
-- [ ] **Step 2: Convert `drop.js`** — `TestImportDrop`: import docs, import again with `--drop`, verify collection was replaced not appended.
+- [ ] **Step 2: Convert `collections.js`** (EXTEND) — Add cases to `TestMongoImportValidateSettings` covering: multi-dot filenames, positional arguments for collection name, `--db` combined with positional arg.
 
-- [ ] **Step 3: Convert `mode.js`** — `TestImportModes`: test each mode (insert, upsert, merge, delete) by importing data over pre-existing documents and verifying the resulting state.
+- [ ] **Step 3: Convert `decimal128.js`** (NEW) — `TestImportDecimal128`: export a document with a Decimal128 field as Extended JSON, import it back, verify the field is stored as BSON Decimal128.
 
-- [ ] **Step 4: Convert `mode_upsert_id_subdoc.js`** — `TestImportUpsertSubdocumentID`: import documents whose `_id` is a subdocument, verify upsert uses the full subdoc as the key.
+- [ ] **Step 4: Convert `fields.js`** (EXTEND) — Add to existing field tests: `--fieldFile` option, nested dotted field names, and CSV rows with more fields than the header.
 
-- [ ] **Step 5: Convert `import_document_validation.js`** — `TestImportDocumentValidation`: create a collection with a `$jsonSchema` validator, import documents that violate it, verify appropriate error or bypass behavior.
+- [ ] **Step 5: Convert `import_document_validation.js`** (NEW) — `TestImportDocumentValidation`: create a collection with a `$jsonSchema` validator, import documents that violate it, verify rejection; test `--bypassDocumentValidation` and `--stopOnError` with validation errors.
 
-- [ ] **Step 6: Convert `stoponerror.js`** — `TestImportStopOnError`: import a file with one bad document; with `--stopOnError`, verify import halts; without it, verify import continues.
+- [ ] **Step 6: Convert `import_types.js`** (NEW) — `TestImportTypes`: import a legacy Extended JSON file containing all BSON types, verify each field's `$type` in the database.
 
-- [ ] **Step 7: Convert `boolean_type.js`** — `TestImportBooleanType`: verify boolean values in CSV/JSON import are preserved as BSON booleans.
+- [ ] **Step 7: Convert `mode.js`** (EXTEND) — Add missing cases to existing mode tests: `--mode=merge` (preserving pre-existing fields), compound `--upsertFields` with non-`_id` fields, and legacy `--upsert` flag.
 
-- [ ] **Step 8: Convert `decimal128.js`** — `TestImportDecimal128`: verify Decimal128 values in Extended JSON are correctly imported as BSON Decimal128.
+- [ ] **Step 8: Convert `mode_upsert_id_subdoc.js`** (EXTEND) — Add case to `mongoimport_test.go`: import documents whose `_id` is a subdocument, verify upsert uses the full subdoc as the key.
 
-- [ ] **Step 9: Convert `fields.js`** — `TestImportFields`: verify `--fields` option correctly maps CSV columns to BSON field names.
+- [ ] **Step 9: Convert `options.js`** (EXTEND) — Add to `TestMongoImportValidateSettings`: invalid DB/collection names, `--jsonArray` with non-array input, type mismatches, conflicting positional args.
 
-- [ ] **Step 10: Convert `typed_fields.js` and `parse_grace.js`** — Extend or add to existing `typed_fields_test.go`. Verify typed field specifiers (e.g., `name.string()`, `age.int32()`) and `--parseGrace` behavior.
+- [ ] **Step 10: Convert `parse_grace.js`** (NEW) — `TestImportParseGrace`: verify `--parseGrace` behavior (stop, skipRow, skipField) when fields contain type conversion errors.
 
-- [ ] **Step 11: Convert `import_write_concern.js`** — `TestImportWriteConcern`: import with `--writeConcern w:2` against a single node; verify appropriate error. Test with `w:1` that it succeeds.
+- [ ] **Step 11: Convert `type_case.js`** (NEW) — `TestImportTypeCase`: verify type name case insensitivity when specifying type formats.
 
-- [ ] **Step 12: Convert topology-specific tests**
+- [ ] **Step 12: Convert `typed_fields.js`** (EXTEND) — Add end-to-end test to `typed_fields_test.go` (or `mongoimport_test.go`): import a CSV with `--columnsHaveTypes`, verify actual database contents match the declared types.
 
-  - `import_write_concern_mongos.js` → `TestImportWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Import with write concern against a mongos endpoint, verify it succeeds.
-  - `replset.js` → `TestImportReplSet`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Test mongoimport against a replica set URI.
-  - `all_primaries_down_error_code.js`, `no_primary_error_code.js` → guard with `testtype.ReplSetTestType`. These require stopping primaries; add as `TestImportNoPrimaryErrorCode` using `mongo.Client` failpoints or by pointing at an unreachable replica set URI.
+- [ ] **Step 13: Convert `types.js`** (NEW) — `TestImportAllBSONTypes`: verify round-trip export-then-import preserves all BSON types (BinData, Boolean, Array, embedded doc, NumberLong, MinKey, MaxKey, ISODate, DBRef, etc.).
 
-- [ ] **Step 13: Convert `collections.js`, `import_types.js`, `types.js`, `type_case.js`** as additional cases in the main test file, covering import of multiple collections and all BSON type round-trips.
+- [ ] **Step 14: Convert `import_write_concern.js`** (NEW) — `TestImportWriteConcern`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Import with `--writeConcern w:2` against a single node; verify appropriate error. Test with `w:1` that it succeeds.
 
-- [ ] **Step 14: Convert `options.js`** — `TestImportOptionValidation`: verify invalid flag combinations return errors.
+- [ ] **Step 15: Convert `replset.js`** (NEW) — `TestImportReplSet`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Test mongoimport against a replica set URI.
 
-- [ ] **Step 15: Run the new tests**
+- [ ] **Step 16: Convert sharded topology tests** (NEW)
+
+  - `import_write_concern_mongos.js` → `TestImportWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Import with write concern against a mongos endpoint, verify it succeeds.
+  - `all_primaries_down_error_code.js` → `TestImportAllPrimariesDownErrorCode`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`.
+  - `no_primary_error_code.js` → `TestImportNoPrimaryErrorCode`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`.
+
+- [ ] **Step 17: Run the new tests**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongoimport/... -v -count=1
@@ -358,7 +371,7 @@ TOOLS_TESTING_TYPE=integration go test ./mongoimport/... -v -count=1
 
 Expected: all PASS.
 
-- [ ] **Step 16: Delete JS files, commit**
+- [ ] **Step 18: Delete JS files, commit**
 
 ```bash
 rm -r test/qa-tests/jstests/import/
@@ -372,40 +385,58 @@ git commit -m "migration: convert mongoimport JS tests to Go"
 
 ### Task 5: Convert mongofiles JS tests
 
-**JS files:** `test/qa-tests/jstests/files/` (~16 files)
+**JS files:** `test/qa-tests/jstests/files/` (16 files)
 **Go target:** `mongofiles/mongofiles_test.go`
+
+Audit results from the annotations:
+- `mongofiles_db.js` — NEW (no Go test verifies `--db` routes files to the correct non-default database)
+- `mongofiles_delete.js` — SKIP (covered by `mongofiles_test.go`)
+- `mongofiles_get.js` — EXTEND (Go tests cover get and get_id to file but not get-to-stdout via `--local -`)
+- `mongofiles_host.js` — NEW (no Go test validates `--host` behavior)
+- `mongofiles_invalid.js` — EXTEND (`TestValidArguments` covers invalid command but not invalid CLI option `--invalid`)
+- `mongofiles_list.js` — SKIP (covered by `mongofiles_test.go`)
+- `mongofiles_local.js` — EXTEND (Go tests cover `--local` for get but not for put, empty `--local` string, or nonexistent file)
+- `mongofiles_port.js` — NEW (no Go test validates `--port` behavior)
+- `mongofiles_prefix.js` — NEW (no Go test validates `--prefix` routing to custom GridFS collection)
+- `mongofiles_put.js` — EXTEND (Go tests cover basic put and content verification but not large multi-chunk files 40MB+ or put-of-a-directory-fails)
+- `mongofiles_replace.js` — NEW
+- `mongofiles_search.js` — NEW
+- `mongofiles_type.js` — NEW
+- `mongofiles_version.js` — NEW (no Go test verifies `--version` output; goes in `common/options/options_test.go` to cover all tools at once)
+- `mongofiles_write_concern.js` — NEW (ReplSetTestType)
+- `mongofiles_write_concern_mongos.js` — NEW (ShardedIntegrationTestType)
 
 Read `mongofiles/mongofiles_test.go` in full before starting.
 
-The JS tests cover: put, get, list, delete, search, replace commands; `--db`, `--host`, `--port`, `--local`, `--prefix`, `--type`, `--version` options; write concern (standalone and mongos).
-
 The mongofiles API: `mongofiles.MongoFiles{ToolOptions: opts, StorageOptions: storageOpts}`, then `mf.Run()`.
 
-- [ ] **Step 1: Triage** — check which JS tests have Go equivalents.
+- [ ] **Step 1: Convert `mongofiles_get.js`** (EXTEND) — Add case to existing get tests: get-to-stdout by passing `--local -`, verify output matches file content.
 
-- [ ] **Step 2: Convert `mongofiles_put.js` and `mongofiles_get.js`** — `TestMongoFilesPutGet`: put a temp file into GridFS, get it back to another temp file, verify byte-for-byte equality.
+- [ ] **Step 2: Convert `mongofiles_invalid.js`** (EXTEND) — Add case to `TestValidArguments`: verify passing an invalid CLI option (`--invalid`) returns an appropriate error.
 
-- [ ] **Step 3: Convert `mongofiles_list.js`** — `TestMongoFilesList`: put several files, list them, verify all appear in output.
+- [ ] **Step 3: Convert `mongofiles_local.js`** (EXTEND) — Add cases: `--local` for put specifying a custom path; empty `--local` string fails; `--local` pointing to a nonexistent file for put fails.
 
-- [ ] **Step 4: Convert `mongofiles_delete.js`** — `TestMongoFilesDelete`: put a file, delete it, verify it no longer appears in list.
+- [ ] **Step 4: Convert `mongofiles_put.js`** (EXTEND) — Add case: put a large multi-chunk file (40MB+) and verify all chunks are stored; verify put-of-a-directory fails.
 
-- [ ] **Step 5: Convert `mongofiles_search.js`** — `TestMongoFilesSearch`: put files with different names, search by prefix, verify only matching names returned.
+- [ ] **Step 5: Convert `mongofiles_db.js`** (NEW) — `TestMongoFilesDB`: put a file with `--db myfiles_test`, verify it appears in `myfiles_test.fs.files` and not in the default `test.fs.files`.
 
-- [ ] **Step 6: Convert `mongofiles_replace.js`** — `TestMongoFilesReplace`: put a file, replace it with different content, get it back, verify new content.
+- [ ] **Step 6: Convert `mongofiles_host.js`** (NEW) — `TestMongoFilesHost`: verify valid host succeeds, invalid/unreachable host fails with connection error.
 
-- [ ] **Step 7: Convert `mongofiles_local.js`** — `TestMongoFilesLocal`: verify `--local` specifies a custom local file path for get/put.
+- [ ] **Step 7: Convert `mongofiles_port.js`** (NEW) — `TestMongoFilesPort`: verify valid port succeeds, wrong or non-numeric port fails with appropriate error.
 
-- [ ] **Step 8: Convert `mongofiles_prefix.js`** — `TestMongoFilesPrefix`: verify `--prefix` changes the GridFS bucket name.
+- [ ] **Step 8: Convert `mongofiles_prefix.js`** (NEW) — `TestMongoFilesPrefix`: put a file with `--prefix mygridfs`, verify the file appears in `mygridfs.files` collection.
 
-- [ ] **Step 9: Convert `mongofiles_type.js`** — `TestMongoFilesType`: verify `--type` sets the MIME type on uploaded files.
+- [ ] **Step 9: Convert `mongofiles_replace.js`** (NEW) — `TestMongoFilesReplace`: put a file, replace it with different content, get it back, verify new content.
 
-- [ ] **Step 10: Convert `mongofiles_invalid.js`** — `TestMongoFilesInvalid`: verify invalid option combinations return errors.
+- [ ] **Step 10: Convert `mongofiles_search.js`** (NEW) — `TestMongoFilesSearch`: put files with different names, search by prefix, verify only matching names returned.
 
-- [ ] **Step 11: Convert `mongofiles_write_concern_mongos.js`** — `TestMongoFilesWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Run a GridFS put against a mongos with an explicit write concern, verify it succeeds.
+- [ ] **Step 11: Convert `mongofiles_type.js`** (NEW) — `TestMongoFilesType`: put a file with `--type image/png`, verify the contentType field in GridFS metadata.
 
-- [ ] **Step 12: Convert remaining option tests** (`mongofiles_db.js`, `mongofiles_host.js`, `mongofiles_port.js`) as option validation tests.
+- [ ] **Step 12: Convert `mongofiles_write_concern.js`** (NEW) — `TestMongoFilesWriteConcern`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Run a GridFS put with explicit write concern, verify it succeeds.
 
-- [ ] **Step 13: Run tests, delete JS files, commit**
+- [ ] **Step 13: Convert `mongofiles_write_concern_mongos.js`** (NEW) — `TestMongoFilesWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run a GridFS put against a mongos with explicit write concern, verify it succeeds.
+
+- [ ] **Step 14: Run tests, delete JS files, commit**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongofiles/... -v -count=1
@@ -421,25 +452,32 @@ git commit -m "migration: convert mongofiles JS tests to Go"
 **JS files:** `test/qa-tests/jstests/stat/` (7 files)
 **Go target:** `mongostat/mongostat_test.go`
 
-Read `mongostat/mongostat_test.go` before starting.
+Audit results from the annotations:
+- `stat_auth.js` — NEW (ShardedIntegrationTestType per annotation)
+- `stat_broken_pipe.js` — SKIP (OS-signal-level)
+- `stat_custom_headers.js` — NEW (ShardedIntegrationTestType)
+- `stat_discover.js` — SKIP (disabled per TOOLS-3018)
+- `stat_discover_shard.js` — NEW (ShardedIntegrationTestType)
+- `stat_header.js` — NEW (ShardedIntegrationTestType)
+- `stat_rowcount.js` — NEW (ShardedIntegrationTestType)
 
-The JS tests cover: authentication, broken pipe, custom headers, `--discover` (disabled in JS), `--discover` with shards, header output, `--rowcount`.
+Read `mongostat/mongostat_test.go` before starting.
 
 mongostat runs as a polling tool; Go tests should run it briefly (1–2 iterations) and verify output format.
 
-- [ ] **Step 1: Triage** — check existing Go coverage.
+- [ ] **Step 1: Convert `stat_header.js`** (NEW) — `TestMongoStatHeader`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run mongostat for 1 second, capture output, verify column headers appear in first line.
 
-- [ ] **Step 2: Convert `stat_header.js`** — `TestMongoStatHeader`: run mongostat for 1 second, capture output, verify column headers appear in first line.
+- [ ] **Step 2: Convert `stat_rowcount.js`** (NEW) — `TestMongoStatRowCount`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run mongostat with `--rowcount=3`, verify exactly 3 data rows appear before exit.
 
-- [ ] **Step 3: Convert `stat_rowcount.js`** — `TestMongoStatRowCount`: run mongostat with `--rowcount=3`, verify exactly 3 data rows appear before exit.
+- [ ] **Step 3: Convert `stat_custom_headers.js`** (NEW) — `TestMongoStatCustomHeaders`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run with custom field selection, verify header names match.
 
-- [ ] **Step 4: Convert `stat_custom_headers.js`** — `TestMongoStatCustomHeaders` (if not already covered): run with custom field selection, verify header names match.
+- [ ] **Step 4: Convert `stat_auth.js`** (NEW) — `TestMongoStatAuth`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Verify mongostat works with `--username`/`--password`.
 
-- [ ] **Step 5: Convert `stat_auth.js`** — Guard with `testtype.SkipUnlessTestType(t, testtype.AuthTestType)`. Verify mongostat works with `--username`/`--password`.
+- [ ] **Step 5: Convert `stat_discover_shard.js`** (NEW) — `TestMongoStatDiscoverShard`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run mongostat with `--discover` against a mongos, verify shard hosts appear in output.
 
-- [ ] **Step 6: Skip `stat_discover.js`** — it's already disabled in JS (TOOLS-3018 comment). Add `// MIGRATION: SKIP — discover mode disabled per TOOLS-3018`.
+- [ ] **Step 6: Skip `stat_discover.js`** — already disabled in JS per TOOLS-3018.
 
-- [ ] **Step 7: Convert `stat_discover_shard.js`** — `TestMongoStatDiscoverShard`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Run mongostat with `--discover` against a mongos, verify shard hosts appear in output. Skip `stat_broken_pipe.js` — broken pipe is OS-signal-level behavior.
+- [ ] **Step 7: Skip `stat_broken_pipe.js`** — broken pipe is OS-signal-level behavior.
 
 - [ ] **Step 8: Run tests, delete JS files, commit**
 
@@ -457,19 +495,26 @@ git commit -m "migration: convert mongostat JS tests to Go"
 **JS files:** `test/qa-tests/jstests/top/` (5 files)
 **Go target:** `mongotop/mongotop_test.go` (new file — only `options_test.go` exists today)
 
-The JS tests cover: JSON output format, report output structure, sharded clusters, stress testing, output validation.
+Audit results from the annotations:
+- `mongotop_json.js` — NEW (options_test.go only tests argument parsing; no Go test runs mongotop and verifies JSON output)
+- `mongotop_reports.js` — NEW (no Go test runs mongotop and verifies namespace activity reporting)
+- `mongotop_sharded.js` — NEW (ShardedIntegrationTestType)
+- `mongotop_stress.js` — NEW (note: stress tests should not be part of standard integration run)
+- `mongotop_validation.js` — NEW (options_test.go only tests positional argument parsing; no Go test covers invalid port, invalid rowcount, negative sleep time errors)
 
 - [ ] **Step 1: Create `mongotop/mongotop_test.go`** with package `mongotop`.
 
-- [ ] **Step 2: Convert `mongotop_json.js`** — `TestMongoTopJSONOutput`: run mongotop with `--json` for 1 iteration, parse JSON output, verify expected fields (`ns`, `totalMs`, `readMs`, `writeMs`) are present.
+- [ ] **Step 2: Convert `mongotop_json.js`** (NEW) — `TestMongoTopJSONOutput`: run mongotop with `--json` for 1 iteration, parse JSON output, verify expected fields (`ns`, `totalMs`, `readMs`, `writeMs`) are present.
 
-- [ ] **Step 3: Convert `mongotop_reports.js`** — `TestMongoTopReports`: run mongotop for 2 iterations, verify output rows appear for the test database's collections.
+- [ ] **Step 3: Convert `mongotop_reports.js`** (NEW) — `TestMongoTopReports`: run mongotop for 2 iterations, verify output rows appear for the test database's collections.
 
-- [ ] **Step 4: Convert `mongotop_validation.js`** — `TestMongoTopOutputValidation`: verify column alignment, header row presence, numeric values in output.
+- [ ] **Step 4: Convert `mongotop_validation.js`** (NEW) — `TestMongoTopValidation`: verify that invalid port, invalid rowcount value, and negative sleep time each return appropriate errors.
 
-- [ ] **Step 5: Convert `mongotop_sharded.js`** — `TestMongoTopSharded`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Run mongotop against a mongos, verify per-shard namespace output. Skip `mongotop_stress.js` — stress tests are not appropriate for a standard integration test run.
+- [ ] **Step 5: Convert `mongotop_sharded.js`** (NEW) — `TestMongoTopSharded`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Run mongotop against a mongos, verify per-shard namespace output.
 
-- [ ] **Step 6: Run tests, delete JS files, commit**
+- [ ] **Step 6: Skip `mongotop_stress.js`** — stress tests are not appropriate for a standard integration test run. If desired, add as a separate stress test binary later.
+
+- [ ] **Step 7: Run tests, delete JS files, commit**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongotop/... -v -count=1
@@ -484,65 +529,77 @@ git commit -m "migration: convert mongotop JS tests to Go"
 
 ### Task 8: Convert mongodump JS tests
 
-**JS files:** `test/qa-tests/jstests/dump/` (~20 files) and `jstests/txn/active-txn-timestamp.js`
+**JS files:** `test/qa-tests/jstests/dump/` (~22 files) and `jstests/txn/active-txn-timestamp.js`
 **Go target:** `mongodump/mongodump_qa_test.go` (new file)
 
-Read all of `mongodump/mongodump_test.go` (2537 lines) before starting. Note which scenarios are already covered so you don't duplicate them.
+Audit results from the annotations:
+- `collection_flag_tests.js` — NEW (no Go test verifies `--collection` dumps only the named collection)
+- `db_flag_tests.js` — NEW (no Go test inserts into two DBs, dumps one with `--db`, and verifies exclusion)
+- `dump_broken_pipe.js` — SKIP (OS-signal-level)
+- `dump_db_users_and_roles_tests.js` — EXTEND (main scenario covered but missing "no users exist" error and `--dumpDbUsersAndRoles` without `--db` error; goes in `mongorestore/dumprestore_auth_test.go`)
+- `dumping_dropped_collections.js` — SKIP (test was already disabled per TOOLS-3019)
+- `dump_server_ko_test.js` — NEW (no Go coverage)
+- `dump_views.js` — EXTEND (`TestMongoDumpViews` checks metadata files but no Go test restores and verifies view data round-trip or `--viewsAsCollections` behavior)
+- `exclude_collections_with_prefix_tests.js` — NEW (no Go coverage)
+- `exclude_collection_tests.js` — NEW (no Go coverage)
+- `force_table_scan_tests.js` — NEW (no Go coverage)
+- `no_sharded_secondary_reads.js` — SKIP (disabled per TOOLS-2661)
+- `oplog_admin_sys_version_test.js` — NEW (no Go coverage; ReplSetTestType; goes in `oplog_dump_test.go`)
+- `oplog_flag_tests.js` — EXTEND (add to `TestMongoDumpOplog`)
+- `oplog_rename_test.js` — NEW (ReplSetTestType; goes in `oplog_dump_test.go`)
+- `oplog_rollover_test.js` — NEW (ReplSetTestType; goes in `oplog_dump_test.go`)
+- `options_json.js` — NEW (no Go coverage)
+- `out_flag_tests.js` — NEW (no Go test covers `--out -` error cases or `--out` to custom directory with restore)
+- `query_extended_json.js` — NEW (no Go test verifies Extended JSON types in `--query`)
+- `query_flag_tests.js` — EXTEND (`TestMongoDumpOrderedQuery` and `TestMongoDumpBSON` cover success paths but missing error cases: without `--db`, without `--collection`, nonexistent `--queryFile`)
+- `read_preference_and_tags.js` — NEW (ReplSetTestType; no Go coverage)
+- `version_test.js` — NEW (no Go test verifies that mongorestore with `-vvv` on an archive dump prints archive format version, server version, and tool version)
+- `active-txn-timestamp.js` (txn/) — SKIP (disabled per TOOLS-2660)
 
-Create `mongodump/mongodump_qa_test.go` with `package mongodump`. It should import the same packages as `mongodump_test.go`.
+Read all of `mongodump/mongodump_test.go` (2537 lines) before starting. Create `mongodump/mongodump_qa_test.go` with `package mongodump`.
 
-- [ ] **Step 1: Triage** `dump/` JS files against `mongodump_test.go`. Mark each as SKIP/EXTEND/NEW.
+- [ ] **Step 1: Convert `collection_flag_tests.js`** (NEW) — `TestDumpCollectionFlag`: verify `--collection` requires `--db`, and limits dump to only the specified collection excluding other collections.
 
-Key existing Go coverage to check against:
-- `TestMongoDumpBSON` — general dump/restore roundtrip
-- `TestMongoDumpViews` / `TestMongoDumpViewsAsCollections` — view handling
-- `TestMongoDumpOplog` — oplog flag
-- `TestMongoDumpMetaData` — metadata output
-- `TestMongoDump*` for various edge cases
+- [ ] **Step 2: Convert `db_flag_tests.js`** (NEW) — `TestDumpDBFlag`: insert into two databases, dump only one with `--db`, verify only that DB's BSON files exist in the output and the other DB is absent.
 
-- [ ] **Step 2: Convert `collection_flag_tests.js`** — `TestDumpCollectionFlag`: verify `--collection` requires `--db`, and limits dump to only the specified collection.
+- [ ] **Step 3: Convert `exclude_collection_tests.js`** (NEW) — `TestDumpExcludeCollection`: verify `--excludeCollection` flag excludes named collections; verify it cannot be used with `--collection`.
 
-- [ ] **Step 3: Convert `db_flag_tests.js`** — `TestDumpDBFlag`: populate two databases, dump only one with `--db`, verify only that DB's BSON files exist in the output.
+- [ ] **Step 4: Convert `exclude_collections_with_prefix_tests.js`** (NEW) — `TestDumpExcludeCollectionWithPrefix`: verify `--excludeCollectionsWithPrefix` glob matching excludes all matching collections.
 
-- [ ] **Step 4: Convert `exclude_collection_tests.js`** — `TestDumpExcludeCollection`: verify `--excludeCollection` flag excludes named collections; verify it cannot be used with `--collection`.
+- [ ] **Step 5: Convert `query_flag_tests.js`** (EXTEND) — Add error cases to existing query tests: `--query` without `--db`, `--query` without `--collection`, and nonexistent `--queryFile`.
 
-- [ ] **Step 5: Convert `exclude_collections_with_prefix_tests.js`** — `TestDumpExcludeCollectionWithPrefix`: verify `--excludeCollectionsWithPrefix` glob matching.
+- [ ] **Step 6: Convert `query_extended_json.js`** (NEW) — `TestDumpQueryExtendedJSON`: dump with Extended JSON query types (`$date`, `$regex`, `$oid`, `$minKey`, `$maxKey`), verify correct filtering.
 
-- [ ] **Step 6: Convert `query_flag_tests.js`** — `TestDumpQueryFlag`: insert 20 docs, dump with `--query '{"x": {"$gt": 10}}'`, verify only matching docs appear in BSON output.
+- [ ] **Step 7: Convert `out_flag_tests.js`** (NEW) — `TestDumpOutFlag`: verify `--out -` fails without `--db`/`--collection`; verify `--out` to a custom directory combined with restore produces correct results.
 
-- [ ] **Step 7: Convert `query_extended_json.js`** — `TestDumpQueryExtendedJSON`: dump with an Extended JSON query (e.g., containing `$oid`), verify correct filtering.
+- [ ] **Step 8: Convert `force_table_scan_tests.js`** (NEW) — `TestDumpForceTableScan`: verify `--forceTableScan` completes without error.
 
-- [ ] **Step 8: Convert `out_flag_tests.js`** — `TestDumpOutFlag`: verify `--out` controls output directory path; verify default is `dump/`.
+- [ ] **Step 9: Convert `dump_views.js`** (EXTEND) — Add cases to dump views test: restore view and verify data matches the view's pipeline output; test `--viewsAsCollections` behavior.
 
-- [ ] **Step 9: Convert `force_table_scan_tests.js`** — `TestDumpForceTableScan`: verify `--forceTableScan` completes without error on a capped collection (where it would normally be required).
+- [ ] **Step 10: Convert `dump_db_users_and_roles_tests.js`** (EXTEND) — In `mongorestore/dumprestore_auth_test.go`, add: "no users exist" error case and `--dumpDbUsersAndRoles` without `--db` error case.
 
-- [ ] **Step 10: Convert `dump_views.js`** — If not already covered by `TestMongoDumpViews`, add cases for views created with `--viewOn` and pipeline, verify dump produces correct metadata.
+- [ ] **Step 11: Convert `oplog_flag_tests.js`** (EXTEND) — Add sub-cases to `TestMongoDumpOplog`: verify oplog file is created; verify oplog entries from during the dump are captured.
 
-- [ ] **Step 11: Convert `dump_db_users_and_roles_tests.js`** — `TestDumpUsersAndRoles` (under `testtype.AuthTestType`): dump a database that has custom users/roles, verify user/role documents appear in the dump output.
+- [ ] **Step 12: Convert `dump_server_ko_test.js`** (NEW) — `TestDumpServerKO`: verify mongodump handles a server that becomes unavailable during the dump with an appropriate error. Guard carefully against flakiness.
 
-- [ ] **Step 12: Convert `oplog_flag_tests.js`** — If not already covered by `TestMongoDumpOplog`, add sub-cases: oplog file is created, oplog entries from during the dump are captured.
+- [ ] **Step 13: Convert `options_json.js`** (NEW) — `TestDumpOptionsJSON`: verify `--out` and other options in combination work correctly.
 
-- [ ] **Step 13: Convert `oplog_rename_test.js`** — `TestDumpOplogRename`: perform a collection rename during a dump with `--oplog`, verify the rename is captured in the oplog output.
+- [ ] **Step 14: Convert `oplog_rename_test.js`** (NEW) — Guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Goes in `oplog_dump_test.go` (create if needed). Perform a collection rename during a dump with `--oplog`, verify the rename is captured.
 
-- [ ] **Step 14: Convert `oplog_rollover_test.js`** — `TestDumpOplogRollover`: verify mongodump exits with an error when the oplog rolls over during a dump.
+- [ ] **Step 15: Convert `oplog_rollover_test.js`** (NEW) — Guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Verify mongodump exits with an error when the oplog rolls over during a dump.
 
-- [ ] **Step 15: Convert `oplog_admin_sys_version_test.js`** — `TestDumpOplogAdminSysVersion`: verify admin and system collections appear correctly in oplog dump.
+- [ ] **Step 16: Convert `oplog_admin_sys_version_test.js`** (NEW) — Guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Verify admin and system collections appear correctly in oplog dump.
 
-- [ ] **Step 16: Convert `options_json.js`** — `TestDumpOptionsJSON`: verify `--out` and other options in combination.
+- [ ] **Step 17: Convert `read_preference_and_tags.js`** (NEW) — Guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Verify `--readPreference` is accepted and dump completes.
 
-- [ ] **Step 17: Convert `read_preference_and_tags.js`** — `TestDumpReadPreference`: verify `--readPreference` is accepted; if no secondary is available, test that primary mode still works.
-
-- [ ] **Step 18: Convert `no_sharded_secondary_reads.js`** — `TestDumpNoShardedSecondaryReads`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Run mongodump against a mongos with `--readPreference=secondary`; verify it exits with an error (or falls back to primary, depending on expected behavior).
-
-- [ ] **Step 19: Skip the following** — add `// MIGRATION: SKIP` comments:
+- [ ] **Step 18: Skip the following:**
   - `dump_broken_pipe.js` — OS-level signal handling
-  - `dump_server_ko_test.js` — server crash simulation (hard to replicate cleanly in Go)
-  - `dumping_dropped_collections.js` — race condition test, not reliably reproducible
-  - `version_test.js` — trivially covered by option parsing tests
+  - `dumping_dropped_collections.js` — disabled per TOOLS-3019
+  - `no_sharded_secondary_reads.js` — disabled per TOOLS-2661
+  - `version_test.js` → convert: `TestRestoreArchiveVersionStrings` in `mongorestore/mongorestore_qa_test.go`: dump one doc to an archive, restore with `-vvv`, verify output contains archive format version, server version, and tool version strings
+  - `active-txn-timestamp.js` — disabled per TOOLS-2660
 
-- [ ] **Step 19: Convert `active-txn-timestamp.js`** (txn/) — Check if it's disabled (JS has a disable comment per TOOLS-2660); if still disabled, add `// MIGRATION: SKIP — disabled per TOOLS-2660`.
-
-- [ ] **Step 20: Run the new tests**
+- [ ] **Step 19: Run the new tests**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongodump/... -v -count=1
@@ -550,7 +607,7 @@ TOOLS_TESTING_TYPE=integration go test ./mongodump/... -v -count=1
 
 Expected: all PASS.
 
-- [ ] **Step 21: Delete JS files, commit**
+- [ ] **Step 20: Delete JS files, commit**
 
 ```bash
 rm -r test/qa-tests/jstests/dump/
@@ -565,79 +622,114 @@ git commit -m "migration: convert mongodump JS tests to Go"
 
 ### Task 9: Convert mongorestore core JS tests
 
-**JS files:** `test/qa-tests/jstests/restore/` — first pass: non-oplog, non-auth files (~20 files)
+**JS files:** `test/qa-tests/jstests/restore/` — non-oplog, non-auth files
 **Go target:** `mongorestore/mongorestore_qa_test.go` (new file)
 
-Read all of `mongorestore/mongorestore_test.go` (3879 lines) and `mongorestore/restore_test.go` before starting. The existing file is comprehensive; many JS tests will be SKIPs.
+Audit results (non-oplog, non-auth, non-sharded subset):
+- `archive_stdout.js` — EXTEND (pipe-based dump `--archive | restore --archive` with special characters not covered)
+- `bad_options.js` — NEW (ReplSetTestType)
+- `blank_collection_bson.js` — NEW (no Go test restores from blank .bson file with missing/blank metadata)
+- `blank_db.js` — NEW (no Go test restores from an empty directory with `--db`)
+- `collation.js` — EXTEND (`TestIndexGetsSimpleCollation` covers index collation but not collection-level collation round-trip)
+- `different_collection.js` — EXTEND (TestMongorestore covers nsFrom/nsTo same-DB rename but not: cross-database restore with --db/--collection, and --db/--collection with a direct .bson file path)
+- `different_db.js` — EXTEND (`--nsFrom`/`--nsTo` covered but `--db` dest path restoring a subdirectory is not)
+- `drop_nonexistent_db.js` — NEW (no Go test verifies `--drop` on a nonexistent DB succeeds without error)
+- `drop_one_collection.js` — NEW (no Go test verifies `--drop --db --collection` only drops the specified collection)
+- `drop_with_data.js` — EXTEND (no Go test specifically inserts different pre-existing data and verifies it is fully replaced)
+- `duplicate_keys.js` — EXTEND (`TestMongorestoreMIOSOE` covers dup key with stopOnError but not batch size iteration behavior)
+- `indexes.js` — EXTEND (`TestCreateIndexes` tests hashed indexes but no Go test creates/round-trips sparse, unique, compound, text, and 2dsphere indexes)
+- `index_version_roundtrip.js` — NEW (no Go test does round-trip with `--keepIndexVersion` verifying version values)
+- `invalid_dump_target.js` — NEW (no Go test passes invalid targets and checks errors)
+- `invalid_metadata.js` — NEW (no Go test verifies restore with invalid indexes in metadata.json fails)
+- `keep_index_version.js` — NEW (no Go test covers `--keepIndexVersion`)
+- `large_bulk.js` — NEW (no Go test creates 32 x ~1MB documents to verify bulk API respects 16MB BSON limit)
+- `malformed_bson.js` — NEW (no Go test restores malformed BSON and verifies failure)
+- `malformed_metadata.js` — NEW (no Go test restores with malformed metadata.json and verifies failure)
+- `missing_dump.js` — NEW (no Go test passes nonexistent paths and verifies error)
+- `multiple_dbs.js` — EXTEND (`TestMongorestore` restores from testdata but does not explicitly verify per-collection document counts)
+- `namespaces.js` — EXTEND (`--nsExclude`, `--nsInclude`, `--nsFrom`/`--nsTo` covered but not `--excludeCollectionsWithPrefix` or complex pattern variables)
+- `no_index_restore.js` — EXTEND (Go tests use `--noIndexRestore` only in timeseries context; no Go test verifies general case)
+- `nonempty_temp_users.js` — EXTEND (`TestRestoreUsersOrRoles` covers cleanup but not the case where `admin.tempusers` already contains data before restore)
+- `no_options_restore.js` — EXTEND (Go tests use `--noOptionsRestore` only in timeseries context; no Go test verifies capped → non-capped or validator stripping)
+- `norestore_profile.js` — NEW (no Go test specifically verifies system.profile is not restored)
+- `objcheck_valid_bson.js` — EXTEND (no Go test explicitly passes `--objcheck` and verifies the flag is accepted)
+- `partial_restore.js` — EXTEND (`--nsInclude` for single-collection restore covered but not `--db` path with subdirectory target)
+- `restore_document_validation.js` — NEW (no Go test for validated collection + restore rejection + `--bypassDocumentValidation`)
+- `slash_in_collectionname.js` — SKIP (covered by `mongorestore_test.go`)
+- `stop_on_error.js` — SKIP (covered by `mongorestore_test.go`)
+- `symlinks.js` — NEW (no Go test exercises restoring from dump directory with symlinked files)
+- `users_and_roles_temp_collections.js` — EXTEND (`TestRestoreUsersOrRoles` covers cleanup but not `--tempUsersColl` and `--tempRolesColl` custom temp collection name options)
+- `write_concern.js` — NEW (ReplSetTestType)
 
-Create `mongorestore/mongorestore_qa_test.go` with `package mongorestore`.
+Read all of `mongorestore/mongorestore_test.go` (3879 lines) and `mongorestore/restore_test.go` before starting. Create `mongorestore/mongorestore_qa_test.go` with `package mongorestore`.
 
-- [ ] **Step 1: Triage** all `restore/` JS files against existing Go tests.
+- [ ] **Step 1: Convert `archive_stdout.js`** (EXTEND) — Add to `mongorestore_archive_test.go` or `mongorestore_qa_test.go`: pipe-based `dump --archive | restore --archive` with special characters in collection names.
 
-Key existing Go coverage to check for:
-- Archive handling (`mongorestore_archive_test.go`)
-- Index restoration (`mongorestore_test.go` — look for TestMongorestore*Index*)
-- Transaction handling (`mongorestore_txn_test.go`)
-- Oplog replay (`oplog_test.go`)
-- Auth tests (`dumprestore_auth_test.go`)
-- Metadata tests (`metadata_test.go`)
-- Filepath tests (`filepath_test.go`)
-- Namespace handling (`ns/ns_test.go`)
+- [ ] **Step 2: Convert `blank_collection_bson.js`** (NEW) — `TestRestoreBlankCollectionBSON`: restore from a blank `.bson` file with missing or blank metadata; verify it succeeds without error.
 
-- [ ] **Step 2: Convert `indexes.js`** — `TestRestoreIndexes`: dump a collection with text, 2dsphere, sparse, unique, and compound indexes; restore it; verify all indexes are recreated with correct properties.
+- [ ] **Step 3: Convert `blank_db.js`** (NEW) — `TestRestoreBlankDB`: restore from an empty directory with `--db`; verify it completes without error.
 
-- [ ] **Step 3: Convert `index_version_roundtrip.js`** — `TestRestoreIndexVersionRoundtrip`: verify index version (v1/v2) is preserved after dump/restore cycle.
+- [ ] **Step 4: Convert `collation.js`** (EXTEND) — Add to restore tests: dump a collection with a collection-level collation, restore it, verify the collation setting is preserved on the restored collection.
 
-- [ ] **Step 4: Convert `keep_index_version.js`** — `TestRestoreKeepIndexVersion`: verify `--keepIndexVersion` flag prevents index version upgrade during restore.
+- [ ] **Step 5: Convert `different_db.js`** (EXTEND) — Add case: restore a subdirectory dump using `--db` to target a different destination database, verify data lands correctly.
 
-- [ ] **Step 5: Convert `no_index_restore.js`** — `TestRestoreNoIndexRestore`: restore with `--noIndexRestore`, verify no indexes are created (other than `_id`).
+- [ ] **Step 6: Convert `drop_nonexistent_db.js`** (NEW) — `TestRestoreDropNonexistentDB`: pass `--drop` when the target database does not exist; verify success without error.
 
-- [ ] **Step 6: Convert `collation.js`** — `TestRestoreCollation`: dump a collection with a collation-based index, restore, verify collation settings are preserved.
+- [ ] **Step 7: Convert `drop_one_collection.js`** (NEW) — `TestRestoreDropOneCollection`: insert data into multiple collections, then restore with `--drop --db --collection` for only one of them; verify only the specified collection is dropped and replaced.
 
-- [ ] **Step 7: Convert `different_collection.js`** — `TestRestoreDifferentCollection`: restore with `--nsFrom` / `--nsTo`, verify data lands in the renamed collection.
+- [ ] **Step 8: Convert `drop_with_data.js`** (EXTEND) — Add case: insert different pre-existing data into target, restore with `--drop`, verify the pre-existing data is fully replaced by the restored data.
 
-- [ ] **Step 8: Convert `different_db.js`** — `TestRestoreDifferentDB`: restore with database renaming, verify data in target DB.
+- [ ] **Step 9: Convert `duplicate_keys.js`** (EXTEND) — Add case to existing dup key tests: verify batch size iteration behavior when multiple batches contain duplicate keys.
 
-- [ ] **Step 9: Convert `drop_with_data.js` and `drop_one_collection.js`** — `TestRestoreDrop`: insert extra data into target, restore with `--drop`, verify the pre-existing data is gone.
+- [ ] **Step 10: Convert `indexes.js`** (EXTEND) — Add cases to index restoration tests: round-trip sparse, unique, compound, text, and 2dsphere indexes; verify each is correctly recreated.
 
-- [ ] **Step 10: Convert `duplicate_keys.js`** — `TestRestoreDuplicateKeys`: attempt to restore a dump containing documents with duplicate `_id` values; verify correct error behavior.
+- [ ] **Step 11: Convert `index_version_roundtrip.js`** (NEW) — `TestRestoreIndexVersionRoundtrip`: dump and restore with `--keepIndexVersion`; verify index version values are preserved.
 
-- [ ] **Step 11: Convert `malformed_bson.js` and `malformed_metadata.js` and `invalid_metadata.js`** — `TestRestoreMalformedInput`: write a temp `.bson` file with corrupted bytes; verify mongorestore returns an appropriate error.
+- [ ] **Step 12: Convert `invalid_dump_target.js`** (NEW) — `TestRestoreInvalidDumpTarget`: pass invalid targets (file instead of directory, file with `--db`, directory with `--collection`) and check for appropriate errors.
 
-- [ ] **Step 12: Convert `stop_on_error.js`** — `TestRestoreStopOnError`: restore a dump where some documents violate a unique index; with `--stopOnError`, verify restore halts.
+- [ ] **Step 13: Convert `invalid_metadata.js`** (NEW) — `TestRestoreInvalidMetadata`: restore a collection whose `metadata.json` contains invalid index definitions; verify failure.
 
-- [ ] **Step 13: Convert `blank_collection_bson.js`, `blank_db.js`, `missing_dump.js`** — `TestRestoreEdgeCases`: empty BSON file restores without error; empty DB directory restores without error; missing dump path returns helpful error.
+- [ ] **Step 14: Convert `keep_index_version.js`** (NEW) — `TestRestoreKeepIndexVersion`: verify `--keepIndexVersion` flag prevents index version upgrade during restore. Note: targets behavior on older server versions.
 
-- [ ] **Step 14: Convert `partial_restore.js`** — `TestRestorePartialNS`: use `--ns` to restore only a specific namespace from a multi-collection dump.
+- [ ] **Step 15: Convert `large_bulk.js`** (NEW) — `TestRestoreLargeBulk`: create 32 documents each ~1MB, dump and restore them; verify the bulk API respects the 16MB BSON document limit and all documents restore correctly.
 
-- [ ] **Step 15: Convert `namespaces.js`** — `TestRestoreNamespaces`: verify namespace mapping and filtering during restore.
+- [ ] **Step 16: Convert `malformed_bson.js`** (NEW) — `TestRestoreMalformedBSON`: write a temp `.bson` file with corrupted bytes; verify mongorestore returns an appropriate error.
 
-- [ ] **Step 16: Convert `slash_in_collectionname.js`** — `TestRestoreSlashInCollectionName`: dump/restore a collection whose name contains a forward slash.
+- [ ] **Step 17: Convert `malformed_metadata.js`** (NEW) — `TestRestoreMalformedMetadata`: restore with a syntactically invalid `metadata.json`; verify failure with a clear error.
 
-- [ ] **Step 17: Convert `symlinks.js`** — `TestRestoreSymlinks`: create a dump directory where a BSON file is actually a symlink; verify restore follows or correctly handles it.
+- [ ] **Step 18: Convert `missing_dump.js`** (NEW) — `TestRestoreMissingDump`: pass nonexistent paths (directory, with `--db`, with `--collection`); verify appropriate error messages.
 
-- [ ] **Step 18: Convert `large_bulk.js`** — `TestRestoreLargeBulk`: restore a dump with many documents (e.g., 10,000), verify correct count after restore.
+- [ ] **Step 19: Convert `multiple_dbs.js`** (EXTEND) — Add explicit per-collection document count assertions after restoring from a multi-DB dump (`testdata/testdirs` or equivalent).
 
-- [ ] **Step 19: Convert `write_concern.js`** — `TestRestoreWriteConcern`: restore with explicit write concern, verify it completes.
+- [ ] **Step 20: Convert `namespaces.js`** (EXTEND) — Add cases: `--excludeCollectionsWithPrefix` behavior and complex `--nsInclude`/`--nsExclude` pattern variables.
 
-- [ ] **Step 20: Convert `no_options_restore.js`, `norestore_profile.js`** — `TestRestoreNoOptions`: verify `--noOptionsRestore` prevents collection options (capped size, etc.) from being applied; `--noRestoreProfile` skips the system.profile collection.
+- [ ] **Step 21: Convert `no_index_restore.js`** (EXTEND) — Add case on a normal (non-timeseries) collection: restore with `--noIndexRestore`, verify no indexes are created beyond `_id`.
 
-- [ ] **Step 21: Convert sharded tests**
+- [ ] **Step 22: Convert `no_options_restore.js`** (EXTEND) — Add cases: dump a capped collection and a collection with a validator, restore with `--noOptionsRestore`, verify the collection is non-capped and validator is stripped.
 
-  - `sharded_fullrestore.js` → `TestRestoreShardedFullRestore`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Dump a sharded cluster, restore to a fresh sharded cluster (pointed at mongos), verify all collections and their shard distributions are restored correctly.
-  - `write_concern_mongos.js` → `TestRestoreWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedTestType)`. Restore with explicit write concern against a mongos, verify it succeeds.
+- [ ] **Step 23: Convert `norestore_profile.js`** (NEW) — `TestRestoreNorestoreProfile`: dump a database that includes system.profile, restore it, verify system.profile is not present in the restore target.
 
-- [ ] **Step 22: Skip the following** with SKIP comments:
-  - `archive_stdout.js` — check if already covered in `mongorestore_archive_test.go` first
-  - `objcheck_valid_bson.js` — if covered by existing tests
+- [ ] **Step 24: Convert `objcheck_valid_bson.js`** (EXTEND) — Add case: restore valid BSON with `--objcheck`, verify the flag is accepted and restore succeeds.
 
-- [ ] **Step 23: Run tests**
+- [ ] **Step 25: Convert `partial_restore.js`** (EXTEND) — Add case: restore a subdirectory using `--db` path targeting, verify only that subdirectory's collections are restored.
+
+- [ ] **Step 26: Convert `restore_document_validation.js`** (NEW) — `TestRestoreDocumentValidation`: create a validated collection, restore into it, verify rejection; test `--bypassDocumentValidation`; test `--stopOnError` with validation errors; test `--maintainInsertionOrder` with validation errors.
+
+- [ ] **Step 27: Convert `symlinks.js`** (NEW) — `TestRestoreSymlinks`: create a dump directory where a `.bson` file is a symlink to actual data; verify restore follows the symlink correctly.
+
+- [ ] **Step 28: Convert `users_and_roles_temp_collections.js`** (EXTEND) — Add cases: verify `--tempUsersColl` and `--tempRolesColl` options correctly name the custom temp collections during restore.
+
+- [ ] **Step 29: Convert `write_concern.js`** (NEW) — `TestRestoreWriteConcern`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Restore with explicit write concern; verify it completes.
+
+- [ ] **Step 30: Convert `bad_options.js`** (NEW) — `TestRestoreBadOptions`: guard with `testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)`. Verify invalid option combinations produce appropriate errors.
+
+- [ ] **Step 31: Run tests**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongorestore/... -v -count=1
 ```
 
-- [ ] **Step 24: Commit**
+- [ ] **Step 32: Commit**
 
 ```bash
 git add mongorestore/mongorestore_qa_test.go test/
@@ -648,38 +740,47 @@ git commit -m "migration: convert mongorestore core JS tests to Go"
 
 ### Task 10: Convert mongorestore oplog JS tests
 
-**JS files:** `test/qa-tests/jstests/restore/oplog_*.js` (~8 files)
-**Go target:** `mongorestore/oplog_test.go` (extend existing) or `mongorestore_qa_test.go`
+**JS files:** `test/qa-tests/jstests/restore/oplog_*.js` and `preserve_oplog_structure_order.js` (9 files)
+**Go target:** `mongorestore/oplog_test.go` (extend existing)
+
+Audit results from the annotations (all NEW, all ReplSetTestType):
+- `oplog_replay_and_limit.js` — NEW
+- `oplog_replay_conflict.js` — NEW
+- `oplog_replay_local_rs.js` — NEW
+- `oplog_replay_noop.js` — NEW
+- `oplog_replay_no_oplog.js` — NEW
+- `oplog_replay_priority_oplog.js` — NEW
+- `oplog_replay_size_safety.js` — NEW
+- `oplog_replay_specify_file.js` — NEW
+- `preserve_oplog_structure_order.js` — NEW
 
 Read `mongorestore/oplog_test.go` in full before starting.
 
-- [ ] **Step 1: Triage** each `oplog_replay_*.js` file against existing `oplog_test.go`.
+- [ ] **Step 1: Convert `oplog_replay_and_limit.js`** (NEW) — `TestOplogReplayWithLimit`: guard with `testtype.ReplSetTestType`. Create an oplog dump with many entries, restore with `--oplogLimit`, verify only entries before the limit are applied.
 
-- [ ] **Step 2: Convert `oplog_replay_and_limit.js`** — `TestOplogReplayWithLimit`: create an oplog dump with many entries, restore with `--oplogLimit`, verify only entries before the limit are applied.
+- [ ] **Step 2: Convert `oplog_replay_conflict.js`** (NEW) — `TestOplogReplayConflict`: guard with `testtype.ReplSetTestType`. Replay an oplog that inserts a document that already exists; verify conflict handling behavior.
 
-- [ ] **Step 3: Convert `oplog_replay_conflict.js`** — `TestOplogReplayConflict`: replay an oplog that inserts a document that already exists; verify conflict handling.
+- [ ] **Step 3: Convert `oplog_replay_local_rs.js`** (NEW) — `TestOplogReplayLocalRS`: guard with `testtype.ReplSetTestType`. Verify oplog replay works correctly against a replica set where the local DB is present.
 
-- [ ] **Step 4: Convert `oplog_replay_local_rs.js`** — Guard with `testtype.ReplSetTestType`. Verify oplog replay works correctly against a replica set where the local DB is present.
+- [ ] **Step 4: Convert `oplog_replay_noop.js`** (NEW) — `TestOplogReplayNoop`: guard with `testtype.ReplSetTestType`. Replay an oplog containing only no-op entries (type `n`), verify no errors and no data changes.
 
-- [ ] **Step 5: Convert `oplog_replay_noop.js`** — `TestOplogReplayNoop`: replay an oplog that contains only no-op entries (type `n`), verify no errors and no data changes.
+- [ ] **Step 5: Convert `oplog_replay_no_oplog.js`** (NEW) — `TestOplogReplayNoOplogFile`: guard with `testtype.ReplSetTestType`. Restore with `--oplogReplay` but no `oplog.bson` file present; verify appropriate error message.
 
-- [ ] **Step 6: Convert `oplog_replay_no_oplog.js`** — `TestOplogReplayNoOplogFile`: restore with `--oplogReplay` but no oplog.bson file; verify appropriate error message.
+- [ ] **Step 6: Convert `oplog_replay_priority_oplog.js`** (NEW) — `TestOplogReplayPriority`: guard with `testtype.ReplSetTestType`. Verify that `oplog.bson` at the root of the dump takes priority over per-DB oplog files.
 
-- [ ] **Step 7: Convert `oplog_replay_priority_oplog.js`** — `TestOplogReplayPriority`: verify that `oplog.bson` at the root of the dump takes priority over per-DB oplog files.
+- [ ] **Step 7: Convert `oplog_replay_size_safety.js`** (NEW) — `TestOplogReplaySizeSafety`: guard with `testtype.ReplSetTestType`. Attempt to replay an oplog entry exceeding the 16MB BSON document size limit; verify safe error handling.
 
-- [ ] **Step 8: Convert `oplog_replay_size_safety.js`** — `TestOplogReplaySizeSafety`: attempt to replay an oplog entry that exceeds the 16MB BSON document size limit; verify safe error handling.
+- [ ] **Step 8: Convert `oplog_replay_specify_file.js`** (NEW) — `TestOplogReplaySpecifyFile`: guard with `testtype.ReplSetTestType`. Use `--oplogFile` to point to a specific oplog dump file rather than the default location.
 
-- [ ] **Step 9: Convert `oplog_replay_specify_file.js`** — `TestOplogReplaySpecifyFile`: use `--oplogFile` to point to a specific oplog dump file rather than the default location.
+- [ ] **Step 9: Convert `preserve_oplog_structure_order.js`** (NEW) — `TestRestorePreserveOplogOrder`: guard with `testtype.ReplSetTestType`. Verify that operations within the same transaction are applied in order.
 
-- [ ] **Step 10: Convert `preserve_oplog_structure_order.js`** — `TestRestorePreserveOplogOrder`: verify that operations within the same transaction are applied in order.
-
-- [ ] **Step 11: Run tests**
+- [ ] **Step 10: Run tests**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./mongorestore/... -v -run ".*[Oo]plog.*" -count=1
 ```
 
-- [ ] **Step 12: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add mongorestore/oplog_test.go mongorestore/mongorestore_qa_test.go test/
@@ -690,24 +791,34 @@ git commit -m "migration: convert mongorestore oplog JS tests to Go"
 
 ### Task 11: Convert mongorestore users/roles + auth JS tests
 
-**JS files:** `restore/users_and_roles*.js`, `restore/drop_authenticated_user.js`, `restore/drop_nonexistent_db.js`, `restore/nonempty_temp_users.js`, `restore/extended_json_metadata.js`, `restore/ordered_partial_index.js`, `restore/restore_document_validation.js`
+**JS files:** `restore/users_and_roles*.js`, `restore/drop_authenticated_user.js`, `restore/nonempty_temp_users.js`, `restore/extended_json_metadata.js`, `restore/ordered_partial_index.js`, `restore/sharded_fullrestore.js`, `restore/write_concern_mongos.js`
 **Go target:** `mongorestore/dumprestore_auth_test.go` (extend) + `mongorestore_qa_test.go`
 
-- [ ] **Step 1: Triage** these files against `dumprestore_auth_test.go`.
+Audit results from the annotations:
+- `drop_authenticated_user.js` — EXTEND (`TestDumpRestorePreservesAdminUsersAndRoles` covers `--drop` but not verifying the restoring user itself survives the drop)
+- `extended_json_metadata.js` — NEW (ShardedIntegrationTestType)
+- `nonempty_temp_users.js` — EXTEND (`TestRestoreUsersOrRoles` covers cleanup but not the case where `admin.tempusers` already has data before restore begins)
+- `ordered_partial_index.js` — NEW (ShardedIntegrationTestType)
+- `sharded_fullrestore.js` — NEW (ShardedIntegrationTestType)
+- `users_and_roles_admin.js` — EXTEND (`TestDumpRestorePreservesAdminUsersAndRoles` covers many scenarios but missing dump-without-flag and `--drop`-override cases)
+- `users_and_roles.js` — EXTEND (`TestDumpRestoreSingleDBWithDBUsersAndRoles` covers main round-trip but `TestRestoreUsersOrRoles` only covers tempusers cleanup)
+- `write_concern_mongos.js` — NEW (ShardedIntegrationTestType)
 
-- [ ] **Step 2: Convert `users_and_roles.js`** — `TestRestoreUsersAndRoles` (under `testtype.AuthTestType`): dump a database with custom users and roles; restore it to a fresh database; verify users and roles are present.
+- [ ] **Step 1: Convert `users_and_roles.js`** (EXTEND) — In `dumprestore_auth_test.go`, add to `TestDumpRestoreSingleDBWithDBUsersAndRoles`: verify tempusers cleanup path fully (not just covered in `TestRestoreUsersOrRoles`).
 
-- [ ] **Step 3: Convert `users_and_roles_admin.js`** — `TestRestoreAdminUsersAndRoles` (under `testtype.AuthTestType`): similar but for admin database users.
+- [ ] **Step 2: Convert `users_and_roles_admin.js`** (EXTEND) — In `dumprestore_auth_test.go`, add to `TestDumpRestorePreservesAdminUsersAndRoles`: the dump-without-`--dumpDbUsersAndRoles` case and the `--drop`-override case.
 
-- [ ] **Step 4: Convert `users_and_roles_temp_collections.js` / `nonempty_temp_users.js`** — `TestRestoreTempUserCollections`: verify that temporary user collections (`system.new_users`, etc.) are handled correctly during restore.
+- [ ] **Step 3: Convert `nonempty_temp_users.js`** (EXTEND) — In `dumprestore_auth_test.go` or `mongorestore_qa_test.go`, add case: pre-populate `admin.tempusers` before starting restore; verify the restore correctly cleans up and replaces contents.
 
-- [ ] **Step 5: Convert `drop_authenticated_user.js`** — `TestRestoreDropWithAuthUser` (under `testtype.AuthTestType`): restore with `--drop` when the collection contains the currently-authenticated user; verify safe handling.
+- [ ] **Step 4: Convert `drop_authenticated_user.js`** (EXTEND) — In `dumprestore_auth_test.go`, add case: restore with `--drop` when the collection contains the currently-authenticated user; verify the restoring user itself survives the drop.
 
-- [ ] **Step 6: Convert `extended_json_metadata.js`** — `TestRestoreExtendedJSONMetadata`: create a `.metadata.json` file using Extended JSON format for index keys and collection options; verify correct parsing during restore.
+- [ ] **Step 5: Convert `extended_json_metadata.js`** (NEW) — `TestRestoreExtendedJSONMetadata`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Create a `metadata.json` file using Extended JSON format for index keys and collection options; verify correct parsing during restore.
 
-- [ ] **Step 7: Convert `restore_document_validation.js`** — `TestRestoreDocumentValidation`: restore with `--bypassDocumentValidation`, verify it bypasses schema validators.
+- [ ] **Step 6: Convert `ordered_partial_index.js`** (NEW) — `TestRestoreOrderedPartialIndex`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Dump/restore a collection with a partial index that has a sort key; verify correct restoration.
 
-- [ ] **Step 8: Convert `ordered_partial_index.js`** — `TestRestoreOrderedPartialIndex`: dump/restore a collection with a partial index that has a sort key; verify correct restoration.
+- [ ] **Step 7: Convert `sharded_fullrestore.js`** (NEW) — `TestRestoreShardedFullRestore`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Dump a sharded cluster, restore to a fresh sharded cluster (pointed at mongos), verify all collections and shard distributions are restored correctly.
+
+- [ ] **Step 8: Convert `write_concern_mongos.js`** (NEW) — `TestRestoreWriteConcernMongos`: guard with `testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)`. Restore with explicit write concern against a mongos; verify it succeeds.
 
 - [ ] **Step 9: Run tests**
 
@@ -730,17 +841,22 @@ git commit -m "migration: convert mongorestore users/roles JS tests to Go"
 ### Task 12: Convert SSL/TLS JS tests
 
 **JS files:** `test/qa-tests/jstests/ssl/ssl_with_system_ca.js`, `jstests/tls/tls_with_system_ca.js`
-**Go target:** These tests start their own mongod (per resmoke comment). In Go they should use `testtype.SSLTestType`.
+
+Audit results:
+- `ssl_with_system_ca.js` — NEW (no Go coverage; goes in new SSL integration test)
+- `tls_with_system_ca.js` — NEW (no Go coverage; goes in new TLS integration test)
 
 These tests verify that the tools can connect to MongoDB using the system's certificate authority store (not a custom CA file). This means connecting with `--tls` and without specifying `--tlsCAFile`.
 
-- [ ] **Step 1: Add `TestExportWithSystemCA`** to `mongoexport/mongoexport_test.go` under `testtype.SkipUnlessTestType(t, testtype.SSLTestType)`. Connect without specifying a CA file; verify export completes.
+- [ ] **Step 1: Create SSL integration test** — add `TestExportWithSystemCA` to a new file (e.g., `mongoexport/ssl_integration_test.go`) under `testtype.SkipUnlessTestType(t, testtype.SSLTestType)`. Connect without specifying a CA file; verify export completes.
 
-- [ ] **Step 2: The test needs a mongod running with a TLS cert signed by the system CA** — document in a comment that this test requires `TOOLS_TESTING_MONGOD` to point to a TLS-enabled mongod with a system-trusted certificate.
+- [ ] **Step 2: Create TLS integration test** — add `TestExportWithSystemTLSCA` similarly for the TLS variant.
 
-- [ ] **Step 3: Run the test** manually in a suitable environment to verify; mark as needing manual verification in CI setup notes.
+- [ ] **Step 3: Document requirements** — the tests require `TOOLS_TESTING_MONGOD` to point to a TLS-enabled mongod with a system-trusted certificate. Add a comment in the test file explaining this.
 
-- [ ] **Step 4: Delete JS files, commit**
+- [ ] **Step 4: Run the test** manually in a suitable environment to verify; mark as needing manual verification in CI setup notes.
+
+- [ ] **Step 5: Delete JS files, commit**
 
 ```bash
 rm -r test/qa-tests/jstests/ssl/
@@ -753,32 +869,105 @@ git commit -m "migration: convert SSL/TLS JS tests to Go"
 
 ### Task 13: Audit and convert legacy42 JS tests
 
-**JS files:** `test/legacy42/jstests/tool/` (~30 files)
+**JS files:** `test/legacy42/jstests/tool/` (34 files)
 
-These were removed from the MongoDB server in 4.2. Many will be covered by the tests already converted in Tasks 2–11.
+Audit results from the annotations:
+- `command_line_quotes.js` — NEW (goes in `common/util` test or tool-specific test)
+- `csv1.js` — EXTEND (csv_test.go covers unit-level CSV but no end-to-end CSV export then re-import with `--headerline`; goes in `mongoexport/mongoexport_test.go`)
+- `csvexport1.js` — NEW (no Go test exports BSON types to CSV and verifies formatting)
+- `csvexport2.js` — SKIP (csv_test.go covers CSV export variants)
+- `csvimport1.js` — EXTEND (csv_test.go covers parsing but no Go test covers end-to-end import of multiline CSV with embedded quotes, empty strings, and leading/trailing whitespace; goes in `mongoimport/mongoimport_test.go`)
+- `dumpauth.js` — EXTEND (`TestDumpRestoreEnforcesAuthRoles` covers backup/restore roles but not that system.profile is included in the dump; goes in `mongorestore/dumprestore_auth_test.go`)
+- `dumprestore10.js` — NEW (ReplSetTestType; goes in `dumprestore_auth_test.go`)
+- `dumprestore1.js` — EXTEND (basic dump/restore covered but missing `--collection` without `--db` error per SERVER-7721 and `--dir -` without `--db --collection` error; goes in `mongodump/mongodump_qa_test.go`)
+- `dumprestore3.js` — NEW (ReplSetTestType; goes in `mongorestore_test.go`)
+- `dumprestore4.js` — EXTEND (`TestMongorestore` covers nsFrom/nsTo rename and `TestCreateIndexes` covers index restoration, but no Go test restores to a renamed database and then verifies the index count on the renamed target; goes in `mongorestore/mongorestore_qa_test.go`)
+- `dumprestore6.js` — EXTEND (`TestUnversionedIndexes` covers v:0 index restoration but `--keepIndexVersion` scenario is commented out per TOOLS-3020; verify `TestUnversionedIndexes` covers this test's assertions before deleting; goes in `mongorestore/mongorestore_qa_test.go`)
+- `dumprestore7.js` — NEW (ReplSetTestType; goes in `mongorestore_test.go`)
+- `dumprestore8.js` — NEW (no Go test creates capped collections, dumps, restores, and verifies capped behavior; goes in `mongorestore/mongorestore_qa_test.go`)
+- `dumprestore9.js` — NEW (ShardedIntegrationTestType; goes in `mongorestore_test.go`)
+- `dumprestore_excludecollections.js` — NEW (no Go test covers `--excludeCollection` and `--excludeCollectionsWithPrefix` for mongodump including error cases; goes in `mongodump/mongodump_qa_test.go`)
+- `dumprestoreWithNoOptions.js` — EXTEND (Go tests use `--noOptionsRestore` only in timeseries context; no Go test verifies capped collections become non-capped across full/single-DB/single-collection restore; goes in `mongorestore/mongorestore_qa_test.go`)
+- `dumpsecondary.js` — NEW (ReplSetTestType; goes in `mongodump_test.go`)
+- `exportimport1.js` — NEW (no Go test covers export/import with undefined array elements and `--jsonArray` round-trip; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport3.js` — EXTEND (json_test.go covers format but no end-to-end `--jsonArray` export/import with 5 documents; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport4.js` — NEW (no Go test covers export/import with NaN values and query filters; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport5.js` — NEW (no Go test covers export/import with Infinity/-Infinity values and query filters; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport6.js` — NEW (no Go test covers `--sort`, `--skip`, `--limit` on export against real data; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport_bigarray.js` — NEW (no Go test covers `--jsonArray` export/import above 16MB BSON size limit; goes in `mongoexport/mongoexport_test.go`)
+- `exportimport_minkey_maxkey.js` — NEW (no Go test covers MinKey/MaxKey as `_id` values surviving export/import round-trip; goes in `mongoexport/mongoexport_test.go`)
+- `gridfs.js` — NEW (ShardedIntegrationTestType; goes in `mongofiles_test.go`)
+- `restorewithauth.js` — SKIP (covered by `dumprestore_auth_test.go`)
+- `shell_mkdir.js` — SKIP (shell mkdir utility, not relevant to Go migration)
+- `stat1.js` — NEW (`mongostat_test.go` only has unit tests for StatLine; no Go integration test runs mongostat with auth; goes in `mongostat/mongostat_test.go`)
+- `tool1.js` — EXTEND (basic dump/restore and export/import round-trips partially covered; this is a comprehensive smoke test; low priority; goes in `mongodump/mongodump_qa_test.go`)
+- `tool_replset.js` — NEW (ReplSetTestType; goes in appropriate tool test file)
+- `tsv1.js` — EXTEND (`tsv_test.go` covers unit-level TSV parsing but no Go test covers end-to-end TSV import with `-f fields` and `--headerline`; goes in `mongoimport/mongoimport_test.go`)
 
-- [ ] **Step 1: Triage every legacy42 file** against the new Go tests written in Tasks 2–11.
+- [ ] **Step 1: Convert `csv1.js`** (EXTEND) — In `mongoexport/mongoexport_test.go`, add end-to-end case: export a collection to CSV, then re-import with `--headerline`, verify round-trip.
 
-  Expected outcome: most are SKIP (covered). A few may test scenarios not yet covered (e.g., `dumpauth.js`, `tool_replset.js`).
+- [ ] **Step 2: Convert `csvexport1.js`** (NEW) — `TestExportCSVBSONTypes`: export ObjectId, BinData, ISODate, Timestamp, Regex, and function values to CSV; verify the formatting of each in the output.
 
-- [ ] **Step 2: For any NEW files** — convert using the same patterns as above, adding to the appropriate tool's test file.
+- [ ] **Step 3: Convert `csvimport1.js`** (EXTEND) — In `mongoimport/mongoimport_test.go`, add end-to-end import case: multiline CSV with embedded quotes, empty strings, and leading/trailing whitespace.
 
-  Candidates likely needing conversion:
-  - `dumpauth.js` → `mongodump/mongodump_qa_test.go` under `testtype.AuthTestType`
-  - `gridfs.js` → check coverage in `mongofiles/mongofiles_test.go`
-  - `restorewithauth.js` → check coverage in `mongorestore/dumprestore_auth_test.go`
+- [ ] **Step 4: Convert `dumpauth.js`** (EXTEND) — In `mongorestore/dumprestore_auth_test.go`, add to `TestDumpRestoreEnforcesAuthRoles`: verify that `system.profile` is included in the dump output.
 
-- [ ] **Step 3: Run the full integration test suite** to confirm all new tests pass
+- [ ] **Step 5: Convert `dumprestore1.js`** (EXTEND) — In `mongodump/mongodump_qa_test.go`, add error cases: `--collection` without `--db` (per SERVER-7721) and `--dir -` without `--db --collection`.
+
+- [ ] **Step 6: Convert `dumprestore4.js`** (EXTEND) — In `mongorestore/mongorestore_qa_test.go`, add case: restore to a renamed database (`--nsFrom`/`--nsTo`), then verify the index count on the renamed target is correct.
+
+- [ ] **Step 7: Convert `dumprestore6.js`** (EXTEND) — In `mongorestore/mongorestore_qa_test.go`, verify `TestUnversionedIndexes` covers the v:0 index scenario from this test (the `--keepIndexVersion` part is commented out per TOOLS-3020); add any missing assertions.
+
+- [ ] **Step 8: Convert `dumprestore8.js`** (NEW) — `TestRestoreCappedCollection`: create capped collections, dump them, restore, verify capped behavior (size limit, max documents) is preserved.
+
+- [ ] **Step 9: Convert `dumprestore_excludecollections.js`** (NEW) — In `mongodump/mongodump_qa_test.go`, add `TestDumpExcludeCollectionsComprehensive`: test `--excludeCollection` and `--excludeCollectionsWithPrefix` including error cases.
+
+- [ ] **Step 10: Convert `dumprestoreWithNoOptions.js`** (EXTEND) — In `mongorestore/mongorestore_qa_test.go`, extend `--noOptionsRestore` tests: verify capped collections become non-capped across full restore, single-DB restore, and single-collection restore.
+
+- [ ] **Step 11: Convert `exportimport1.js`** (NEW) — `TestExportImportUndefinedArrayElements`: export/import with undefined array elements and `--jsonArray` round-trip.
+
+- [ ] **Step 12: Convert `exportimport3.js`** (EXTEND) — Add end-to-end `--jsonArray` export/import with 5 documents; verify all documents survive the round-trip.
+
+- [ ] **Step 13: Convert `exportimport4.js`** (NEW) — `TestExportImportNaN`: export/import with NaN values and query filters; verify NaN is handled correctly.
+
+- [ ] **Step 14: Convert `exportimport5.js`** (NEW) — `TestExportImportInfinity`: export/import with Infinity and -Infinity values and query filters.
+
+- [ ] **Step 15: Convert `exportimport6.js`** (NEW) — `TestExportSortSkipLimit`: cover `--sort`, `--skip`, `--limit` on export against real data. (This may overlap with Task 3 Step 15; combine if so.)
+
+- [ ] **Step 16: Convert `exportimport_bigarray.js`** (NEW) — `TestExportImportBigArray`: `--jsonArray` export/import where the total size exceeds the 16MB BSON document size limit.
+
+- [ ] **Step 17: Convert `exportimport_minkey_maxkey.js`** (NEW) — `TestExportImportMinKeyMaxKey`: verify MinKey and MaxKey as `_id` values survive export/import round-trip.
+
+- [ ] **Step 18: Convert `stat1.js`** (NEW) — `TestMongoStatWithAuth`: run mongostat with correct and incorrect `--username`/`--password`; verify correct password succeeds and wrong password fails with auth error.
+
+- [ ] **Step 19: Convert `tsv1.js`** (EXTEND) — In `mongoimport/mongoimport_test.go`, add end-to-end TSV import: import a TSV file with `-f` fields specification and with `--headerline`; verify document contents.
+
+- [ ] **Step 20: Convert `tool1.js`** (EXTEND, low priority) — In `mongodump/mongodump_qa_test.go`, add a comprehensive smoke test covering basic dump/restore and export/import round-trips together.
+
+- [ ] **Step 21: Convert `command_line_quotes.js`** (NEW) — Add to `common/util` or an appropriate tool test: verify command-line arguments with embedded quotes and spaces are handled correctly.
+
+- [ ] **Step 22: Convert replica set tests** (NEW, all require `testtype.ReplSetTestType`):
+  - `dumprestore10.js` → `TestDumpRestoreAuthReplSet` in `dumprestore_auth_test.go`
+  - `dumprestore3.js` → `TestMongorestore_Legacy42_3` in `mongorestore_test.go`
+  - `dumprestore7.js` → `TestMongorestore_Legacy42_7` in `mongorestore_test.go`
+  - `dumpsecondary.js` → `TestDumpSecondary` in `mongodump_test.go`
+  - `tool_replset.js` → `TestToolReplSet` in appropriate tool test file
+
+- [ ] **Step 23: Convert sharded tests** (NEW, all require `testtype.ShardedIntegrationTestType`):
+  - `dumprestore9.js` → `TestMongorestore_Legacy42_9` in `mongorestore_test.go`
+  - `gridfs.js` → `TestGridFS_Sharded` in `mongofiles_test.go`
+
+- [ ] **Step 24: Run the full integration test suite**
 
 ```bash
 TOOLS_TESTING_TYPE=integration go test ./... -count=1
 ```
 
-- [ ] **Step 4: Delete legacy42 directory, commit**
+- [ ] **Step 25: Delete legacy42 directory, commit**
 
 ```bash
 rm -r test/legacy42/
-git add test/ mongodump/ mongorestore/ mongofiles/
+git add test/ mongodump/ mongorestore/ mongofiles/ mongoexport/ mongoimport/ mongostat/
 git commit -m "migration: convert legacy42 JS tests to Go"
 ```
 
@@ -841,26 +1030,24 @@ git commit -m "migration: remove JS test infrastructure (resmoke, run_qa.sh, com
 
 ## Summary of Batches
 
-| Batch | Task | JS files | Go target | Notes |
-|---|---|---|---|---|
-| 0 | ShardedTestType infra | — | `common/testtype/types.go`, `common.yml` | New test type + CI variant |
-| 1 | Audit | All | — | Triage only |
-| 2 | bsondump | 7 | `bsondump/bsondump_test.go` | |
-| 3 | mongoexport | ~20 | `mongoexport/mongoexport_test.go` | |
-| 4 | mongoimport | ~19 | `mongoimport/mongoimport_test.go` | Skip replica set tests |
-| 5 | mongofiles | ~16 | `mongofiles/mongofiles_test.go` | |
-| 6 | mongostat | 7 | `mongostat/mongostat_test.go` | |
-| 7 | mongotop | 5 | `mongotop/mongotop_test.go` (new) | |
-| 8 | mongodump | ~20 | `mongodump/mongodump_qa_test.go` (new) | Extend, don't duplicate |
-| 9 | mongorestore core | ~20 | `mongorestore/mongorestore_qa_test.go` (new) | |
-| 10 | mongorestore oplog | ~8 | `mongorestore/oplog_test.go` | |
-| 11 | mongorestore auth | ~7 | `mongorestore/dumprestore_auth_test.go` | |
-| 12 | SSL/TLS | 2 | `mongoexport/mongoexport_test.go` | Manual env setup required |
-| 13 | legacy42 | ~30 | Various | Mostly SKIP |
-| 14 | Cleanup | — | `common.yml`, `build.go`, `scripts/` | Remove infrastructure |
+| Batch | Task | JS files | Go target | Status | Notes |
+|---|---|---|---|---|---|
+| 0 | ShardedIntegrationTestType infra | — | `common/testtype/types.go`, `common.yml` | DONE (5b34c02b) | New test type + CI variant |
+| 1 | Audit | All | — | DONE (53346f4c) | 21 SKIP, 111 NEW, 47 EXTEND |
+| 2 | bsondump | 7 | `bsondump/bsondump_test.go` | | 2 SKIP, 3 NEW, 2 EXTEND |
+| 3 | mongoexport | 19 | `mongoexport/mongoexport_test.go` | | 1 SKIP, 14 NEW, 4 EXTEND |
+| 4 | mongoimport | 20 | `mongoimport/mongoimport_test.go` | | 2 SKIP, 11 NEW, 7 EXTEND |
+| 5 | mongofiles | 16 | `mongofiles/mongofiles_test.go` | | 3 SKIP, 8 NEW, 5 EXTEND |
+| 6 | mongostat | 7 | `mongostat/mongostat_test.go` | | 2 SKIP, 5 NEW |
+| 7 | mongotop | 5 | `mongotop/mongotop_test.go` (new) | | 5 NEW (1 stress, skip) |
+| 8 | mongodump | ~22 | `mongodump/mongodump_qa_test.go` (new) | | 5 SKIP, 12 NEW, 5 EXTEND |
+| 9 | mongorestore core | ~38 | `mongorestore/mongorestore_qa_test.go` (new) | | 3 SKIP, 20 NEW, 15 EXTEND |
+| 10 | mongorestore oplog | 9 | `mongorestore/oplog_test.go` | | 9 NEW (all ReplSetTestType) |
+| 11 | mongorestore auth/sharded | 8 | `mongorestore/dumprestore_auth_test.go` + `mongorestore_qa_test.go` | | 4 NEW (sharded), 4 EXTEND |
+| 12 | SSL/TLS | 2 | new SSL/TLS integration test files | | 2 NEW; manual env setup required |
+| 13 | legacy42 | 34 | Various | | 4 SKIP, 20 NEW, 10 EXTEND |
+| 14 | Cleanup | — | `common.yml`, `build.go`, `scripts/` | | Remove infrastructure |
 
 **Consistent SKIPs across all batches:**
 - Broken pipe tests — OS-signal behavior, untestable in Go unit/integration tests
 - Tests disabled in JS with comments — respect the existing disable rationale
-
-**Sharded/mongos tests** are converted under `testtype.ShardedTestType` (see Task 0), not skipped.

--- a/test/legacy42/jstests/tool/command_line_quotes.js
+++ b/test/legacy42/jstests/tool/command_line_quotes.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in common/util test or tool-specific test
 jsTest.log("Testing spaces in mongodump command-line options...");
 
 /**

--- a/test/legacy42/jstests/tool/csv1.js
+++ b/test/legacy42/jstests/tool/csv1.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — csv_test.go covers unit-level CSV parsing but no Go test covers end-to-end CSV export then re-import with --headerline; goes in mongoexport/mongoexport_test.go
 // csv1.js
 
 t = new ToolTest("csv1");

--- a/test/legacy42/jstests/tool/csvexport1.js
+++ b/test/legacy42/jstests/tool/csvexport1.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test exports various BSON types (ObjectId, BinData, ISODate, Timestamp, Regex, function) to CSV and verifies formatting; goes in mongoexport/mongoexport_test.go
 // csvexport1.js
 
 t = new ToolTest("csvexport1");

--- a/test/legacy42/jstests/tool/csvexport2.js
+++ b/test/legacy42/jstests/tool/csvexport2.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — csv_test.go covers CSV export variants
 // csvexport2.js
 
 t = new ToolTest("csvexport2");

--- a/test/legacy42/jstests/tool/csvimport1.js
+++ b/test/legacy42/jstests/tool/csvimport1.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — csv_test.go covers parsing but no Go test covers end-to-end import of multiline CSV with embedded quotes, empty strings, and leading/trailing whitespace; goes in mongoimport/mongoimport_test.go
 // csvimport1.js
 
 t = new ToolTest("csvimport1");

--- a/test/legacy42/jstests/tool/dumpauth.js
+++ b/test/legacy42/jstests/tool/dumpauth.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestDumpRestoreEnforcesAuthRoles covers backup/restore roles but does not verify system.profile is included in the dump; goes in mongorestore/dumprestore_auth_test.go
 // dumpauth.js
 // test mongodump with authentication
 

--- a/test/legacy42/jstests/tool/dumprestore1.js
+++ b/test/legacy42/jstests/tool/dumprestore1.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — basic dump/restore covered but missing --collection without --db error (SERVER-7721) and --dir - without --db --collection error; goes in mongodump/mongodump_qa_test.go
 // dumprestore1.js
 
 t = new ToolTest("dumprestore1");

--- a/test/legacy42/jstests/tool/dumprestore10.js
+++ b/test/legacy42/jstests/tool/dumprestore10.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in dumprestore_auth_test.go (ReplSetTestType)
 // simple test to ensure write concern functions as expected
 (function() {
 // Skip this test if running with --nojournal and WiredTiger.

--- a/test/legacy42/jstests/tool/dumprestore3.js
+++ b/test/legacy42/jstests/tool/dumprestore3.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ReplSetTestType)
 // mongodump/mongoexport from primary should succeed.  mongorestore and mongoimport to a
 // secondary node should fail.
 

--- a/test/legacy42/jstests/tool/dumprestore4.js
+++ b/test/legacy42/jstests/tool/dumprestore4.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongorestore covers nsFrom/nsTo rename and TestCreateIndexes covers index restoration separately, but no Go test restores to a renamed database and then verifies the index count on the renamed target; goes in mongorestore/mongorestore_qa_test.go
 // dumprestore4.js -- see SERVER-2186
 
 // The point of this test is to ensure that mongorestore successfully

--- a/test/legacy42/jstests/tool/dumprestore6.js
+++ b/test/legacy42/jstests/tool/dumprestore6.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestUnversionedIndexes covers v:0 index restoration but --keepIndexVersion scenario is commented out per TOOLS-3020; verify TestUnversionedIndexes covers this test's assertions before deleting; goes in mongorestore/mongorestore_qa_test.go
 // Test restoring from a dump with v:0 indexes.
 // mongodump strips the 'v' property from the index specification by default.  When using
 // --keepIndexVersion, the 'v' property is not stripped, but index creation will fail.

--- a/test/legacy42/jstests/tool/dumprestore7.js
+++ b/test/legacy42/jstests/tool/dumprestore7.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ReplSetTestType)
 (function() {
 "use strict";
 

--- a/test/legacy42/jstests/tool/dumprestore8.js
+++ b/test/legacy42/jstests/tool/dumprestore8.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test creates capped collections, dumps, restores, and verifies capped behavior is preserved; goes in mongorestore/mongorestore_qa_test.go
 // dumprestore8.js
 
 // This file tests that indexes and capped collection options get properly dumped and restored.

--- a/test/legacy42/jstests/tool/dumprestore9.js
+++ b/test/legacy42/jstests/tool/dumprestore9.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ShardedIntegrationTestType)
 // Test disabled until SERVER-3853 is finished
 if (0) {
     (function() {

--- a/test/legacy42/jstests/tool/dumprestoreWithNoOptions.js
+++ b/test/legacy42/jstests/tool/dumprestoreWithNoOptions.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests use --noOptionsRestore only in timeseries context; no Go test verifies capped collections become non-capped across full/single-DB/single-collection restore; goes in mongorestore/mongorestore_qa_test.go
 // SERVER-6366
 // relates to SERVER-808
 //

--- a/test/legacy42/jstests/tool/dumprestore_excludecollections.js
+++ b/test/legacy42/jstests/tool/dumprestore_excludecollections.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --excludeCollection and --excludeCollectionsWithPrefix for mongodump including error cases; goes in mongodump/mongodump_qa_test.go
 // Tests for mongodump options for excluding collections
 
 var testBaseName = "jstests_tool_dumprestore_excludecollections";

--- a/test/legacy42/jstests/tool/dumpsecondary.js
+++ b/test/legacy42/jstests/tool/dumpsecondary.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go (ReplSetTestType)
 (function() {
 // Skip this test if running with --nojournal and WiredTiger.
 if (jsTest.options().noJournal &&

--- a/test/legacy42/jstests/tool/exportimport1.js
+++ b/test/legacy42/jstests/tool/exportimport1.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers export/import with undefined array elements and --jsonArray round-trip; goes in mongoexport/mongoexport_test.go
 // exportimport1.js
 
 t = new ToolTest("exportimport1");

--- a/test/legacy42/jstests/tool/exportimport3.js
+++ b/test/legacy42/jstests/tool/exportimport3.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — json_test.go TestJSONArray covers format but no Go test covers end-to-end --jsonArray export/import with 5 documents; goes in mongoexport/mongoexport_test.go
 // exportimport3.js
 
 t = new ToolTest("exportimport3");

--- a/test/legacy42/jstests/tool/exportimport4.js
+++ b/test/legacy42/jstests/tool/exportimport4.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers export/import with NaN values and query filters; goes in mongoexport/mongoexport_test.go
 // exportimport4.js
 
 t = new ToolTest("exportimport4");

--- a/test/legacy42/jstests/tool/exportimport5.js
+++ b/test/legacy42/jstests/tool/exportimport5.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers export/import with Infinity/-Infinity values and query filters; goes in mongoexport/mongoexport_test.go
 // exportimport4.js
 
 t = new ToolTest("exportimport5");

--- a/test/legacy42/jstests/tool/exportimport6.js
+++ b/test/legacy42/jstests/tool/exportimport6.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --sort, --skip, --limit on export against real data; goes in mongoexport/mongoexport_test.go
 // exportimport6.js
 // test export with skip, limit and sort
 

--- a/test/legacy42/jstests/tool/exportimport_bigarray.js
+++ b/test/legacy42/jstests/tool/exportimport_bigarray.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --jsonArray export/import above 16MB BSON size limit; goes in mongoexport/mongoexport_test.go
 // Test importing collections represented as a single line array above the maximum document size
 var tt = new ToolTest('exportimport_bigarray_test');
 

--- a/test/legacy42/jstests/tool/exportimport_minkey_maxkey.js
+++ b/test/legacy42/jstests/tool/exportimport_minkey_maxkey.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers MinKey/MaxKey as _id values surviving export/import round-trip; goes in mongoexport/mongoexport_test.go
 var tt = new ToolTest('exportimport_minkey_maxkey_test');
 
 var exportimport_db = tt.startDB();

--- a/test/legacy42/jstests/tool/gridfs.js
+++ b/test/legacy42/jstests/tool/gridfs.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go (ShardedIntegrationTestType)
 // tests gridfs with a sharded fs.chunks collection.
 // @tags: [requires_sharding]
 

--- a/test/legacy42/jstests/tool/restorewithauth.js
+++ b/test/legacy42/jstests/tool/restorewithauth.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — dumprestore_auth_test.go covers auth restore
 /* SERVER-4972
  * Test for mongorestore on server with --auth allows restore without credentials of colls
  * with no index

--- a/test/legacy42/jstests/tool/shell_mkdir.js
+++ b/test/legacy42/jstests/tool/shell_mkdir.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — shell mkdir utility, not relevant to Go migration
 // Test the shell's mkdir utility.
 
 (function() {

--- a/test/legacy42/jstests/tool/stat1.js
+++ b/test/legacy42/jstests/tool/stat1.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — mongostat_test.go only has unit tests for StatLine; no Go integration test runs mongostat with auth (correct/wrong password); goes in mongostat/mongostat_test.go
 // stat1.js
 // test mongostat with authentication SERVER-3875
 baseName = "tool_stat1";

--- a/test/legacy42/jstests/tool/tool1.js
+++ b/test/legacy42/jstests/tool/tool1.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — basic dump/restore and export/import round-trips are partially covered in Go but this is a comprehensive smoke test; low priority; goes in mongodump/mongodump_qa_test.go
 // mongo tool tests, very basic to start with
 
 baseName = "jstests_tool_tool1";

--- a/test/legacy42/jstests/tool/tool_replset.js
+++ b/test/legacy42/jstests/tool/tool_replset.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in appropriate tool test file (ReplSetTestType)
 /*
  * Test to ensure that (dump/restore/export/import/oplog) works with a replica set connection string
  * 1. Start a replica set.

--- a/test/legacy42/jstests/tool/tsv1.js
+++ b/test/legacy42/jstests/tool/tsv1.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — tsv_test.go covers unit-level TSV parsing but no Go test covers end-to-end TSV import with -f fields and --headerline; goes in mongoimport/mongoimport_test.go
 // tsv1.js
 
 t = new ToolTest("tsv1");

--- a/test/qa-tests/jstests/bson/all_types.js
+++ b/test/qa-tests/jstests/bson/all_types.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --type=debug output or verifies BSON type numbers; goes in bsondump/bsondump_test.go
 // This test runs bsondump on a .bson file containing non-deprecated BSON types
 // and makes sure their debug type values exist in the output.
 (function() {

--- a/test/qa-tests/jstests/bson/all_types_json.js
+++ b/test/qa-tests/jstests/bson/all_types_json.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies JSON serialization of all BSON types (binary, regex, decimal128, etc.); goes in bsondump/bsondump_test.go
 // This test runs bsondump on a .bson file containing non-deprecated BSON types
 // and makes sure their JSON type representations exist in the output.
 (function() {

--- a/test/qa-tests/jstests/bson/bad_files.js
+++ b/test/qa-tests/jstests/bson/bad_files.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — add to TestBsondump in bsondump_test.go
 // This test makes sure that certain invalid BSON succeeds or fails
 // with both JSON and debug output types AND --objcheck
 (function() {

--- a/test/qa-tests/jstests/bson/bsondump_broken_pipe.js
+++ b/test/qa-tests/jstests/bson/bsondump_broken_pipe.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — broken pipe is OS-signal-level, not testable in Go
 (function() {
   var bsondumpArgs = ['bsondump', '--failpoints', 'SlowBSONDump', '--type=json', 'jstests/bson/testdata/all_types.bson'];
   var ddArgs = ['dd', 'count=1000000', 'bs=1024', 'of=/dev/null'];

--- a/test/qa-tests/jstests/bson/bsondump_options.js
+++ b/test/qa-tests/jstests/bson/bsondump_options.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — add to TestBsondump in bsondump_test.go
 // This test checks reasonable and unreasonable option configurations for bsondump
 (function() {
   load('jstests/libs/extended_assert.js');

--- a/test/qa-tests/jstests/bson/deep_nested.js
+++ b/test/qa-tests/jstests/bson/deep_nested.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test exercises deeply nested BSON documents; goes in bsondump/bsondump_test.go
 // This test checks that bsondump can handle a deeply nested document without breaking
 
 (function() {

--- a/test/qa-tests/jstests/bson/output_file.js
+++ b/test/qa-tests/jstests/bson/output_file.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — TestBsondump in bsondump_test.go covers file output variants
 /**
  * output_file.js
  *

--- a/test/qa-tests/jstests/dump/collection_flag_tests.js
+++ b/test/qa-tests/jstests/dump/collection_flag_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --collection dumps only the named collection excluding other DBs; goes in mongodump/mongodump_qa_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/db_flag_tests.js
+++ b/test/qa-tests/jstests/dump/db_flag_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test inserts into two DBs, dumps one with --db, and verifies the other is excluded; goes in mongodump/mongodump_qa_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/dump_broken_pipe.js
+++ b/test/qa-tests/jstests/dump/dump_broken_pipe.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — broken pipe is OS-signal-level, not testable in Go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/dump_db_users_and_roles_tests.js
+++ b/test/qa-tests/jstests/dump/dump_db_users_and_roles_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestDumpRestoreSingleDBWithDBUsersAndRoles covers main scenario but missing "no users exist" error and --dumpDbUsersAndRoles without --db error; goes in mongorestore/dumprestore_auth_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/dump_server_ko_test.js
+++ b/test/qa-tests/jstests/dump/dump_server_ko_test.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/dump_views.js
+++ b/test/qa-tests/jstests/dump/dump_views.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongoDumpViews checks metadata files but no Go test restores and verifies view data round-trip or --viewsAsCollections behavior; goes in mongodump/mongodump_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/dumping_dropped_collections.js
+++ b/test/qa-tests/jstests/dump/dumping_dropped_collections.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — test was already disabled (body commented out) per TOOLS-3019
 /* TODO: fix and re-enable test, see TOOLS-3019
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/exclude_collection_tests.js
+++ b/test/qa-tests/jstests/dump/exclude_collection_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/exclude_collections_with_prefix_tests.js
+++ b/test/qa-tests/jstests/dump/exclude_collections_with_prefix_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go
 if (typeof getToolTest === 'undefined') {
   load('jstests/configs/plain_28.config.js');
 }

--- a/test/qa-tests/jstests/dump/force_table_scan_tests.js
+++ b/test/qa-tests/jstests/dump/force_table_scan_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/no_sharded_secondary_reads.js
+++ b/test/qa-tests/jstests/dump/no_sharded_secondary_reads.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — test is disabled per TOOLS-2661
 /* Disabled: see TOOLS-2661
 (function() {
   // This test makes sure that mongodump does not do secondary reads when talking to a mongos.

--- a/test/qa-tests/jstests/dump/oplog_admin_sys_version_test.js
+++ b/test/qa-tests/jstests/dump/oplog_admin_sys_version_test.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_dump_test.go (ReplSetTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/replset_28.config.js');

--- a/test/qa-tests/jstests/dump/oplog_flag_tests.js
+++ b/test/qa-tests/jstests/dump/oplog_flag_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — add to TestMongoDumpOplog in mongodump_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/replset_28.config.js');

--- a/test/qa-tests/jstests/dump/oplog_rename_test.js
+++ b/test/qa-tests/jstests/dump/oplog_rename_test.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_dump_test.go (ReplSetTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/replset_28.config.js');

--- a/test/qa-tests/jstests/dump/oplog_rollover_test.js
+++ b/test/qa-tests/jstests/dump/oplog_rollover_test.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_dump_test.go (ReplSetTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/replset_single_28_tinyoplog.config.js');

--- a/test/qa-tests/jstests/dump/options_json.js
+++ b/test/qa-tests/jstests/dump/options_json.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/out_flag_tests.js
+++ b/test/qa-tests/jstests/dump/out_flag_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --out - error cases (without --db/--collection) or --out to custom directory with restore; goes in mongodump/mongodump_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/query_extended_json.js
+++ b/test/qa-tests/jstests/dump/query_extended_json.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies extended JSON types ($date, $regex, $oid, $minKey, $maxKey) in --query; goes in mongodump/mongodump_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/query_flag_tests.js
+++ b/test/qa-tests/jstests/dump/query_flag_tests.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongoDumpOrderedQuery and TestMongoDumpBSON cover --query/--queryFile success paths but missing error cases (without --db, without --collection, nonexistent --queryFile); goes in mongodump/mongodump_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/dump/read_preference_and_tags.js
+++ b/test/qa-tests/jstests/dump/read_preference_and_tags.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongodump_test.go (ReplSetTestType)
 (function() {
   jsTest.log('Testing that dump utilizes read preferences and tags');
   var TOOLS_TEST_CONFIG = {};

--- a/test/qa-tests/jstests/dump/version_test.js
+++ b/test/qa-tests/jstests/dump/version_test.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies that mongorestore with -vvv on an archive dump prints archive format version, server version, and tool version; goes in mongorestore/mongorestore_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/export/basic_data.js
+++ b/test/qa-tests/jstests/export/basic_data.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers end-to-end export-then-import round-trip of basic data; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/export/data_types.js
+++ b/test/qa-tests/jstests/export/data_types.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers round-trip export/import of diverse BSON types (int, float, string, subdoc, array, BinData, ISODate, Timestamp, Regex); goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/export/export_broken_pipe.js
+++ b/test/qa-tests/jstests/export/export_broken_pipe.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — broken pipe is OS-signal-level, not testable in Go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/export/export_views.js
+++ b/test/qa-tests/jstests/export/export_views.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test creates or exports from a MongoDB view; goes in mongoexport/mongoexport_test.go
 // @tags: [requires_min_mongo_34](
 (function() {
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/export/field_file.js
+++ b/test/qa-tests/jstests/export/field_file.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/fields_csv.js
+++ b/test/qa-tests/jstests/export/fields_csv.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — csv_test.go covers unit-level CSV field extraction but no Go test covers end-to-end --fields filtering with --csv against a real server; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/fields_json.js
+++ b/test/qa-tests/jstests/export/fields_json.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --fields limits which fields appear in JSON export output; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/force_table_scan.js
+++ b/test/qa-tests/jstests/export/force_table_scan.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/json_array.js
+++ b/test/qa-tests/jstests/export/json_array.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — json_test.go TestJSONArray covers basic jsonArray format but not round-trip or that import without --jsonArray fails; goes in mongoexport/mongoexport_test.go
 (function() {
 
   // Tests running mongoexport with the --jsonArray output option.

--- a/test/qa-tests/jstests/export/limit.js
+++ b/test/qa-tests/jstests/export/limit.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test exercises the --limit flag; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/namespace_validation.js
+++ b/test/qa-tests/jstests/export/namespace_validation.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go
 (function() {
 
   // Tests running mongoexport with bad command line options.

--- a/test/qa-tests/jstests/export/nested_fields_csv.js
+++ b/test/qa-tests/jstests/export/nested_fields_csv.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — add to csv_test.go for nested field handling
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/no_data.js
+++ b/test/qa-tests/jstests/export/no_data.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongoExportTOOLS2174 covers empty collection export but no Go test covers --assertExists flag; goes in mongoexport/mongoexport_test.go
 (function() {
 
   // Tests running mongoexport with no data in the target collection.

--- a/test/qa-tests/jstests/export/pretty.js
+++ b/test/qa-tests/jstests/export/pretty.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/export/query.js
+++ b/test/qa-tests/jstests/export/query.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test inserts data and verifies --query or --queryFile correctly filter export output; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/slave_ok.js
+++ b/test/qa-tests/jstests/export/slave_ok.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go (ReplSetTestType)
 (function() {
   // Tests running mongoexport with --slaveOk.
 

--- a/test/qa-tests/jstests/export/sort_and_skip.js
+++ b/test/qa-tests/jstests/export/sort_and_skip.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --sort and --skip correctly affect export output; goes in mongoexport/mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/export/stdout.js
+++ b/test/qa-tests/jstests/export/stdout.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies mongoexport writes correct JSON to stdout when no --out is specified; goes in mongoexport/mongoexport_test.go
 // Tests running mongoexport writing to stdout.
 (function() {
   load('jstests/libs/extended_assert.js');

--- a/test/qa-tests/jstests/export/type_case.js
+++ b/test/qa-tests/jstests/export/type_case.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoexport_test.go
 (function() {
 
   if (typeof getToolTest === "undefined") {

--- a/test/qa-tests/jstests/files/mongofiles_db.js
+++ b/test/qa-tests/jstests/files/mongofiles_db.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --db routes files to the correct non-default database; goes in mongofiles/mongofiles_test.go
 // mongofiles_db.js; ensure that running mongofiles using the db flag works as
 // expected
 var testName = 'mongofiles_db';

--- a/test/qa-tests/jstests/files/mongofiles_delete.js
+++ b/test/qa-tests/jstests/files/mongofiles_delete.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — delete command covered by mongofiles_test.go
 // mongofiles_delete.js; ensure that delete command works as expected
 var testName = 'mongofiles_delete';
 load('jstests/files/util/mongofiles_common.js');

--- a/test/qa-tests/jstests/files/mongofiles_get.js
+++ b/test/qa-tests/jstests/files/mongofiles_get.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover get and get_id to file but not get-to-stdout (--local -); goes in mongofiles/mongofiles_test.go
 // mongofiles_get.js; ensure that get command works as expected
 var testName = 'mongofiles_get';
 (function() {

--- a/test/qa-tests/jstests/files/mongofiles_host.js
+++ b/test/qa-tests/jstests/files/mongofiles_host.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test validates --host behavior (valid hosts succeed, invalid hosts fail); goes in mongofiles/mongofiles_test.go
 // mongofiles_host.js; ensure that running mongofiles using valid and invalid
 // host names or IP addresses succeeds/fails as expected
 var testName = 'mongofiles_host';

--- a/test/qa-tests/jstests/files/mongofiles_invalid.js
+++ b/test/qa-tests/jstests/files/mongofiles_invalid.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestValidArguments covers invalid command but not invalid CLI option (--invalid); goes in mongofiles/mongofiles_test.go
 // mongofiles_invalid.js; runs mongofiles with an invalid command and
 // option - ensures it fails in all cases
 var testName = 'mongofiles_invalid';

--- a/test/qa-tests/jstests/files/mongofiles_list.js
+++ b/test/qa-tests/jstests/files/mongofiles_list.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — list command covered by mongofiles_test.go
 // mongofiles_list.js; tests the mongofiles list option by doing the following:
 //
 // 1. Inserts the mongod/mongo binaries using mongofiles put

--- a/test/qa-tests/jstests/files/mongofiles_local.js
+++ b/test/qa-tests/jstests/files/mongofiles_local.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover --local for get but not --local for put, empty --local string, or --local with nonexistent file; goes in mongofiles/mongofiles_test.go
 // mongofiles_local.js; ensure that when --local is passed:
 // a. for puts, the supplied argument is read and stored using the gridfs filename
 // b. for gets, the supplied argument is used to store the retrieved file

--- a/test/qa-tests/jstests/files/mongofiles_port.js
+++ b/test/qa-tests/jstests/files/mongofiles_port.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test validates --port behavior (valid port succeeds, wrong/non-numeric port fails); goes in mongofiles/mongofiles_test.go
 // mongofiles_port.js; ensure that supplying valid/invalid port addresses
 // succeeds/fails as expected
 var testName = 'mongofiles_port';

--- a/test/qa-tests/jstests/files/mongofiles_prefix.js
+++ b/test/qa-tests/jstests/files/mongofiles_prefix.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test validates --prefix routing files to a custom GridFS collection; goes in mongofiles/mongofiles_test.go
 // mongofiles_prefix.js; ensure that passing --prefix works as expected - the
 // provided prefix is used as the collection name prefix
 var testName = 'mongofiles_prefix';

--- a/test/qa-tests/jstests/files/mongofiles_put.js
+++ b/test/qa-tests/jstests/files/mongofiles_put.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover basic put and content verification but not large multi-chunk files (40MB+) or put-of-a-directory-fails; goes in mongofiles/mongofiles_test.go
 // mongofiles_put.js; ensure that put works with very large files.
 // NOTE: this test uses mongodump to create a large file
 var testName = 'mongofiles_put';

--- a/test/qa-tests/jstests/files/mongofiles_replace.js
+++ b/test/qa-tests/jstests/files/mongofiles_replace.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go
 // mongofiles_replace.js; ensure that after putting a file once multiple times,
 // on using --replace, any and all occurrences of the given file is replaced in
 // the GridFS collection - all other files are left as is

--- a/test/qa-tests/jstests/files/mongofiles_search.js
+++ b/test/qa-tests/jstests/files/mongofiles_search.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go
 // mongofiles_search.js; ensures that the search command returns any and all
 // files that match the regex supplied
 var testName = 'mongofiles_search';

--- a/test/qa-tests/jstests/files/mongofiles_type.js
+++ b/test/qa-tests/jstests/files/mongofiles_type.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go
 // mongofiles_type.js; ensure that the given content type is stored when passed
 // as the --type argument. If no argument is passed, it should be omitted in the
 // database.

--- a/test/qa-tests/jstests/files/mongofiles_version.js
+++ b/test/qa-tests/jstests/files/mongofiles_version.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --version output; goes in common/options/options_test.go (covers all tools)
 // mongofiles_version.js; ensure that getting the version works without error
 var testName = 'mongofiles_version';
 load('jstests/files/util/mongofiles_common.js');

--- a/test/qa-tests/jstests/files/mongofiles_write_concern.js
+++ b/test/qa-tests/jstests/files/mongofiles_write_concern.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go (ReplSetTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/files/mongofiles_write_concern_mongos.js
+++ b/test/qa-tests/jstests/files/mongofiles_write_concern_mongos.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongofiles_test.go (ShardedIntegrationTestType)
 // (function() {
 //   if (typeof getToolTest === 'undefined') {
 //     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/all_primaries_down_error_code.js
+++ b/test/qa-tests/jstests/import/all_primaries_down_error_code.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go (ShardedIntegrationTestType)
 /**
  * all_primaries_down_error_code.js
  *

--- a/test/qa-tests/jstests/import/boolean_type.js
+++ b/test/qa-tests/jstests/import/boolean_type.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test imports a JSON file with Boolean() objects and verifies round-trip fidelity; goes in mongoimport/mongoimport_test.go
 /**
  * boolean_type.js
  *

--- a/test/qa-tests/jstests/import/collections.js
+++ b/test/qa-tests/jstests/import/collections.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongoImportValidateSettings covers basic --file to collection name derivation but not multi-dot filenames, positional args, or --db with positional arg; goes in mongoimport/mongoimport_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/import/decimal128.js
+++ b/test/qa-tests/jstests/import/decimal128.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies round-trip export-then-import of Decimal128 through Extended JSON; goes in mongoimport/mongoimport_test.go
 (function() {
   // skip this test where NumberDecimal is unsupported (3.2 and earlier)
   if (typeof NumberDecimal === 'undefined') {

--- a/test/qa-tests/jstests/import/drop.js
+++ b/test/qa-tests/jstests/import/drop.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — --drop flag covered by mongoimport_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/import/fields.js
+++ b/test/qa-tests/jstests/import/fields.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover --fields and --ignoreBlanks for CSV but not --fieldFile, nested dotted field names, or extra-fields-beyond-header in end-to-end import; goes in mongoimport/mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/import_document_validation.js
+++ b/test/qa-tests/jstests/import/import_document_validation.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test creates a validated collection and tests import rejection, --bypassDocumentValidation, or --stopOnError with validation errors; goes in mongoimport/mongoimport_test.go
 /**
  * import_document_validation.js
  *

--- a/test/qa-tests/jstests/import/import_types.js
+++ b/test/qa-tests/jstests/import/import_types.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test imports a legacy Extended JSON file containing all BSON types and verifies each field's $type in the database; goes in mongoimport/mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/import_write_concern.js
+++ b/test/qa-tests/jstests/import/import_write_concern.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go (ReplSetTestType)
 (function() {
 
   load("jstests/configs/replset_28.config.js");

--- a/test/qa-tests/jstests/import/import_write_concern_mongos.js
+++ b/test/qa-tests/jstests/import/import_write_concern_mongos.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go (ShardedIntegrationTestType)
 // (function() {
 
 //   load("jstests/configs/replset_28.config.js");

--- a/test/qa-tests/jstests/import/mode.js
+++ b/test/qa-tests/jstests/import/mode.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover --mode=upsert and --mode=delete but not --mode=merge (preserving pre-existing fields), --upsertFields with compound non-_id fields, or legacy --upsert flag; goes in mongoimport/mongoimport_test.go
 (function() {
   jsTest.log('Testing running import with modes');
 

--- a/test/qa-tests/jstests/import/mode_upsert_id_subdoc.js
+++ b/test/qa-tests/jstests/import/mode_upsert_id_subdoc.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — add to mongoimport_test.go for upsert with ID in subdoc
 (function() {
   // This test creates a collection with a subdocument _id field. We export the collection,
   // replace the existing documents with a pre-made dataset and --mode=upsert, then overwrite

--- a/test/qa-tests/jstests/import/no_primary_error_code.js
+++ b/test/qa-tests/jstests/import/no_primary_error_code.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go (ShardedIntegrationTestType)
 /**
  * no_primary_error_code.js
  *

--- a/test/qa-tests/jstests/import/options.js
+++ b/test/qa-tests/jstests/import/options.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongoImportValidateSettings covers some option validation but not invalid DB/collection names, --jsonArray with non-array input, type mismatches, or conflicting positional args; goes in mongoimport/mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/parse_grace.js
+++ b/test/qa-tests/jstests/import/parse_grace.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/replset.js
+++ b/test/qa-tests/jstests/import/replset.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go (ReplSetTestType)
 (function() {
   jsTest.log('Testing running import with upserts');
 

--- a/test/qa-tests/jstests/import/stoponerror.js
+++ b/test/qa-tests/jstests/import/stoponerror.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — --stopOnError covered by mongoimport_test.go
 (function() {
   jsTest.log('Testing running import with upserts');
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/import/type_case.js
+++ b/test/qa-tests/jstests/import/type_case.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/typed_fields.js
+++ b/test/qa-tests/jstests/import/typed_fields.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — typed_fields_test.go covers header parsing and field parsers at unit level but no Go test covers end-to-end --columnsHaveTypes import verifying actual database contents; goes in mongoimport/mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/import/types.js
+++ b/test/qa-tests/jstests/import/types.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies round-trip export-then-import preserving all BSON types (BinData, Boolean, Array, embedded doc, NumberLong, MinKey, MaxKey, ISODate, DBRef, etc.); goes in mongoimport/mongoimport_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/restore/archive_stdout.js
+++ b/test/qa-tests/jstests/restore/archive_stdout.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongorestoreArchiveWithOplog restores a pre-existing archive but no Go test covers pipe-based dump --archive | restore --archive with special characters in collection names; goes in mongorestore/mongorestore_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/restore/bad_options.js
+++ b/test/qa-tests/jstests/restore/bad_options.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ReplSetTestType)
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/blank_collection_bson.js
+++ b/test/qa-tests/jstests/restore/blank_collection_bson.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test restores from a blank .bson file with missing/blank metadata; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/blank_db.js
+++ b/test/qa-tests/jstests/restore/blank_db.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test restores from an empty directory with --db; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/collation.js
+++ b/test/qa-tests/jstests/restore/collation.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestIndexGetsSimpleCollation covers index collation but no Go test verifies collection-level collation round-trip through dump/restore; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/different_collection.js
+++ b/test/qa-tests/jstests/restore/different_collection.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongorestore covers nsFrom/nsTo same-DB rename but not: (1) cross-database restore with --db/--collection, (2) different-DB different-collection, (3) --db/--collection with a direct .bson file path; goes in mongorestore/mongorestore_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/restore/different_db.js
+++ b/test/qa-tests/jstests/restore/different_db.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — --nsFrom/--nsTo path is covered in Go but the --db dest path restoring a subdirectory is not; goes in mongorestore/mongorestore_qa_test.go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/restore/drop_authenticated_user.js
+++ b/test/qa-tests/jstests/restore/drop_authenticated_user.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestDumpRestorePreservesAdminUsersAndRoles covers admin user/role preservation with --drop but does not verify the restoring user itself survives the drop; goes in mongorestore/dumprestore_auth_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/drop_nonexistent_db.js
+++ b/test/qa-tests/jstests/restore/drop_nonexistent_db.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --drop on a nonexistent DB succeeds without error; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/drop_one_collection.js
+++ b/test/qa-tests/jstests/restore/drop_one_collection.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies --drop --db --collection only drops the specified collection leaving others untouched; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/drop_with_data.js
+++ b/test/qa-tests/jstests/restore/drop_with_data.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — --drop is exercised in several Go tests but none specifically insert different pre-existing data and verify it is fully replaced by the restored data; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/duplicate_keys.js
+++ b/test/qa-tests/jstests/restore/duplicate_keys.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongorestoreMIOSOE covers dup key with stopOnError but not the batch size iteration behavior; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/extended_json_metadata.js
+++ b/test/qa-tests/jstests/restore/extended_json_metadata.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ShardedIntegrationTestType)
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/index_version_roundtrip.js
+++ b/test/qa-tests/jstests/restore/index_version_roundtrip.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test does a round-trip with --keepIndexVersion verifying index version values; goes in mongorestore/mongorestore_qa_test.go
 // @tags: [requires_min_mongo_34](
 (function() {
 

--- a/test/qa-tests/jstests/restore/indexes.js
+++ b/test/qa-tests/jstests/restore/indexes.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestCreateIndexes tests hashed indexes but no Go test creates and round-trips sparse, unique, compound, text, and 2dsphere indexes; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/invalid_dump_target.js
+++ b/test/qa-tests/jstests/restore/invalid_dump_target.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test passes invalid targets (file instead of dir, file with --db, dir with --collection) and checks for errors; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/invalid_metadata.js
+++ b/test/qa-tests/jstests/restore/invalid_metadata.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test verifies restore of a collection with invalid indexes in metadata.json fails; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/keep_index_version.js
+++ b/test/qa-tests/jstests/restore/keep_index_version.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test covers --keepIndexVersion for index version preservation (targets old server versions); goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load('jstests/common/check_version.js');

--- a/test/qa-tests/jstests/restore/large_bulk.js
+++ b/test/qa-tests/jstests/restore/large_bulk.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test creates 32 x ~1MB documents to verify bulk API respects 16MB BSON limit; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   // this test tests that the bulk api doesn't create BSON documents greater then the

--- a/test/qa-tests/jstests/restore/malformed_bson.js
+++ b/test/qa-tests/jstests/restore/malformed_bson.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test restores from a malformed BSON file and verifies failure; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/malformed_metadata.js
+++ b/test/qa-tests/jstests/restore/malformed_metadata.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test restores with malformed metadata.json and verifies failure; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/missing_dump.js
+++ b/test/qa-tests/jstests/restore/missing_dump.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test passes nonexistent paths (directory, with --db, with --collection) and verifies error; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/multiple_dbs.js
+++ b/test/qa-tests/jstests/restore/multiple_dbs.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestMongorestore restores from testdata/testdirs (db1+db2) but does not explicitly verify per-collection document counts across both databases; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/namespaces.js
+++ b/test/qa-tests/jstests/restore/namespaces.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover --nsExclude, --nsInclude, --nsFrom/--nsTo but not --excludeCollectionsWithPrefix or complex pattern variables; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/no_index_restore.js
+++ b/test/qa-tests/jstests/restore/no_index_restore.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests use --noIndexRestore only in timeseries context; no Go test verifies the general case on normal collections; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/no_options_restore.js
+++ b/test/qa-tests/jstests/restore/no_options_restore.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests use --noOptionsRestore only in timeseries context; no Go test verifies capped collections become non-capped or validators are stripped; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/nonempty_temp_users.js
+++ b/test/qa-tests/jstests/restore/nonempty_temp_users.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestRestoreUsersOrRoles covers cleanup of temp collections but not the case where admin.tempusers already contains data before restore begins; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/norestore_profile.js
+++ b/test/qa-tests/jstests/restore/norestore_profile.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test specifically verifies system.profile is not restored; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/objcheck_valid_bson.js
+++ b/test/qa-tests/jstests/restore/objcheck_valid_bson.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — every Go restore test uses valid BSON implicitly, but no Go test explicitly passes --objcheck and verifies the flag is accepted and restore succeeds; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/oplog_replay_and_limit.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_and_limit.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/oplog_replay_conflict.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_conflict.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 /**
  * oplog_replay_conflict.js
  *

--- a/test/qa-tests/jstests/restore/oplog_replay_local_rs.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_local_rs.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 /**
  * oplog_replay_local_rs.js
  *

--- a/test/qa-tests/jstests/restore/oplog_replay_no_oplog.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_no_oplog.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 (function() {
 
   load("jstests/configs/standard_dump_targets.config.js");

--- a/test/qa-tests/jstests/restore/oplog_replay_noop.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_noop.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/oplog_replay_priority_oplog.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_priority_oplog.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 /**
  * oplog_replay_priority_oplog.js
  *

--- a/test/qa-tests/jstests/restore/oplog_replay_size_safety.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_size_safety.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/oplog_replay_specify_file.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_specify_file.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 /**
  * oplog_replay_specify_file.js
  *

--- a/test/qa-tests/jstests/restore/ordered_partial_index.js
+++ b/test/qa-tests/jstests/restore/ordered_partial_index.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ShardedIntegrationTestType)
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/partial_restore.js
+++ b/test/qa-tests/jstests/restore/partial_restore.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — Go tests cover --nsInclude for single-collection restore but not the --db path with a subdirectory target; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/preserve_oplog_structure_order.js
+++ b/test/qa-tests/jstests/restore/preserve_oplog_structure_order.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in oplog_test.go (ReplSetTestType)
 (function() {
 
   load('jstests/common/check_version.js');

--- a/test/qa-tests/jstests/restore/restore_document_validation.js
+++ b/test/qa-tests/jstests/restore/restore_document_validation.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test creates a validated collection and tests restore rejection, --bypassDocumentValidation, --stopOnError, or --maintainInsertionOrder with validation errors; goes in mongorestore/mongorestore_qa_test.go
 /**
  * restore_document_validation.js
  *

--- a/test/qa-tests/jstests/restore/sharded_fullrestore.js
+++ b/test/qa-tests/jstests/restore/sharded_fullrestore.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — requires sharded cluster; goes in mongorestore/mongorestore_qa_test.go (ShardedIntegrationTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/sharding_28.config.js');

--- a/test/qa-tests/jstests/restore/slash_in_collectionname.js
+++ b/test/qa-tests/jstests/restore/slash_in_collectionname.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — special characters in collection names covered by mongorestore_test.go
 // Tests using mongodump/mongorestore to dump/restore data from/to a collection with a slash in its name
 
 (function() {

--- a/test/qa-tests/jstests/restore/stop_on_error.js
+++ b/test/qa-tests/jstests/restore/stop_on_error.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — --stopOnError covered by mongorestore_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/symlinks.js
+++ b/test/qa-tests/jstests/restore/symlinks.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go test exercises restoring from a dump directory containing symlinked files; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   // Tests using mongorestore on a dump directory containing symlinks

--- a/test/qa-tests/jstests/restore/users_and_roles.js
+++ b/test/qa-tests/jstests/restore/users_and_roles.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestDumpRestoreSingleDBWithDBUsersAndRoles covers the main round-trip but TestRestoreUsersOrRoles only covers tempusers cleanup; goes in mongorestore/dumprestore_auth_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/users_and_roles_admin.js
+++ b/test/qa-tests/jstests/restore/users_and_roles_admin.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestDumpRestorePreservesAdminUsersAndRoles covers many scenarios under AuthTestType but missing dump-without-flag and --drop-override cases; goes in mongorestore/dumprestore_auth_test.go
 // Tests that mongodump and mongorestore properly handle access control information when doing
 // single-db dumps and restores. Tests proper handling of dumping and restoring the admin database.
 // This test is derived from legacy30 test dumprestore_auth3.js

--- a/test/qa-tests/jstests/restore/users_and_roles_temp_collections.js
+++ b/test/qa-tests/jstests/restore/users_and_roles_temp_collections.js
@@ -1,3 +1,4 @@
+// MIGRATION: EXTEND — TestRestoreUsersOrRoles covers tempusers cleanup but no Go test exercises --tempUsersColl and --tempRolesColl custom temp collection name options; goes in mongorestore/mongorestore_qa_test.go
 (function() {
 
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/restore/write_concern.js
+++ b/test/qa-tests/jstests/restore/write_concern.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ReplSetTestType)
 /* TODO: fix and re-enable test, see TOOLS-3017
 (function() {
 

--- a/test/qa-tests/jstests/restore/write_concern_mongos.js
+++ b/test/qa-tests/jstests/restore/write_concern_mongos.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongorestore_test.go (ShardedIntegrationTestType)
 /* TODO: fix and re-enable test, see TOOLS-3017
 (function() {
 

--- a/test/qa-tests/jstests/ssl/ssl_with_system_ca.js
+++ b/test/qa-tests/jstests/ssl/ssl_with_system_ca.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in new SSL integration test
 // On OSX this test assumes that jstests/libs/trusted-ca.pem has been added as a trusted
 // certificate to the login keychain of the evergreen user. See,
 // https://github.com/10gen/buildslave-cookbooks/commit/af7cabe5b6e0885902ebd4902f7f974b64cc8961

--- a/test/qa-tests/jstests/stat/stat_auth.js
+++ b/test/qa-tests/jstests/stat/stat_auth.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongostat_test.go (ShardedIntegrationTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/stat/stat_broken_pipe.js
+++ b/test/qa-tests/jstests/stat/stat_broken_pipe.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — broken pipe is OS-signal-level, not testable in Go
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/stat/stat_custom_headers.js
+++ b/test/qa-tests/jstests/stat/stat_custom_headers.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongostat_test.go (ShardedIntegrationTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/stat/stat_discover.js
+++ b/test/qa-tests/jstests/stat/stat_discover.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — test is disabled per TOOLS-3018
 /* TODO: fix and re-enable test, see TOOLS-3018
 (function() {
   if (typeof getToolTest === 'undefined') {

--- a/test/qa-tests/jstests/stat/stat_discover_shard.js
+++ b/test/qa-tests/jstests/stat/stat_discover_shard.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongostat_test.go (ShardedIntegrationTestType)
 (function() {
   load("jstests/libs/output.js");
 

--- a/test/qa-tests/jstests/stat/stat_header.js
+++ b/test/qa-tests/jstests/stat/stat_header.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongostat_test.go (ShardedIntegrationTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/stat/stat_rowcount.js
+++ b/test/qa-tests/jstests/stat/stat_rowcount.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongostat_test.go (ShardedIntegrationTestType)
 (function() {
   if (typeof getToolTest === 'undefined') {
     load('jstests/configs/plain_28.config.js');

--- a/test/qa-tests/jstests/tls/tls_with_system_ca.js
+++ b/test/qa-tests/jstests/tls/tls_with_system_ca.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in new TLS integration test
 // On OSX this test assumes that jstests/libs/trusted-ca.pem has been added as a trusted
 // certificate to the login keychain of the evergreen user. See,
 // https://github.com/10gen/buildslave-cookbooks/commit/af7cabe5b6e0885902ebd4902f7f974b64cc8961

--- a/test/qa-tests/jstests/top/mongotop_json.js
+++ b/test/qa-tests/jstests/top/mongotop_json.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — options_test.go only tests argument parsing; no Go test runs mongotop and verifies JSON output; goes in mongotop/mongotop_test.go
 // mongotop_json.js; ensure that running mongotop using the --json flag works as
 // expected
 var testName = 'mongotop_json';

--- a/test/qa-tests/jstests/top/mongotop_reports.js
+++ b/test/qa-tests/jstests/top/mongotop_reports.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — options_test.go only tests argument parsing; no Go test runs mongotop and verifies namespace activity reporting; goes in mongotop/mongotop_test.go
 // mongotop_reports.js; ensure that running mongotop reports accurately on operations
 // going on in namespaces
 var testName = 'mongotop_reports';

--- a/test/qa-tests/jstests/top/mongotop_sharded.js
+++ b/test/qa-tests/jstests/top/mongotop_sharded.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in mongotop package integration test (ShardedIntegrationTestType)
 // mongotop_sharded.js; ensure that running mongotop against a sharded cluster
 // fails with a useful error message
 var testName = 'mongotop_sharded';

--- a/test/qa-tests/jstests/top/mongotop_stress.js
+++ b/test/qa-tests/jstests/top/mongotop_stress.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — no Go coverage, goes in new stress test file in mongotop package
 // mongotop_stress.js; ensure that running mongotop, even when the server is
 // under heavy load, works as expected
 var testName = 'mongotop_stress';

--- a/test/qa-tests/jstests/top/mongotop_validation.js
+++ b/test/qa-tests/jstests/top/mongotop_validation.js
@@ -1,3 +1,4 @@
+// MIGRATION: NEW — options_test.go only tests positional argument parsing; no Go test covers invalid port, invalid rowcount, negative sleep time errors; goes in mongotop/mongotop_test.go
 // mongotop_validation.js; ensure that running mongotop using invalid arguments
 // fail as expected
 var testName = 'mongotop_validation';

--- a/test/qa-tests/jstests/txn/active-txn-timestamp.js
+++ b/test/qa-tests/jstests/txn/active-txn-timestamp.js
@@ -1,3 +1,4 @@
+// MIGRATION: SKIP — test is disabled per TOOLS-2660
 // Verifies that mongodump --oplog will start the oplog dump from the active
 // transaction timestamp instead of the last entry in the oplog, if a transaction
 // is in progress.


### PR DESCRIPTION
Adds a // MIGRATION: comment to the first line of every JS test file under test/qa-tests/ and test/legacy42/ indicating its migration status:

- SKIP (27 files): genuinely covered by existing Go tests, broken pipe   tests (OS-signal-level, not testable in Go), or already disabled
- NEW (111 files): no Go test coverage exists for this scenario
- EXTEND (41 files): partial Go coverage exists but specific sub-scenarios   are missing

Each annotation includes the justification and the target Go test file.