### PR TITLE
Fix evergreen-validate failures in CI

### DIFF
--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -403,16 +403,21 @@ func SAEvergreenValidate(ctx *task.Context) error {
 		return fmt.Errorf("error from `evergreen validate`: %s: %w", output, err)
 	}
 
-	// TODO: change this if-block in TOOLS-2840.
-	// This check ignores any YAML warnings related to duplicate keys in YAML maps.
-	// See ticket for more details.
 	if strings.HasSuffix(output, "is valid with warnings") {
 		for _, line := range strings.Split(output, "\n") {
-			if !strings.HasSuffix(line, "unmarshal errors:") &&
-				!strings.HasSuffix(line, "already set in map") &&
-				!strings.HasSuffix(line, "is valid with warnings") {
-				return fmt.Errorf("error from `evergreen validate`: %s", output)
+			if strings.HasPrefix(line, "WARNING: ") &&
+				strings.HasSuffix(
+					line,
+					"defined but not used by any variants; consider using or disabling",
+				) {
+				continue
 			}
+
+			if strings.HasSuffix(line, "is valid with warnings") {
+				continue
+			}
+
+			return fmt.Errorf("error from `evergreen validate`: %s", output)
 		}
 	}
 

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -70,7 +70,7 @@ tasks:
         params:
           files:
             - src/github.com/mongodb/mongo-tools/manual-tasks.json
-    patch_only: true
+    allowed_requesters: ["patch"]
 
   # Task dependencies have been changed slightly here, to allow this
   # task to execute concurrently with "compile_coverage".


### PR DESCRIPTION
This also rewrites the code that ignores certain warnings to be a bit clearer.