### PR TITLE
Add a name to our `package.json` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mongo-tools",
       "devDependencies": {
         "eslint": "8.57.0",
         "github-codeowners": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "mongo-tools",
   "devDependencies": {
     "eslint": "8.57.0",
     "github-codeowners": "0.2.1",


### PR DESCRIPTION
If this isn't set, then every time we run `npm`, it updates the name in the `package-lock.json` file to match the current directory. I discovered this when working in a second copy of the tools repo in a directory named `mongo-tools2`.