### PR TITLE
TOOLS-4154 Fix handling empty `partialFilterExpression` option 

### DIFF
--- a/common/idx/idx.go
+++ b/common/idx/idx.go
@@ -18,7 +18,7 @@ import (
 type IndexDocument struct {
 	Options                 bson.M `bson:",inline"`
 	Key                     bson.D `bson:"key"`
-	PartialFilterExpression bson.D `bson:"partialFilterExpression,omitempty"`
+	PartialFilterExpression *bson.D `bson:"partialFilterExpression,omitempty"`
 }
 
 // newIndexDocumentFromD converts a bson.D index spec into an IndexDocument. This is only used in
@@ -37,7 +37,8 @@ func newIndexDocumentFromD(doc bson.D) (*IndexDocument, error) {
 			}
 		case "partialFilterExpression":
 			if val, ok := elem.Value.(bson.D); ok {
-				indexDoc.PartialFilterExpression = val
+				partialFilterExpression := val
+				indexDoc.PartialFilterExpression = &partialFilterExpression
 				continue
 			} else {
 				return nil, fmt.Errorf("index partialFilterExpression could not type assert to bson.D")

--- a/common/idx/idx.go
+++ b/common/idx/idx.go
@@ -16,8 +16,8 @@ import (
 
 // IndexDocument holds information about a collection's index.
 type IndexDocument struct {
-	Options                 bson.M `bson:",inline"`
-	Key                     bson.D `bson:"key"`
+	Options                 bson.M  `bson:",inline"`
+	Key                     bson.D  `bson:"key"`
 	PartialFilterExpression *bson.D `bson:"partialFilterExpression,omitempty"`
 }
 

--- a/common/idx/idx_test.go
+++ b/common/idx/idx_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -47,3 +48,37 @@ func TestIsDefaultIdIndex(t *testing.T) {
 		)
 	}
 }
+
+func TestIndexDocumentMarshalPartialFilterExpression(t *testing.T) {
+	t.Run("omits partialFilterExpression when nil", func(t *testing.T) {
+		indexDoc := IndexDocument{Key: bson.D{{"_id", 1}}}
+
+		bytes, err := bson.Marshal(indexDoc)
+		require.NoError(t, err)
+
+		_, err = bson.Raw(bytes).LookupErr("partialFilterExpression")
+		assert.Error(t, err, "expected partialFilterExpression to be omitted when nil")
+	})
+
+	t.Run("keeps partialFilterExpression when empty document", func(t *testing.T) {
+		emptyPartialFilterExpression := bson.D{}
+		indexDoc := IndexDocument{
+			Key:                     bson.D{{"_id", 1}},
+			PartialFilterExpression: &emptyPartialFilterExpression,
+		}
+
+		bytes, err := bson.Marshal(indexDoc)
+		require.NoError(t, err)
+
+		partialFilterExpressionValue, err := bson.Raw(bytes).LookupErr("partialFilterExpression")
+		require.NoError(t, err, "expected partialFilterExpression to be present")
+
+		partialFilterExpressionDoc, ok := partialFilterExpressionValue.DocumentOK()
+		require.True(t, ok, "expected partialFilterExpression to marshal as a document")
+
+		elements, err := partialFilterExpressionDoc.Elements()
+		require.NoError(t, err)
+		assert.Len(t, elements, 0, "expected partialFilterExpression to marshal as an empty document")
+	})
+}
+

--- a/common/idx/idx_test.go
+++ b/common/idx/idx_test.go
@@ -78,7 +78,50 @@ func TestIndexDocumentMarshalPartialFilterExpression(t *testing.T) {
 
 		elements, err := partialFilterExpressionDoc.Elements()
 		require.NoError(t, err)
-		assert.Len(t, elements, 0, "expected partialFilterExpression to marshal as an empty document")
+		assert.Len(
+			t,
+			elements,
+			0,
+			"expected partialFilterExpression to marshal as an empty document",
+		)
 	})
-}
 
+	t.Run(
+		"round-trip marshal and unmarshal with empty partialFilterExpression",
+		func(t *testing.T) {
+			// Create an index document with an empty partial filter expression
+			emptyPartialFilterExpression := bson.D{}
+			originalDoc := IndexDocument{
+				Key:                     bson.D{{"field", int32(1)}},
+				PartialFilterExpression: &emptyPartialFilterExpression,
+				Options:                 bson.M{"name": "field_1"},
+			}
+
+			marshaled, err := bson.Marshal(originalDoc)
+			require.NoError(t, err)
+
+			var unmarshaled IndexDocument
+			err = bson.Unmarshal(marshaled, &unmarshaled)
+			require.NoError(t, err)
+
+			// Verify the empty partial filter expression is preserved
+			assert.NotNil(
+				t,
+				unmarshaled.PartialFilterExpression,
+				"expected partialFilterExpression to be non-nil after round-trip",
+			)
+			assert.Equal(
+				t,
+				len(*unmarshaled.PartialFilterExpression),
+				0,
+				"expected empty partialFilterExpression to remain empty",
+			)
+			assert.Equal(
+				t,
+				originalDoc.Key,
+				unmarshaled.Key,
+				"expected key to match after round-trip",
+			)
+		},
+	)
+}

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -629,7 +629,8 @@ func extractIndexDocumentFromCommitIndexBuilds(op db.Oplog) (string, []*idx.Inde
 						indexSpec.Key = elem.Value.(bson.D)
 					case "partialFilterExpression":
 						//nolint:errcheck
-						indexSpec.PartialFilterExpression = elem.Value.(bson.D)
+						partialFilterExpression := elem.Value.(bson.D)
+						indexSpec.PartialFilterExpression = &partialFilterExpression
 					default:
 						indexSpec.Options[elem.Key] = elem.Value
 					}
@@ -659,7 +660,8 @@ func extractIndexDocumentFromCreateIndexes(op db.Oplog) (string, *idx.IndexDocum
 			indexDocument.Key = elem.Value.(bson.D)
 		case "partialFilterExpression":
 			//nolint:errcheck
-			indexDocument.PartialFilterExpression = elem.Value.(bson.D)
+			partialFilterExpression := elem.Value.(bson.D)
+			indexDocument.PartialFilterExpression = &partialFilterExpression
 		default:
 			indexDocument.Options[elem.Key] = elem.Value
 		}


### PR DESCRIPTION
This commit makes the `PartialFilterExpression` field a pointer so that it's not omitted when set to a valid empty document.  