### PR TITLE
Fix linting ignore rule for bson types like `bson.D`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
         path: \.go$
         text: is deprecated
       - path: (.+)\.go$
-        text: "composites: .+(primitive.(Binary|Decimal128|E|Timestamp)|types.(Destination|Source)(Client|Database)) struct literal uses unkeyed fields"
+        text: "composites: .+(bson.(Binary|Decimal128|E|Timestamp)|types.(Destination|Source)(Client|Database)) struct literal uses unkeyed fields"
     paths:
       - third_party$
       - builtin$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,12 @@ go run build.go sa:modtidy   # go mod tidy
 - New tests should use `testify` (`github.com/stretchr/testify/require` and `assert`). The codebase
   is actively migrating away from GoConvey — do not add new GoConvey tests.
 
+## Linting
+
+Run `go run build.go sa:lint` to check for lint errors. Ignore LSP diagnostics that are suppressed
+by `.golangci.yml` — in particular, `bson.E struct literal uses unkeyed fields` is explicitly
+allowed and should not be treated as an error.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
The package changed when we converted to v2 of the Go driver, but we didn't update the golangci-lint config.