### PR TITLE
TOOLS-4158 Properly escape DB and collection names in tool output

### DIFF
--- a/common/util/strings.go
+++ b/common/util/strings.go
@@ -6,7 +6,13 @@
 
 package util
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/samber/lo"
+)
 
 // Pluralize takes an amount and two strings denoting the singular
 // and plural noun the amount represents. If the amount is singular,
@@ -18,6 +24,15 @@ func Pluralize(amount int, singular, plural string) string {
 		return singular
 	}
 	return plural
+}
+
+// QuoteAndJoin quotes each string in ss using Go's %#q format, then joins
+// them with sep. This makes special characters in each element visible in log
+// output.
+func QuoteAndJoin(ss []string, sep string) string {
+	return strings.Join(lo.Map(ss, func(s string, _ int) string {
+		return fmt.Sprintf("%#q", s)
+	}), sep)
 }
 
 var uriRedactionRE = regexp.MustCompile(`^([^:]+)://[^/?]*@`)

--- a/common/util/strings_test.go
+++ b/common/util/strings_test.go
@@ -4,7 +4,60 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestQuoteAndJoin(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	cases := []struct {
+		input   []string
+		sep     string
+		expect  string
+		message string
+	}{
+		{
+			input:   []string{"foo", "bar", "baz"},
+			sep:     ", ",
+			expect:  "`foo`, `bar`, `baz`",
+			message: "plain strings are backtick-quoted",
+		},
+		{
+			input:   []string{"has space", "has\nnewline"},
+			sep:     ", ",
+			expect:  "`has space`, \"has\\nnewline\"",
+			message: "strings with spaces use backticks; newlines force double-quoting with escaping",
+		},
+		{
+			input:   []string{"weird\x00name"},
+			sep:     ",",
+			expect:  `"weird\x00name"`,
+			message: "null bytes are escaped with double-quoting",
+		},
+		{
+			input:   []string{"has`backtick"},
+			sep:     ",",
+			expect:  "\"has`backtick\"",
+			message: "strings containing backticks are double-quoted",
+		},
+		{
+			input:   []string{},
+			sep:     ", ",
+			expect:  "",
+			message: "empty slice produces empty string",
+		},
+		{
+			input:   []string{"only"},
+			sep:     ", ",
+			expect:  "`only`",
+			message: "single element has no separator",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expect, QuoteAndJoin(c.input, c.sep), c.message)
+	}
+}
 
 func TestSanitizeURI(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -67,7 +67,7 @@ func (dump *MongoDump) dumpMetadata(
 	// We keep a running list of all the indexes
 	// for the current collection as we iterate over the cursor, and include
 	// that list as the "indexes" field of the metadata document.
-	log.Logvf(log.DebugHigh, "\treading indexes for `%v`", intent.Namespace())
+	log.Logvf(log.DebugHigh, "\treading indexes for %#q", intent.Namespace())
 
 	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
@@ -77,7 +77,7 @@ func (dump *MongoDump) dumpMetadata(
 	if dump.OutputOptions.ViewsAsCollections || intent.IsView() {
 		log.Logvf(
 			log.DebugLow,
-			"not dumping indexes metadata for '%v' because it is a view",
+			"not dumping indexes metadata for %#q because it is a view",
 			intent.Namespace(),
 		)
 	} else {
@@ -87,7 +87,7 @@ func (dump *MongoDump) dumpMetadata(
 			return err
 		}
 		if indexesIter == nil {
-			log.Logvf(log.Always, "the collection %v appears to have been dropped after the dump started", intent.Namespace())
+			log.Logvf(log.Always, "the collection %#q appears to have been dropped after the dump started", intent.Namespace())
 			return nil
 		}
 		defer indexesIter.Close(context.Background())

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -233,7 +233,7 @@ func (dump *MongoDump) Dump() (err error) {
 		return fmt.Errorf("error verifying collection info: %v", err)
 	}
 	if !exists {
-		log.Logvf(log.Always, "namespace with DB %s and collection %s does not exist",
+		log.Logvf(log.Always, "namespace with DB %#q and collection %#q does not exist",
 			dump.ToolOptions.DB, dump.ToolOptions.Collection)
 		return nil
 	}
@@ -414,7 +414,7 @@ func (dump *MongoDump) Dump() (err error) {
 			}
 		}
 		if dump.OutputOptions.DumpDBUsersAndRoles {
-			log.Logvf(log.Always, "dumping users and roles for %v", dump.ToolOptions.DB)
+			log.Logvf(log.Always, "dumping users and roles for %#q", dump.ToolOptions.DB)
 			if dump.ToolOptions.DB == "admin" {
 				log.Logvf(log.Always, "skipping users/roles dump, already dumped admin database")
 			} else {
@@ -477,7 +477,7 @@ func (dump *MongoDump) Dump() (err error) {
 		}
 		log.Logvf(log.DebugHigh, "oplog entry %v still exists", dump.oplogStart)
 
-		log.Logvf(log.Always, "writing captured oplog to %v", dump.manager.Oplog().Location)
+		log.Logvf(log.Always, "writing captured oplog to %#q", dump.manager.Oplog().Location)
 
 		err = dump.DumpOplogBetweenTimestamps(dump.oplogStart, dump.oplogEnd)
 		if err != nil {
@@ -645,7 +645,7 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 	var dumpCount int64
 
 	if dump.OutputOptions.Out == "-" {
-		log.Logvf(log.Always, "writing %v to stdout", intent.DataNamespace())
+		log.Logvf(log.Always, "writing %#q to stdout", intent.DataNamespace())
 		dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer)
 		if err == nil {
 			// on success, print the document count
@@ -654,14 +654,14 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 		return err
 	}
 
-	log.Logvf(log.Always, "writing %v to %v", intent.DataNamespace(), intent.Location)
+	log.Logvf(log.Always, "writing %#q to %#q", intent.DataNamespace(), intent.Location)
 	if dumpCount, err = dump.dumpQueryToIntent(findQuery, intent, buffer); err != nil {
 		return err
 	}
 
 	log.Logvf(
 		log.Always,
-		"done dumping %v (%v %v)",
+		"done dumping %#q (%v %v)",
 		intent.DataNamespace(),
 		dumpCount,
 		docPlural(dumpCount),
@@ -688,15 +688,14 @@ func (dump *MongoDump) dumpQueryToIntent(
 // the oplog collection to avoid the performance issue in TOOLS-2068.
 func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent) (int64, error) {
 	if len(dump.query) != 0 || intent.IsOplog() {
-		log.Logvf(log.DebugLow, "not counting query on %v", intent.Namespace())
+		log.Logvf(log.DebugLow, "not counting query on %#q", intent.Namespace())
 		return 0, nil
 	}
 
 	log.Logvf(
 		log.DebugHigh,
-		"Getting estimated count for %v.%v",
-		query.Coll.Database().Name(),
-		query.Coll.Name(),
+		"Getting estimated count for %#q",
+		query.Coll.Database().Name()+"."+query.Coll.Name(),
 	)
 	// We call getCount() when we are dumping a collection. If we are dumping views as collections, we need to run a
 	// count instead of an estimatedDocumentCount which uses collStats. We don't do this if the intent is timeseries because
@@ -708,7 +707,7 @@ func (dump *MongoDump) getCount(query *db.DeferredQuery, intent *intents.Intent)
 
 	log.Logvf(
 		log.DebugLow,
-		"counted %v %v in %v",
+		"counted %v %v in %#q",
 		total,
 		docPlural(int64(total)),
 		intent.Namespace(),

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -60,7 +60,7 @@ type realBSONFile struct {
 func (f *realBSONFile) Open() (err error) {
 	if f.path == "" {
 		// This should not occur normally. All realBSONFile's should have a path
-		return fmt.Errorf("error creating BSON file without a path, namespace: %v",
+		return fmt.Errorf("error creating BSON file without a path, namespace: %#q",
 			f.intent.Namespace())
 	}
 	err = os.MkdirAll(filepath.Dir(f.path), os.ModeDir|os.ModePerm)
@@ -71,7 +71,7 @@ func (f *realBSONFile) Open() (err error) {
 
 	f.WriteCloser, err = os.Create(f.path)
 	if err != nil {
-		return fmt.Errorf("error creating BSON file %v: %v", f.path, err)
+		return fmt.Errorf("error creating BSON file %#q: %v", f.path, err)
 	}
 
 	return nil
@@ -91,7 +91,7 @@ type realMetadataFile struct {
 // Open opens the file on disk that the intent indicates. Any directories needed are created.
 func (f *realMetadataFile) Open() (err error) {
 	if f.path == "" {
-		return fmt.Errorf("No metadata path for %v.%v", f.intent.DB, f.intent.C)
+		return fmt.Errorf("No metadata path for %#q.%#q", f.intent.DB, f.intent.C)
 	}
 	err = os.MkdirAll(filepath.Dir(f.path), os.ModeDir|os.ModePerm)
 	if err != nil {
@@ -101,7 +101,7 @@ func (f *realMetadataFile) Open() (err error) {
 
 	f.WriteCloser, err = os.Create(f.path)
 	if err != nil {
-		return fmt.Errorf("error creating metadata file %v: %v", f.path, err)
+		return fmt.Errorf("error creating metadata file %#q: %v", f.path, err)
 	}
 	return nil
 }
@@ -282,7 +282,7 @@ func (dump *MongoDump) CreateUsersRolesVersionIntentsForDB(db string) error {
 // collection is specified by --db and --collection.
 func (dump *MongoDump) CreateCollectionIntent(dbName, colName string) error {
 	if dump.shouldSkipCollection(colName) {
-		log.Logvf(log.DebugLow, "skipping dump of %v.%v, it is excluded", dbName, colName)
+		log.Logvf(log.DebugLow, "skipping dump of %#q, it is excluded", dbName+"."+colName)
 		return nil
 	}
 
@@ -341,7 +341,7 @@ func (dump *MongoDump) NewIntentFromOptions(
 			intent.BSONFile = &realBSONFile{path: path, intent: intent}
 			intent.Location = path
 		} else if ci.IsView() && !dump.OutputOptions.ViewsAsCollections {
-			log.Logvf(log.DebugLow, "not dumping data for %v.%v because it is a view", dbName, ci.Name)
+			log.Logvf(log.DebugLow, "not dumping data for %#q because it is a view", dbName+"."+ci.Name)
 		} else {
 			// otherwise, if it's either not a view or we're treating views as collections
 			// then create a standard filesystem path for this collection.
@@ -378,7 +378,7 @@ func (dump *MongoDump) NewIntentFromOptions(
 	if err != nil {
 		return nil, err
 	}
-	log.Logvf(log.DebugHigh, "Getting estimated count for %v.%v", dbName, ci.Name)
+	log.Logvf(log.DebugHigh, "Getting estimated count for %#q", dbName+"."+ci.Name)
 	count, err := session.Database(dbName).
 		Collection(ci.Name).
 		EstimatedDocumentCount(context.Background())
@@ -401,7 +401,7 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 
 	colsIter, err := db.GetCollections(session.Database(dbName), "")
 	if err != nil {
-		return fmt.Errorf("error getting collections for database `%v`: %v", dbName, err)
+		return fmt.Errorf("error getting collections for database %#q: %v", dbName, err)
 	}
 	defer colsIter.Close(context.Background())
 
@@ -423,24 +423,26 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 		if dump.shouldSkipSystemNamespace(dbName, collInfo.Name) {
 			log.Logvf(
 				log.DebugHigh,
-				"will not dump system collection '%s.%s'",
-				dbName,
-				collInfo.Name,
+				"will not dump system collection %#q",
+				dbName+"."+collInfo.Name,
 			)
 			continue
 		}
 
 		if dump.shouldSkipCollection(collInfo.Name) {
-			log.Logvf(log.DebugLow, "skipping dump of %v.%v, it is excluded", dbName, collInfo.Name)
+			log.Logvf(
+				log.DebugLow,
+				"skipping dump of %#q, it is excluded",
+				dbName+"."+collInfo.Name,
+			)
 			continue
 		}
 
 		if dump.OutputOptions.ViewsAsCollections && !collInfo.IsView() {
 			log.Logvf(
 				log.DebugLow,
-				"skipping dump of %v.%v because it is not a view",
-				dbName,
-				collInfo.Name,
+				"skipping dump of %#q because it is not a view",
+				dbName+"."+collInfo.Name,
 			)
 			continue
 		}
@@ -489,7 +491,7 @@ func (dump *MongoDump) GetValidDbs() ([]string, error) {
 
 	dbs = lo.Without(dbs, internalDBs...)
 
-	log.Logvf(log.DebugHigh, "found databases: %v", strings.Join(dbs, ", "))
+	log.Logvf(log.DebugHigh, "found databases: %v", util.QuoteAndJoin(dbs, ", "))
 
 	for _, dbName := range dbs {
 		if dbName == "local" {
@@ -517,7 +519,7 @@ func (dump *MongoDump) CreateAllIntents() error {
 	}
 	for _, dbName := range dbs {
 		if err := dump.CreateIntentsForDatabase(dbName); err != nil {
-			return fmt.Errorf("error creating intents for database %s: %v", dbName, err)
+			return fmt.Errorf("error creating intents for database %#q: %v", dbName, err)
 		}
 	}
 	return nil

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -297,9 +297,8 @@ func (exp *MongoExport) getCount() (int64, error) {
 
 	log.Logvf(
 		log.DebugHigh,
-		"Getting estimated count for %v.%v",
-		exp.ToolOptions.DB,
-		exp.ToolOptions.Collection,
+		"Getting estimated count for %#q",
+		exp.ToolOptions.DB+"."+exp.ToolOptions.Collection,
 	)
 	c, err := coll.EstimatedDocumentCount(context.TODO())
 	if err != nil {

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -224,7 +224,7 @@ func getUpsertValue(field string, document bson.D) any {
 	left := field[0:index]
 	subDoc, _ := bsonutil.FindValueByKey(left, &document)
 	if subDoc == nil {
-		log.Logvf(log.DebugHigh, "no subdoc found for '%v'", left)
+		log.Logvf(log.DebugHigh, "no subdoc found for %#q", left)
 		return nil
 	}
 	switch subDoc := subDoc.(type) {
@@ -235,7 +235,7 @@ func getUpsertValue(field string, document bson.D) any {
 		subDocD := subDoc
 		return getUpsertValue(field[index+1:], *subDocD)
 	default:
-		log.Logvf(log.DebugHigh, "subdoc found for '%v', but couldn't coerce to bson.D", left)
+		log.Logvf(log.DebugHigh, "subdoc found for %#q, but couldn't coerce to bson.D", left)
 		return nil
 	}
 }
@@ -524,8 +524,8 @@ func tokensToBSON(
 		if index < len(colSpecs) {
 			parsedValue, err := colSpecs[index].Parser.Parse(token)
 			if err != nil {
-				log.Logvf(log.DebugHigh, "parse failure in document #%d for column '%s',"+
-					"could not parse token '%s' to type %s",
+				log.Logvf(log.DebugHigh, "parse failure in document #%d for column %#q,"+
+					"could not parse token %#q to type %s",
 					numProcessed, colSpecs[index].Name, token, colSpecs[index].TypeName)
 				switch colSpecs[index].ParseGrace {
 				case pgAutoCast:
@@ -841,9 +841,9 @@ func validateReaderFields(fields []string, useArrayIndexFields bool) error {
 		return err
 	}
 	if len(fields) == 1 {
-		log.Logvf(log.Info, "using field: %v", fields[0])
+		log.Logvf(log.Info, "using field: %#q", fields[0])
 	} else {
-		log.Logvf(log.Info, "using fields: %v", strings.Join(fields, ","))
+		log.Logvf(log.Info, "using fields: %v", util.QuoteAndJoin(fields, ","))
 	}
 	return nil
 }

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -241,7 +241,7 @@ func (imp *MongoImport) validateSettings() error {
 
 	if imp.IngestOptions.Mode != modeInsert {
 		imp.IngestOptions.MaintainInsertionOrder = true
-		log.Logvf(log.Info, "using upsert fields: %v", imp.upsertFields)
+		log.Logvf(log.Info, "using upsert fields: %v", util.QuoteAndJoin(imp.upsertFields, ","))
 	}
 
 	if imp.IngestOptions.MaintainInsertionOrder {
@@ -273,7 +273,7 @@ func (imp *MongoImport) validateSettings() error {
 		if lastDotIndex != -1 {
 			fileBaseName = fileBaseName[0:lastDotIndex]
 		}
-		log.Logvf(log.Always, "using filename '%v' as collection", fileBaseName)
+		log.Logvf(log.Always, "using filename %#q as collection", fileBaseName)
 		imp.ToolOptions.Collection = fileBaseName
 	}
 	err = util.ValidateCollectionName(imp.ToolOptions.Collection)
@@ -372,9 +372,7 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (uint64, uint64
 		util.SanitizeURI(imp.ToolOptions.ConnectionString),
 	)
 
-	log.Logvf(log.Info, "ns: %v.%v",
-		imp.ToolOptions.DB,
-		imp.ToolOptions.Collection)
+	log.Logvf(log.Info, "ns: %#q", imp.ToolOptions.DB+"."+imp.ToolOptions.Collection)
 
 	// check if the server is a replica set, mongos, or standalone
 	imp.nodeType, err = imp.SessionProvider.GetNodeType()
@@ -385,9 +383,7 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (uint64, uint64
 
 	// drop the database if necessary
 	if imp.IngestOptions.Drop {
-		log.Logvf(log.Always, "dropping: %v.%v",
-			imp.ToolOptions.DB,
-			imp.ToolOptions.Collection)
+		log.Logvf(log.Always, "dropping: %#q", imp.ToolOptions.DB+"."+imp.ToolOptions.Collection)
 		collection := session.Database(imp.ToolOptions.DB).
 			Collection(imp.ToolOptions.Collection)
 		if err := collection.Drop(context.TODO()); err != nil {

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -105,18 +105,18 @@ type realBSONFile struct {
 func (f *realBSONFile) Open() (err error) {
 	if f.path == "" {
 		// this error shouldn't happen normally
-		return fmt.Errorf("error reading BSON file for %v", f.intent.Namespace())
+		return fmt.Errorf("error reading BSON file for %#q", f.intent.Namespace())
 	}
 	file, err := os.Open(f.path)
 	if err != nil {
-		return fmt.Errorf("error reading BSON file %v: %v", f.path, err)
+		return fmt.Errorf("error reading BSON file %#q: %v", f.path, err)
 	}
 	posFile := &posTrackingReader{0, file}
 	if f.gzip {
 		gzFile, err := gzip.NewReader(posFile)
 		posUncompressedFile := &posTrackingReader{0, gzFile}
 		if err != nil {
-			return fmt.Errorf("error decompressing compresed BSON file %v: %v", f.path, err)
+			return fmt.Errorf("error decompressing compresed BSON file %#q: %v", f.path, err)
 		}
 		f.PosReader = &mixedPosTrackingReader{
 			readHolder: posUncompressedFile,
@@ -146,16 +146,16 @@ type realMetadataFile struct {
 // can be called on them.
 func (f *realMetadataFile) Open() (err error) {
 	if f.path == "" {
-		return fmt.Errorf("error reading metadata for %v", f.intent.Namespace())
+		return fmt.Errorf("error reading metadata for %#q", f.intent.Namespace())
 	}
 	file, err := os.Open(f.path)
 	if err != nil {
-		return fmt.Errorf("error reading metadata %v: %v", f.path, err)
+		return fmt.Errorf("error reading metadata %#q: %v", f.path, err)
 	}
 	if f.gzip {
 		gzFile, err := gzip.NewReader(file)
 		if err != nil {
-			return fmt.Errorf("error reading compressed metadata %v: %v", f.path, err)
+			return fmt.Errorf("error reading compressed metadata %#q: %v", f.path, err)
 		}
 		f.ReadCloser = &util.WrappedReadCloser{gzFile, file}
 	} else {
@@ -317,7 +317,7 @@ func (restore *MongoRestore) getCollectionNameFromMetadata(
 // CreateAllIntents drills down into a dump folder, creating intents for all of
 // the databases and collections it finds.
 func (restore *MongoRestore) CreateAllIntents(dir archive.DirLike) error {
-	log.Logvf(log.DebugHigh, "using %v as dump root directory", dir.Path())
+	log.Logvf(log.DebugHigh, "using %#q as dump root directory", dir.Path())
 	entries, err := dir.ReadDir()
 	if err != nil {
 		return fmt.Errorf("error reading root dump folder: %v", err)
@@ -325,7 +325,7 @@ func (restore *MongoRestore) CreateAllIntents(dir archive.DirLike) error {
 	for _, entry := range entries {
 		if entry.IsDir() {
 			if err = util.ValidateDBName(entry.Name()); err != nil {
-				return fmt.Errorf("invalid database name '%v': %v", entry.Name(), err)
+				return fmt.Errorf("invalid database name %#q: %v", entry.Name(), err)
 			}
 
 			// Don't restore anything into the admin DB if connected to atlas proxy.
@@ -378,7 +378,7 @@ func (restore *MongoRestore) CreateAllIntents(dir archive.DirLike) error {
 				}
 				restore.manager.Put(oplogIntent)
 			} else {
-				log.Logvf(log.Always, `don't know what to do with file "%v", skipping...`, entry.Path())
+				log.Logvf(log.Always, `don't know what to do with file %#q, skipping...`, entry.Path())
 			}
 		}
 	}
@@ -393,10 +393,10 @@ func (restore *MongoRestore) CreateIntentForOplog() error {
 	if err != nil {
 		return err
 	}
-	log.Logvf(log.DebugLow, "reading oplog from %v", target.Path())
+	log.Logvf(log.DebugLow, "reading oplog from %#q", target.Path())
 
 	if target.IsDir() {
-		return fmt.Errorf("file %v is a directory, not a bson file", target.Path())
+		return fmt.Errorf("file %#q is a directory, not a bson file", target.Path())
 	}
 
 	// Then create its intent.
@@ -420,7 +420,7 @@ func (restore *MongoRestore) CreateIntentForOplog() error {
 // for all of the collection dump files it finds for the db database.
 func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) (err error) {
 	var entries []archive.DirLike
-	log.Logvf(log.DebugHigh, "reading collections for database %v in %v", db, dir.Name())
+	log.Logvf(log.DebugHigh, "reading collections for database %#q in %#q", db, dir.Name())
 	entries, err = dir.ReadDir()
 	if err != nil {
 		return fmt.Errorf("error reading db folder %v: %v", db, err)
@@ -428,7 +428,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 	usesMetadataFiles := hasMetadataFiles(entries)
 	for _, entry := range entries {
 		if entry.IsDir() {
-			log.Logvf(log.Always, `don't know what to do with subdirectory "%v", skipping...`,
+			log.Logvf(log.Always, `don't know what to do with subdirectory %#q, skipping...`,
 				filepath.Join(dir.Name(), entry.Name()))
 		} else {
 			// Pass the full file path in case a .metadata.json file needs to be opened and inspected.
@@ -447,21 +447,21 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				// If these special files manage to be included in a dump directory during a full
 				// (multi-db) restore, we should ignore them.
 				if restore.ToolOptions.Namespace != nil && restore.ToolOptions.DB == "" && strings.HasPrefix(collection, "$") {
-					log.Logvf(log.DebugLow, "not restoring special collection %v.%v", db, collection)
+					log.Logvf(log.DebugLow, "not restoring special collection %#q", db+"."+collection)
 					skip = true
 				}
 				// TOOLS-717: disallow restoring to the system.profile collection.
 				// Server versions >= 3.0.3 disallow user inserts to system.profile so
 				// it would likely fail anyway.
 				if collection == "system.profile" {
-					log.Logvf(log.DebugLow, "skipping restore of system.profile collection in %v", db)
+					log.Logvf(log.DebugLow, "skipping restore of system.profile collection in %#q", db)
 					skip = true
 				}
 				// skip restoring the indexes collection if we are using metadata
 				// files to store index information, to eliminate redundancy
 				if collection == "system.indexes" && usesMetadataFiles {
 					log.Logvf(log.DebugLow,
-						"not restoring system.indexes collection because database %v "+
+						"not restoring system.indexes collection because database %#q "+
 							"has .metadata.json files", db)
 					skip = true
 				}
@@ -469,11 +469,11 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				checkSourceNS := db + "." + strings.TrimPrefix(collection, common.TimeseriesBucketPrefix)
 
 				if !restore.includer.Has(checkSourceNS) {
-					log.Logvf(log.DebugLow, "skipping restoring %v.%v, it is not included", db, collection)
+					log.Logvf(log.DebugLow, "skipping restoring %#q, it is not included", db+"."+collection)
 					skip = true
 				}
 				if restore.excluder.Has(checkSourceNS) {
-					log.Logvf(log.DebugLow, "skipping restoring %v.%v, it is excluded", db, collection)
+					log.Logvf(log.DebugLow, "skipping restoring %#q, it is excluded", db+"."+collection)
 					skip = true
 				}
 				destNS := restore.renamer.Get(sourceNS)
@@ -515,7 +515,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 					intent.Location = entry.Path()
 					intent.BSONFile = &realBSONFile{path: entry.Path(), intent: intent, gzip: restore.InputOptions.Gzip}
 				}
-				log.Logvf(log.Info, "found collection %v bson to restore to %v", sourceNS, destNS)
+				log.Logvf(log.Info, "found collection %#q bson to restore to %#q", sourceNS, destNS)
 				restore.manager.PutWithNamespace(checkSourceNS, intent)
 			case MetadataFileType:
 				if collection == "system.profile" {
@@ -529,11 +529,11 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 				}
 
 				if !restore.includer.Has(checkSourceNS) {
-					log.Logvf(log.DebugLow, "skipping restoring %v.%v metadata, it is not included", db, collection)
+					log.Logvf(log.DebugLow, "skipping restoring %#q metadata, it is not included", db+"."+collection)
 					continue
 				}
 				if restore.excluder.Has(checkSourceNS) {
-					log.Logvf(log.DebugLow, "skipping restoring %v.%v metadata, it is excluded", db, collection)
+					log.Logvf(log.DebugLow, "skipping restoring %#q metadata, it is excluded", db+"."+collection)
 					continue
 				}
 
@@ -557,11 +557,11 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 					intent.MetadataLocation = entry.Path()
 					intent.MetadataFile = &realMetadataFile{path: entry.Path(), intent: intent, gzip: restore.InputOptions.Gzip}
 				}
-				log.Logvf(log.Info, "found collection metadata from %v to restore to %v", sourceNS, destNS)
-				log.Logvf(log.DebugLow, "adding intent for %v", sourceNS)
+				log.Logvf(log.Info, "found collection metadata from %#q to restore to %#q", sourceNS, destNS)
+				log.Logvf(log.DebugLow, "adding intent for %#q", sourceNS)
 				restore.manager.PutWithNamespace(sourceNS, intent)
 			default:
-				log.Logvf(log.Always, `don't know what to do with file "%v", skipping...`,
+				log.Logvf(log.Always, `don't know what to do with file %#q, skipping...`,
 					entry.Path())
 			}
 		}
@@ -572,7 +572,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 // CreateStdinIntentForCollection builds an intent for the given database and collection name
 // that is to be read from standard input.
 func (restore *MongoRestore) CreateStdinIntentForCollection(db string, collection string) error {
-	log.Logvf(log.DebugLow, "reading collection %v for database %v from standard input",
+	log.Logvf(log.DebugLow, "reading collection %#q for database %#q from standard input",
 		collection, db)
 	intent := &intents.Intent{
 		ServerVersion: restore.serverVersion,
@@ -596,7 +596,7 @@ func (restore *MongoRestore) CreateIntentForCollection(
 	collection string,
 	bsonFile archive.DirLike,
 ) error {
-	log.Logvf(log.DebugLow, "reading collection %v for database %v from %v",
+	log.Logvf(log.DebugLow, "reading collection %#q for database %#q from %#q",
 		collection, db, bsonFile.Path())
 	// First ensure that the bson file exists with one of correct file extensions.
 	_, err := bsonFile.Stat()
@@ -604,14 +604,14 @@ func (restore *MongoRestore) CreateIntentForCollection(
 		return err
 	}
 	if bsonFile.IsDir() {
-		return fmt.Errorf("file %v is a directory, not a bson file", bsonFile.Path())
+		return fmt.Errorf("file %#q is a directory, not a bson file", bsonFile.Path())
 	}
 	_, fileType, err := restore.getInfoFromFile(bsonFile.Path())
 	if err != nil {
 		return err
 	}
 	if fileType != BSONFileType {
-		return fmt.Errorf("file %v does not have .bson or .bson.gz extension", bsonFile.Path())
+		return fmt.Errorf("file %#q does not have .bson or .bson.gz extension", bsonFile.Path())
 	}
 
 	var isTimeseries bool
@@ -639,7 +639,7 @@ func (restore *MongoRestore) CreateIntentForCollection(
 	}
 	// Check if the bson file has a corresponding .metadata.json file in its folder. If there's a
 	// directory error, log a note but attempt to restore without the metadata file anyway.
-	log.Logvf(log.DebugLow, "scanning directory %v for metadata", bsonFile.Parent())
+	log.Logvf(log.DebugLow, "scanning directory %#q for metadata", bsonFile.Parent())
 	entries, err := bsonFile.Parent().ReadDir()
 	if err != nil {
 		if isTimeseries {
@@ -670,7 +670,7 @@ func (restore *MongoRestore) CreateIntentForCollection(
 	for _, entry := range entries {
 		if entry.Name() == metadataName {
 			metadataPath := entry.Path()
-			log.Logvf(log.Info, "found metadata for collection at %v", metadataPath)
+			log.Logvf(log.Info, "found metadata for collection at %#q", metadataPath)
 			intent.MetadataLocation = metadataPath
 			intent.MetadataFile = &realMetadataFile{
 				path:   metadataPath,
@@ -723,7 +723,7 @@ func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 		}
 
 		if fileType != BSONFileType {
-			return fmt.Errorf("file %v does not have .bson extension", path)
+			return fmt.Errorf("file %#q does not have .bson extension", path)
 		}
 		restore.ToolOptions.Collection = newCollectionName
 		log.Logvf(

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -227,10 +227,10 @@ func (restore *MongoRestore) CreateIndexes(
 	// if we're here, the connected server does not support the command, so we fall back
 	log.Logv(log.Info, "\tcreateIndexes command not supported, attemping legacy index insertion")
 	for _, idx := range indexes {
-		log.Logvf(log.Info, "\tmanually creating index %v", idx.Options["name"])
+		log.Logvf(log.Info, "\tmanually creating index %#q", idx.Options["name"])
 		err = restore.LegacyInsertIndex(dbName, idx)
 		if err != nil {
-			return fmt.Errorf("error creating index %v: %v", idx.Options["name"], err)
+			return fmt.Errorf("error creating index %#q: %v", idx.Options["name"], err)
 		}
 	}
 	return nil
@@ -454,13 +454,13 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 			// just skip auth collections with empty .bson files to avoid gnarly logic later on.
 			log.Logvf(
 				log.Always,
-				"%v file '%v' is empty; skipping %v restoration",
+				"%v file %#q is empty; skipping %v restoration",
 				arg.intentType,
 				arg.intent.Location,
 				arg.intentType,
 			)
 		}
-		log.Logvf(log.Always, "restoring %v from %v", arg.intentType, arg.intent.Location)
+		log.Logvf(log.Always, "restoring %v from %#q", arg.intentType, arg.intent.Location)
 
 		mergeArgs = append(mergeArgs, bson.E{
 			Key:   arg.mergeParamName,

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -485,7 +485,7 @@ func (restore *MongoRestore) Restore() Result {
 			restore.ToolOptions.Collection,
 		)
 	case restore.ToolOptions.DB != "" && restore.ToolOptions.Collection != "":
-		log.Logvf(log.Always, "checking for collection data in %v", target.Path())
+		log.Logvf(log.Always, "checking for collection data in %#q", target.Path())
 		err = restore.CreateIntentForCollection(
 			restore.ToolOptions.DB,
 			restore.ToolOptions.Collection,
@@ -568,7 +568,7 @@ func (restore *MongoRestore) Restore() Result {
 			ns, ok := <-namespaceChan
 			// the archive can have only special collections. In that case we keep reading until
 			// the namespaces are exhausted, indicated by the namespaceChan being closed.
-			log.Logvf(log.DebugLow, "received %v from namespaceChan", ns)
+			log.Logvf(log.DebugLow, "received %#q from namespaceChan", ns)
 			if !ok {
 				break
 			}
@@ -576,18 +576,18 @@ func (restore *MongoRestore) Restore() Result {
 			ns = dbName + "." + strings.TrimPrefix(collName, common.TimeseriesBucketPrefix)
 			intent := restore.manager.IntentForNamespace(ns)
 			if intent == nil {
-				return Result{Err: fmt.Errorf("no intent for collection in archive: %v", ns)}
+				return Result{Err: fmt.Errorf("no intent for collection in archive: %#q", ns)}
 			}
 			if intent.IsSystemIndexes() ||
 				intent.IsUsers() ||
 				intent.IsRoles() ||
 				intent.IsAuthVersion() {
-				log.Logvf(log.DebugLow, "special collection %v found", ns)
+				log.Logvf(log.DebugLow, "special collection %#q found", ns)
 				namespaceErrorChan <- nil
 			} else {
 				// Put the ns back on the announcement chan so that the
 				// demultiplexer can start correctly
-				log.Logvf(log.DebugLow, "first non special collection %v found."+
+				log.Logvf(log.DebugLow, "first non special collection %#q found."+
 					" The demultiplexer will handle it and the remainder", ns)
 				namespaceChan <- ns
 				break

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -43,7 +43,7 @@ type Result struct {
 
 // log pretty-prints the result, associated with restoring the given namespace.
 func (result *Result) log(ns string) {
-	log.Logvf(log.Always, "finished restoring %v (%v %v, %v %v)",
+	log.Logvf(log.Always, "finished restoring %#q (%v %v, %v %v)",
 		ns, result.Successes, util.Pluralize(int(result.Successes), "document", "documents"),
 		result.Failures, util.Pluralize(int(result.Failures), "failure", "failures"))
 }
@@ -175,7 +175,7 @@ func (restore *MongoRestore) RestoreIndexesForNamespace(namespace *options.Names
 			}
 		}
 
-		log.Logvf(log.Always, "restoring indexes for collection %v from metadata", namespaceString)
+		log.Logvf(log.Always, "restoring indexes for collection %#q from metadata", namespaceString)
 		if restore.OutputOptions.ConvertLegacyIndexes {
 			indexes = restore.convertLegacyIndexes(indexes, namespaceString)
 		}
@@ -195,7 +195,7 @@ func (restore *MongoRestore) RestoreIndexesForNamespace(namespace *options.Names
 			)
 		}
 	} else {
-		log.Logvf(log.Always, "no indexes to restore for collection %v", namespaceString)
+		log.Logvf(log.Always, "no indexes to restore for collection %#q", namespaceString)
 	}
 
 	return nil
@@ -243,7 +243,7 @@ func (restore *MongoRestore) PopulateMetadataForIntents() error {
 			}
 			defer intent.MetadataFile.Close()
 
-			log.Logvf(log.Always, "reading metadata for %v from %v", intent.Namespace(), intent.MetadataLocation)
+			log.Logvf(log.Always, "reading metadata for %#q from %#q", intent.Namespace(), intent.MetadataLocation)
 			metadataJSON, err := io.ReadAll(intent.MetadataFile)
 			if err != nil {
 				return fmt.Errorf("error reading metadata from %v: %v", intent.MetadataLocation, err)
@@ -268,7 +268,7 @@ func (restore *MongoRestore) PopulateMetadataForIntents() error {
 
 				if restore.OutputOptions.PreserveUUID {
 					if metadata.UUID == "" {
-						log.Logvf(log.Always, "--preserveUUID used but no UUID found in %v, generating new UUID for %v", intent.MetadataLocation, intent.Namespace())
+						log.Logvf(log.Always, "--preserveUUID used but no UUID found in %#q, generating new UUID for %#q", intent.MetadataLocation, intent.Namespace())
 					}
 					intent.UUID = metadata.UUID
 				}
@@ -382,7 +382,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 					intent.Namespace(),
 				)
 			} else {
-				log.Logvf(log.Always, "dropping collection %v before restoring", intent.Namespace())
+				log.Logvf(log.Always, "dropping collection %#q before restoring", intent.Namespace())
 				err = restore.DropCollection(intent)
 				if err != nil {
 					return Result{Err: err} // no context needed
@@ -390,7 +390,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 				collectionExists = false
 			}
 		} else {
-			log.Logvf(log.DebugLow, "collection %v doesn't exist, skipping drop command", intent.Namespace())
+			log.Logvf(log.DebugLow, "collection %#q doesn't exist, skipping drop command", intent.Namespace())
 		}
 	}
 
@@ -441,7 +441,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 	}
 
 	if !collectionExists {
-		log.Logvf(log.Info, "creating collection %v %s", intent.Namespace(), logMessageSuffix)
+		log.Logvf(log.Info, "creating collection %#q %s", intent.Namespace(), logMessageSuffix)
 		log.Logvf(log.DebugHigh, "using collection options: %#v", options)
 		err = restore.CreateCollection(intent, options, uuid)
 		if err != nil {
@@ -451,7 +451,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 		}
 		restore.addToKnownCollections(intent)
 	} else {
-		log.Logvf(log.Info, "collection %v already exists - skipping collection create", intent.Namespace())
+		log.Logvf(log.Info, "collection %#q already exists - skipping collection create", intent.Namespace())
 	}
 
 	var result Result
@@ -462,7 +462,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 		}
 		defer intent.BSONFile.Close()
 
-		log.Logvf(log.Always, "restoring %v from %v", intent.DataNamespace(), intent.Location)
+		log.Logvf(log.Always, "restoring %#q from %#q", intent.DataNamespace(), intent.Location)
 
 		bsonSource := db.NewDecodedBSONSource(db.NewBSONSource(intent.BSONFile))
 		defer bsonSource.Close()
@@ -583,7 +583,7 @@ func (restore *MongoRestore) RestoreCollectionToDB(
 			}
 
 			if restore.terminate.Load() {
-				log.Logvf(log.Always, "terminating read on %v.%v", dbName, colName)
+				log.Logvf(log.Always, "terminating read on %#q", dbName+"."+colName)
 				termErr = util.ErrTerminated
 				close(docChan)
 				return


### PR DESCRIPTION
Previously, we used `%v` or `%s` to print these names. But they can contain things like newlines or tabs, which make a huge mess when printed. This changes the code to `%#q` when printing these names.

Along the way, it also changes how we print other strings like filenames and such to use this as well.

This only covers mongodump, mongorestore, mongoexport, and mongoimport for now. I will make some follow-up PRs with more escaping.