### PR TITLE
TOOLS-4158 Use `%#q` for all strings and runes in output

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,12 +15,7 @@ We will use the following guidelines to determine when each version component wi
 
 The team recognizes that log messages, while intended to be informational, may cause breakage if
 scripts attempt to parse output. While we will not commit to a formal versioning policy for log
-message changes, we will attempt to adhere to the following guidelines:
-
-- **log.Always** level (the default): adding logging is a "minor" change; changing or removing
-  logging is a "major" change.
-- **log.Info** and higher levels (-v to -vvv): additions, modifications and removals are "patch"
-  changes. We make no promises about message stability at these levels.
+message changes, we will always bump the minor version of the tools when there are logging changes.
 
 At the moment, there are no pre-release (alpha, beta, rc, etc.) versions of the Tools. If there is a
 need to support pre-release versions of the Tools, we will need to update our release infrastructure

--- a/bsondump/options.go
+++ b/bsondump/options.go
@@ -90,7 +90,7 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 		return Options{toolOpts, outputOpts}, nil
 	default:
 		return Options{}, fmt.Errorf(
-			"unsupported output type '%v'. Must be either '%v' or '%v'",
+			"unsupported output type %#q. Must be either %#q or %#q",
 			DebugOutputType,
 			JSONOutputType,
 			outputOpts.Type,

--- a/common/archive/demultiplexer.go
+++ b/common/archive/demultiplexer.go
@@ -176,18 +176,18 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 		crc, ok := demux.outs[demux.currentNamespace].Sum64()
 		if ok {
 			if crc != colHeader.CRC {
-				return fmt.Errorf("CRC mismatch for namespace %v, %v!=%v",
+				return fmt.Errorf("CRC mismatch for namespace %#q, %v!=%v",
 					demux.currentNamespace,
 					crc,
 					colHeader.CRC,
 				)
 			}
 			log.Logvf(log.DebugHigh,
-				"demux checksum for namespace %v is correct (%v), %v bytes",
+				"demux checksum for namespace %#q is correct (%v), %v bytes",
 				demux.currentNamespace, crc, length)
 		} else {
 			log.Logvf(log.DebugHigh,
-				"demux checksum for namespace %v was not calculated.",
+				"demux checksum for namespace %#q was not calculated.",
 				demux.currentNamespace)
 		}
 		delete(demux.outs, demux.currentNamespace)
@@ -213,12 +213,15 @@ func (demux *Demultiplexer) End() error {
 			demux.outs[ns].End()
 		}
 		err = newError(
-			fmt.Sprintf("archive finished but contained files were unfinished (%v)", openNss),
+			fmt.Sprintf(
+				"archive finished but contained files were unfinished (%v)",
+				util.QuoteAndJoin(openNss, ", "),
+			),
 		)
 	} else {
 		for ns, status := range demux.NamespaceStatus {
 			if status != NamespaceClosed {
-				err = newError(fmt.Sprintf("archive finished before all collections were seen (%v)", ns))
+				err = newError(fmt.Sprintf("archive finished before all collections were seen (%#q)", ns))
 			}
 		}
 	}
@@ -258,7 +261,7 @@ func (demux *Demultiplexer) Open(ns string, out DemuxOut) {
 	// or while the demutiplexer is inside of the NamespaceChan NamespaceErrorChan conversation
 	// I think that we don't need to lock outs, but I suspect that if the implementation changes
 	// we may need to lock when outs is accessed
-	log.Logvf(log.DebugHigh, "demux Open for %s", ns)
+	log.Logvf(log.DebugHigh, "demux Open for %#q", ns)
 	if demux.outs == nil {
 		demux.outs = make(map[string]DemuxOut)
 		demux.lengths = make(map[string]int64)
@@ -534,11 +537,11 @@ func (prioritizer *Prioritizer) Get() *intents.Intent {
 	namespace = destDB + "." + strings.TrimPrefix(destC, common.TimeseriesBucketPrefix)
 	intent := prioritizer.mgr.IntentForNamespace(namespace)
 	if intent == nil {
-		prioritizer.NamespaceErrorChan <- fmt.Errorf("no intent for namespace %v", namespace)
+		prioritizer.NamespaceErrorChan <- fmt.Errorf("no intent for namespace %#q", namespace)
 	} else {
 		if intent.BSONFile != nil {
 			if err := intent.BSONFile.Open(); err != nil {
-				prioritizer.NamespaceErrorChan <- fmt.Errorf("error opening BSON file for %s: %v", intent.Namespace(), err)
+				prioritizer.NamespaceErrorChan <- fmt.Errorf("error opening BSON file for %#q: %v", intent.Namespace(), err)
 			}
 		}
 		if intent.IsOplog() {

--- a/common/archive/multiplexer.go
+++ b/common/archive/multiplexer.go
@@ -91,7 +91,7 @@ func (mux *Multiplexer) Run() {
 				mux.Completed <- fmt.Errorf("non MuxIn received on Control chan") // one for the MuxIn.Open
 				return
 			}
-			log.Logvf(log.DebugLow, "Mux open namespace %v", muxIn.Intent.DataNamespace())
+			log.Logvf(log.DebugLow, "Mux open namespace %#q", muxIn.Intent.DataNamespace())
 			mux.selectCases = append(mux.selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectRecv,
 				Chan: reflect.ValueOf(muxIn.writeChan),
@@ -114,7 +114,7 @@ func (mux *Multiplexer) Run() {
 					mux.Out = &nopCloseNopWriter{}
 					completionErr = err
 				}
-				log.Logvf(log.DebugLow, "Mux close namespace %v", mux.ins[index].Intent.DataNamespace())
+				log.Logvf(log.DebugLow, "Mux close namespace %#q", mux.ins[index].Intent.DataNamespace())
 				mux.currentNamespace = ""
 				mux.selectCases = append(mux.selectCases[:index], mux.selectCases[index+1:]...)
 				mux.ins = append(mux.ins[:index], mux.ins[index+1:]...)
@@ -249,7 +249,7 @@ func (muxIn *MuxIn) Pos() int64 {
 // formatEOF to occur.
 func (muxIn *MuxIn) Close() error {
 	// the mux side of this gets closed in the mux when it gets an eof on the read
-	log.Logvf(log.DebugHigh, "MuxIn close %v", muxIn.Intent.DataNamespace())
+	log.Logvf(log.DebugHigh, "MuxIn close %#q", muxIn.Intent.DataNamespace())
 	if bufferWrites {
 		muxIn.writeChan <- muxIn.buf
 		length := <-muxIn.writeLenChan
@@ -270,7 +270,7 @@ func (muxIn *MuxIn) Close() error {
 // Open is implemented in Mux.open, but in short, it creates chans and a select case
 // and adds the SelectCase and the MuxIn in to the Multiplexer.
 func (muxIn *MuxIn) Open() error {
-	log.Logvf(log.DebugHigh, "MuxIn open %v", muxIn.Intent.DataNamespace())
+	log.Logvf(log.DebugHigh, "MuxIn open %#q", muxIn.Intent.DataNamespace())
 	muxIn.writeChan = make(chan []byte)
 	muxIn.writeLenChan = make(chan int)
 	muxIn.writeCloseFinishedChan = make(chan struct{})

--- a/common/archive/prelude.go
+++ b/common/archive/prelude.go
@@ -146,7 +146,7 @@ func (prelude *Prelude) AddMetadata(cm *CollectionMetadata) {
 		prelude.NamespaceMetadatasByDB[cm.Database],
 		cm,
 	)
-	log.Logvf(log.Info, "archive prelude %v.%v", cm.Database, cm.Collection)
+	log.Logvf(log.Info, "archive prelude %#q", cm.Database+"."+cm.Collection)
 }
 
 // Write writes the archive header.
@@ -380,7 +380,7 @@ func (mpf *MetadataPreludeFile) Open() error {
 	db, c := util.SplitNamespace(mpf.Origin)
 	dbMetadatas, ok := mpf.Prelude.NamespaceMetadatasByDB[db]
 	if !ok {
-		return fmt.Errorf("no metadata found for '%s'", db)
+		return fmt.Errorf("no metadata found for %#q", db)
 	}
 	for _, metadata := range dbMetadatas {
 		if metadata.Collection == c {
@@ -388,7 +388,7 @@ func (mpf *MetadataPreludeFile) Open() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("no matching metadata found for '%s'", mpf.Origin)
+	return fmt.Errorf("no matching metadata found for %#q", mpf.Origin)
 }
 
 // Close is part of the intents.file interface.

--- a/common/bsonutil/bsonutil.go
+++ b/common/bsonutil/bsonutil.go
@@ -128,7 +128,7 @@ func FindIntByKey(keyName string, document *bson.D) (int, error) {
 	case int:
 		return x, nil
 	default:
-		return 0, fmt.Errorf("field '%s' is not an integer type", keyName)
+		return 0, fmt.Errorf("field %#q is not an integer type", keyName)
 	}
 }
 
@@ -142,7 +142,7 @@ func FindSubdocumentByKey(keyName string, document *bson.D) (bson.D, error) {
 	}
 	doc, ok := value.(bson.D)
 	if !ok {
-		return bson.D{}, fmt.Errorf("field '%s' is not a document", keyName)
+		return bson.D{}, fmt.Errorf("field %#q is not a document", keyName)
 	}
 	return doc, nil
 }

--- a/common/bsonutil/indexes.go
+++ b/common/bsonutil/indexes.go
@@ -97,7 +97,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 		newJSONString := CreateExtJSONString(indexKey)
 		log.Logvf(
 			log.Always,
-			"convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
+			"convertLegacyIndexes: converted index values %#q to %#q on collection %#q",
 			originalJSONString,
 			newJSONString,
 			ns,
@@ -161,7 +161,7 @@ func ConvertLegacyIndexOptions(indexOptions bson.M) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Always, "convertLegacyIndexes: converted index options '%s' to '%s'",
+		log.Logvf(log.Always, "convertLegacyIndexes: converted index options %#q to %#q",
 			originalJSONString, newJSONString)
 	}
 }

--- a/common/idx/index_catalog.go
+++ b/common/idx/index_catalog.go
@@ -138,9 +138,9 @@ func (i *IndexCatalog) String() string {
 	b.WriteString("IndexCatalog:\n")
 	for dbName, coll := range i.indexes {
 		for collName, collIndexCatalog := range coll {
-			b.WriteString(fmt.Sprintf("\t%s.%s: \n", dbName, collName))
+			b.WriteString(fmt.Sprintf("\t%#q: \n", dbName+"."+collName))
 			for indexName, indexSpec := range collIndexCatalog.indexes {
-				b.WriteString(fmt.Sprintf("\t\t%s: %+#v\n", indexName, indexSpec))
+				b.WriteString(fmt.Sprintf("\t\t%#q: %+#v\n", indexName, indexSpec))
 			}
 			b.WriteByte('\n')
 		}
@@ -239,9 +239,9 @@ func (i *IndexCatalog) DeleteIndexes(database, collection string, dropCmd bson.D
 		for key, value := range collIndexes {
 			isEq, err := bsonutil.IsEqual(indexToDrop, value.Key)
 			if err != nil {
-				return fmt.Errorf("could not drop index on %s.%s, could not handle %v: "+
+				return fmt.Errorf("could not drop index on %#q, could not handle %v: "+
 					"was unable to find matching index in indexCatalog. Error with equality test: %v",
-					database, collection, dropCmd[0].Key, err)
+					database+"."+collection, dropCmd[0].Key, err)
 			}
 
 			if isEq {
@@ -249,8 +249,8 @@ func (i *IndexCatalog) DeleteIndexes(database, collection string, dropCmd bson.D
 			}
 		}
 		if len(toDelete) > 1 {
-			return fmt.Errorf("could not drop index on %s.%s: "+
-				"the key %v somehow matched more than one index in the collection", database, collection, dropCmd[0].Key)
+			return fmt.Errorf("could not drop index on %#q: "+
+				"the key %v somehow matched more than one index in the collection", database+"."+collection, dropCmd[0].Key)
 		}
 		// Could we have 0 items in toDelete? I'm not sure, so it's best to
 		// avoid accessing toDelete[0].
@@ -258,12 +258,12 @@ func (i *IndexCatalog) DeleteIndexes(database, collection string, dropCmd bson.D
 			delete(collIndexes, td)
 		}
 
-		log.Logvf(log.DebugHigh, "Must drop index on %s.%s by key pattern: %v", database, collection, indexToDrop)
+		log.Logvf(log.DebugHigh, "Must drop index on %#q by key pattern: %v", database+"."+collection, indexToDrop)
 		return nil
 	default:
-		return fmt.Errorf("could not drop index on %s.%s, could not handle %v: "+
+		return fmt.Errorf("could not drop index on %#q, could not handle %v: "+
 			"expected string or object for 'index', found: %T, %v",
-			database, collection, dropCmd[0].Key, indexToDrop, indexToDrop)
+			database+"."+collection, dropCmd[0].Key, indexToDrop, indexToDrop)
 	}
 }
 
@@ -336,7 +336,7 @@ func (i *IndexCatalog) collMod(database, collection string, indexModValue any) e
 		} else if k == "unique" || k == "forceNonUnique" {
 			v, boolOk := element.Value.(bool)
 			if !boolOk {
-				return errors.Errorf("cannot convert %s value to bool: %v", k, element.Value)
+				return errors.Errorf("cannot convert %#q value to bool: %v", k, element.Value)
 			}
 
 			if k == "unique" && v {
@@ -348,7 +348,7 @@ func (i *IndexCatalog) collMod(database, collection string, indexModValue any) e
 			}
 			matchingIndex.Options[k] = v
 		} else {
-			return errors.Errorf("unknown index option: %v", k)
+			return errors.Errorf("unknown index option: %#q", k)
 		}
 	}
 

--- a/common/intents/intent.go
+++ b/common/intents/intent.go
@@ -32,7 +32,7 @@ type DestinationConflictError struct {
 }
 
 func (e DestinationConflictError) Error() string {
-	return fmt.Sprintf("destination conflict: %s (src) => %s (dst)", e.Src, e.Dst)
+	return fmt.Sprintf("destination conflict: %#q (src) => %#q (dst)", e.Src, e.Dst)
 }
 
 // FileNeedsIOBuffer is an interface that denotes that a struct needs
@@ -335,7 +335,7 @@ func (mgr *Manager) putNormalIntentWithNamespace(ns string, intent *Intent) {
 // Put inserts an intent into the manager with the same source namespace as
 // its destinations.
 func (mgr *Manager) Put(intent *Intent) {
-	log.Logvf(log.DebugLow, "enqueued collection '%v'", intent.Namespace())
+	log.Logvf(log.DebugLow, "enqueued collection %#q", intent.Namespace())
 	mgr.PutWithNamespace(intent.Namespace(), intent)
 }
 

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -37,11 +37,11 @@ var BuiltWithGSSAPI = true
 
 const IncompatibleArgsErrorFormat = "illegal argument combination: cannot specify %s and --uri"
 
-const unknownOptionsWarningFormat = "WARNING: ignoring unsupported URI parameter '%v'"
+const unknownOptionsWarningFormat = "WARNING: ignoring unsupported URI parameter %#q"
 
 func ConflictingArgsErrorFormat(optionName, uriValue, cliValue, cliOptionName string) error {
 	return fmt.Errorf(
-		"Invalid Options: Cannot specify different %s in connection URI and command-line option (\"%s\" was specified in the URI and \"%s\" was specified in the %s option)",
+		"Invalid Options: Cannot specify different %s in connection URI and command-line option %#q was specified in the URI and %#q was specified in the %s option",
 		optionName,
 		uriValue,
 		cliValue,
@@ -742,7 +742,7 @@ func (opts *ToolOptions) handleUnknownOption(
 			"See http://dochub.mongodb.org/core/tools-dbpath-deprecated for more information")
 	}
 
-	return args, fmt.Errorf(`unknown option "%v"`, option)
+	return args, fmt.Errorf(`unknown option %#q`, option)
 }
 
 // Sets options from the URI. If any options are already set, they are added to the connection string.

--- a/common/util/mongo.go
+++ b/common/util/mongo.go
@@ -124,12 +124,12 @@ func ValidateFullNamespace(namespace string) error {
 
 	// the namespace cannot begin with a dot
 	if firstDotIndex == 0 {
-		return fmt.Errorf("namespace %v begins with a '.'", namespace)
+		return fmt.Errorf("namespace %#q begins with a '.'", namespace)
 	}
 
 	// the namespace cannot end with a dot
 	if firstDotIndex == len(namespace)-1 {
-		return fmt.Errorf("namespace %v ends with a '.'", namespace)
+		return fmt.Errorf("namespace %#q ends with a '.'", namespace)
 	}
 
 	// split the namespace, if applicable
@@ -168,13 +168,13 @@ func ValidateDBName(database string) error {
 
 	// must be < 64 characters
 	if len([]byte(database)) > 63 {
-		return fmt.Errorf("db name '%v' is longer than 63 characters", database)
+		return fmt.Errorf("db name %#q is longer than 63 characters", database)
 	}
 
 	// check for illegal characters
 	for _, illegalRune := range InvalidDBChars {
 		if strings.ContainsRune(database, illegalRune) {
-			return fmt.Errorf("illegal character '%c' found in db name '%v'", illegalRune, database)
+			return fmt.Errorf("illegal character %#q found in db name %#q", illegalRune, database)
 		}
 	}
 
@@ -187,8 +187,7 @@ func ValidateDBName(database string) error {
 func ValidateCollectionName(collection string) error {
 	// collection names cannot begin with 'system.'
 	if strings.HasPrefix(collection, "system.") {
-		return fmt.Errorf("collection name '%v' is not allowed to begin with"+
-			" 'system.'", collection)
+		return fmt.Errorf("collection name %#q is not allowed to begin with 'system.'", collection)
 	}
 
 	return ValidateCollectionGrammar(collection)
@@ -207,7 +206,7 @@ func ValidateCollectionGrammar(collection string) error {
 	// check for illegal characters
 	for _, illegalRune := range InvalidCollectionChars {
 		if strings.ContainsRune(collection, illegalRune) {
-			return fmt.Errorf("illegal character '%c' found in '%v'", illegalRune, collection)
+			return fmt.Errorf("illegal character %#q found in %#q", illegalRune, collection)
 		}
 	}
 

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -104,7 +104,7 @@ func (dump *MongoDump) dumpMetadata(
 		}
 
 		if err := indexesIter.Err(); err != nil {
-			return fmt.Errorf("error getting indexes for collection `%v`: %v", intent.Namespace(), err)
+			return fmt.Errorf("error getting indexes for collection %#q: %v", intent.Namespace(), err)
 		}
 	}
 
@@ -112,7 +112,7 @@ func (dump *MongoDump) dumpMetadata(
 	jsonBytes, err := bsonutil.MarshalExtJSONWithBSONRoundtripConsistency(meta, true, false)
 	if err != nil {
 		return fmt.Errorf(
-			"error marshaling metadata json for collection `%v`: %v",
+			"error marshaling metadata json for collection %#q: %v",
 			intent.Namespace(),
 			err,
 		)
@@ -126,7 +126,7 @@ func (dump *MongoDump) dumpMetadata(
 		closeErr := intent.MetadataFile.Close()
 		if err == nil && closeErr != nil {
 			err = fmt.Errorf(
-				"error writing metadata for collection `%v` to disk: %v",
+				"error writing metadata for collection %#q to disk: %v",
 				intent.Namespace(),
 				closeErr,
 			)
@@ -142,7 +142,7 @@ func (dump *MongoDump) dumpMetadata(
 			closeErr := buffer.Close()
 			if err == nil && closeErr != nil {
 				err = fmt.Errorf(
-					"error writing metadata for collection `%v` to disk: %v",
+					"error writing metadata for collection %#q to disk: %v",
 					intent.Namespace(),
 					closeErr,
 				)
@@ -152,7 +152,7 @@ func (dump *MongoDump) dumpMetadata(
 	_, err = f.Write(jsonBytes)
 	if err != nil {
 		err = fmt.Errorf(
-			"error writing metadata for collection `%v` to disk: %v",
+			"error writing metadata for collection %#q to disk: %v",
 			intent.Namespace(),
 			err,
 		)

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -613,7 +613,7 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 			if err != nil {
 				return errors.Wrapf(
 					err,
-					"could not find timeseries options for %s",
+					"could not find timeseries options for %#q",
 					intent.Namespace(),
 				)
 			}
@@ -621,14 +621,14 @@ func (dump *MongoDump) DumpIntent(intent *intents.Intent, buffer resettableOutpu
 			if err != nil {
 				return errors.Wrapf(
 					err,
-					"could not determine the metaField for %s",
+					"could not determine the metaField for %#q",
 					intent.Namespace(),
 				)
 			}
 			for i, predicate := range dump.query {
 				splitPredicateKey := strings.SplitN(predicate.Key, ".", 2)
 				if splitPredicateKey[0] != metaKey {
-					return fmt.Errorf("cannot process query %v for timeseries collection %s. "+
+					return fmt.Errorf("cannot process query %v for timeseries collection %#q. "+
 						"mongodump only processes queries on metadata fields for timeseries collections.", dump.query, intent.Namespace())
 				}
 				if len(splitPredicateKey) > 1 {
@@ -736,7 +736,7 @@ func (dump *MongoDump) dumpValidatedQueryToIntent(
 		closeErr := intent.BSONFile.Close()
 		if err == nil && closeErr != nil {
 			err = fmt.Errorf(
-				"error writing data for collection `%v` to disk: %v",
+				"error writing data for collection %#q to disk: %v",
 				intent.Namespace(),
 				closeErr,
 			)
@@ -767,7 +767,7 @@ func (dump *MongoDump) dumpValidatedQueryToIntent(
 			closeErr := buffer.Close()
 			if err == nil && closeErr != nil {
 				err = fmt.Errorf(
-					"error writing data for collection `%v` to disk: %v",
+					"error writing data for collection %#q to disk: %v",
 					intent.Namespace(),
 					closeErr,
 				)
@@ -783,7 +783,7 @@ func (dump *MongoDump) dumpValidatedQueryToIntent(
 	dumpCount, _ = dumpProgressor.Progress()
 	if err != nil {
 		err = fmt.Errorf(
-			"error writing data for collection `%v` to disk: %v",
+			"error writing data for collection %#q to disk: %v",
 			intent.Namespace(),
 			err,
 		)

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -332,7 +332,7 @@ func (dump *MongoDump) NewIntentFromOptions(
 			if dump.OutputOptions.Archive == "-" {
 				intent.Location = "archive on stdout"
 			} else {
-				intent.Location = fmt.Sprintf("archive '%v'", dump.OutputOptions.Archive)
+				intent.Location = fmt.Sprintf("archive %#q", dump.OutputOptions.Archive)
 			}
 		} else if ci.IsTimeseries() && !dump.serverVersionArray.SupportsRawData() {
 			// 8.3+ supports viewless timeseries, so they end up in the final else block as a normal

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -388,7 +388,7 @@ func (exp *MongoExport) verifyCollectionExists() (bool, error) {
 		var collInfoErr error
 		if exp.InputOpts.AssertExists {
 			collInfoErr = fmt.Errorf(
-				"collection '%s' does not exist",
+				"collection %#q does not exist",
 				exp.ToolOptions.Collection,
 			)
 		}

--- a/mongofiles/gfsfile.go
+++ b/mongofiles/gfsfile.go
@@ -96,7 +96,7 @@ func (file *gfsFile) OpenStreamForReading() (*mongo.GridFSDownloadStream, error)
 // Note: this file must be closed if it had been written to before being deleted. Any download streams will be closed as part of this deletion.
 func (file *gfsFile) Delete(ctx context.Context) error {
 	if err := file.mf.bucket.Delete(ctx, file.ID); err != nil {
-		return fmt.Errorf("error while removing '%v' from GridFS: %v", file.Name, err)
+		return fmt.Errorf("error while removing %#q from GridFS: %v", file.Name, err)
 	}
 
 	return nil

--- a/mongofiles/mongofiles.go
+++ b/mongofiles/mongofiles.go
@@ -127,7 +127,7 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		// monogofiles put ... and mongofiles get ... should work
 		// over a list of files, i.e. by using mf.FileNameList
 		if len(args) == 1 || args[1] == "" {
-			return fmt.Errorf("'%v' argument missing", args[0])
+			return fmt.Errorf("%#q argument missing", args[0])
 		}
 
 		mf.FileNameList = args[1:]
@@ -135,7 +135,7 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		// mongofiles get_regex ... should work over a PCRE
 		// and a string of options passed to the $regex query
 		if len(args) == 1 || args[1] == "" {
-			return fmt.Errorf("'%v' argument missing", args[0])
+			return fmt.Errorf("%#q argument missing", args[0])
 		} else if len(args) > 2 {
 			return fmt.Errorf("too many non-URI positional arguments (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)")
 		}
@@ -150,7 +150,7 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 		// also make sure the supporting argument isn't literally an
 		// empty string for example, mongofiles get ""
 		if len(args) == 1 || args[1] == "" {
-			return fmt.Errorf("'%v' argument missing", args[0])
+			return fmt.Errorf("%#q argument missing", args[0])
 		}
 		mf.FileName = args[1]
 	case GetID, DeleteID:
@@ -160,7 +160,7 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 			)
 		}
 		if len(args) == 1 || args[1] == "" {
-			return fmt.Errorf("'%v' argument missing", args[0])
+			return fmt.Errorf("%#q argument missing", args[0])
 		}
 		mf.Id = args[1]
 	case PutID:
@@ -170,13 +170,13 @@ func (mf *MongoFiles) ValidateCommand(args []string) error {
 			)
 		}
 		if len(args) < 3 || args[1] == "" || args[2] == "" {
-			return fmt.Errorf("'%v' argument(s) missing", args[0])
+			return fmt.Errorf("%#q argument(s) missing", args[0])
 		}
 		mf.FileName = args[1]
 		mf.Id = args[2]
 	default:
 		return fmt.Errorf(
-			"'%v' is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
+			"%#q is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
 			args[0],
 		)
 	}
@@ -270,7 +270,10 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 		// Case supporting queries one or many files specified in mongofiles ... get ...
 		query = bson.M{"filename": bson.M{"$in": mf.FileNameList}}
 		minimumExpectedDocs = len(mf.FileNameList)
-		minimumExpectedDocsError = fmt.Errorf("requested files not found: %v", mf.FileNameList)
+		minimumExpectedDocsError = fmt.Errorf(
+			"requested files not found: %v",
+			util.QuoteAndJoin(mf.FileNameList, ", "),
+		)
 	} else if mf.FileNameRegex != "" {
 		// Case supporting queries by regex specified in mongofiles ... get_regex ...
 		query = bson.M{
@@ -279,10 +282,10 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 				"$options": mf.StorageOptions.RegexOptions,
 			},
 		}
-		minimumExpectedDocsError = fmt.Errorf("files matching the following pattern were not found: %v", mf.FileNameRegex)
+		minimumExpectedDocsError = fmt.Errorf("files matching the following pattern were not found: %#q", mf.FileNameRegex)
 	} else if mf.Id != "" {
 		// Case supporting queries by file ID specified in mongofiles ... get_id ...
-		minimumExpectedDocsError = fmt.Errorf("no such file with _id: %v", mf.Id)
+		minimumExpectedDocsError = fmt.Errorf("no such file with _id: %#q", mf.Id)
 
 		id, err := mf.parseOrCreateID()
 		if err != nil {
@@ -294,7 +297,7 @@ func (mf *MongoFiles) getTargetGFSFiles() ([]*gfsFile, error) {
 		// Case supporting queries of a single file with specific local
 		// file name, i.e. with mongofiles ... get ... --local ...
 		query = bson.M{"filename": mf.FileName}
-		minimumExpectedDocsError = fmt.Errorf("no such file with name: %v", mf.FileName)
+		minimumExpectedDocsError = fmt.Errorf("no such file with name: %#q", mf.FileName)
 	}
 
 	gridFiles, err := mf.findGFSFiles(query)
@@ -362,7 +365,7 @@ func (mf *MongoFiles) deleteAll(baseCtx context.Context, filename string) error 
 
 		cancel()
 	}
-	log.Logvf(log.Always, "successfully deleted all instances of '%v' from GridFS\n", mf.FileName)
+	log.Logvf(log.Always, "successfully deleted all instances of %#q from GridFS\n", mf.FileName)
 
 	return nil
 }
@@ -381,7 +384,7 @@ func (mf *MongoFiles) handleDeleteID(baseCtx context.Context) error {
 	if err := file.Delete(ctx); err != nil {
 		return err
 	}
-	log.Logvf(log.Always, "successfully deleted file with _id %v from GridFS", mf.Id)
+	log.Logvf(log.Always, "successfully deleted file with _id %#q from GridFS", mf.Id)
 
 	return nil
 }
@@ -444,7 +447,7 @@ func (mf *MongoFiles) writeGFSFileToLocal(gridFile *gfsFile) (err error) {
 		defer dc.CloseWithErrorCapture(&err)
 	}
 
-	log.Logvf(log.DebugLow, "created local file '%v'", localFileName)
+	log.Logvf(log.DebugLow, "created local file %#q", localFileName)
 
 	stream, err := gridFile.OpenStreamForReading()
 	if err != nil {
@@ -454,10 +457,10 @@ func (mf *MongoFiles) writeGFSFileToLocal(gridFile *gfsFile) (err error) {
 	defer dc.CloseWithErrorCapture(&err)
 
 	if _, err = io.Copy(localFile, stream); err != nil {
-		return fmt.Errorf("error while writing Data into local file '%v': %v", localFileName, err)
+		return fmt.Errorf("error while writing Data into local file %#q: %v", localFileName, err)
 	}
 
-	log.Logvf(log.Always, "finished writing to %s\n", localFileName)
+	log.Logvf(log.Always, "finished writing to %#q\n", localFileName)
 	return nil
 }
 
@@ -480,11 +483,11 @@ func (mf *MongoFiles) put(
 	} else {
 		localFile, err = os.Open(localFileName)
 		if err != nil {
-			return 0, fmt.Errorf("error while opening local gridFile '%v' : %v", localFileName, err)
+			return 0, fmt.Errorf("error while opening local gridFile %#q: %v", localFileName, err)
 		}
 		dc := util.DeferredCloser{Closer: localFile}
 		defer dc.CloseWithErrorCapture(&err)
-		log.Logvf(log.DebugLow, "creating GridFS gridFile '%v' from local gridFile '%v'", mf.FileName, localFileName)
+		log.Logvf(log.DebugLow, "creating GridFS gridFile %#q from local gridFile %#q", mf.FileName, localFileName)
 	}
 
 	// check if --replace flag turned on
@@ -510,7 +513,7 @@ func (mf *MongoFiles) put(
 
 	n, err := io.Copy(stream, localFile)
 	if err != nil {
-		return n, fmt.Errorf("error while storing '%v' into GridFS: %v", localFileName, err)
+		return n, fmt.Errorf("error while storing %#q into GridFS: %v", localFileName, err)
 	}
 
 	return n, nil
@@ -528,7 +531,7 @@ func (mf *MongoFiles) handlePut(ctx context.Context) error {
 			return err
 		}
 
-		log.Logvf(log.Always, "adding gridFile: %v\n", filename)
+		log.Logvf(log.Always, "adding gridFile: %#q\n", filename)
 
 		n, err := mf.put(ctx, id, filename)
 		if err != nil {
@@ -536,7 +539,7 @@ func (mf *MongoFiles) handlePut(ctx context.Context) error {
 			return err
 		}
 		log.Logvf(log.DebugLow, "copied %v bytes to server", n)
-		log.Logvf(log.Always, "added gridFile: %v\n", filename)
+		log.Logvf(log.Always, "added gridFile: %#q\n", filename)
 	}
 
 	return nil

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -319,7 +319,7 @@ func TestValidArguments(t *testing.T) {
 		args := []string{"put_id", "arg1"}
 		err := mf.ValidateCommand(args)
 		require.Error(t, err)
-		assert.EqualError(t, err, fmt.Sprintf("'%v' argument(s) missing", "put_id"))
+		assert.EqualError(t, err, fmt.Sprintf("%#q argument(s) missing", "put_id"))
 	})
 
 	t.Run("list with no args", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestValidArguments(t *testing.T) {
 			assert.EqualError(
 				t,
 				err,
-				fmt.Sprintf("'%v' argument missing", command),
+				fmt.Sprintf("%#q argument missing", command),
 				"%s with no additional argument",
 				command,
 			)
@@ -364,7 +364,7 @@ func TestValidArguments(t *testing.T) {
 			t,
 			err,
 			fmt.Sprintf(
-				"'%v' is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
+				"%#q is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
 				args[0],
 			),
 		)
@@ -489,7 +489,7 @@ func TestMongoFilesCommands(t *testing.T) {
 				logOutput := buff.String()
 
 				for _, testFile := range localTestFiles {
-					logEvent := fmt.Sprintf("finished writing to %v", testFile)
+					logEvent := fmt.Sprintf("finished writing to %#q", testFile)
 					So(logOutput, ShouldContainSubstring, logEvent)
 				}
 			})
@@ -1022,8 +1022,8 @@ func TestMongoFilesCommands(t *testing.T) {
 
 			Convey("log an event specifying the completion of each file", func() {
 				const (
-					logAdding = "adding gridFile: %v"
-					logAdded  = "added gridFile: %v"
+					logAdding = "adding gridFile: %#q"
+					logAdded  = "added gridFile: %#q"
 				)
 
 				logOutput := buff.String()
@@ -1073,7 +1073,7 @@ func TestMongoFilesCommands(t *testing.T) {
 						So(str, ShouldBeEmpty)
 
 						testName := fmt.Sprintf(
-							"compare contents of %v and original lorem ipsum file",
+							"compare contents of %#q and original lorem ipsum file",
 							testFile,
 						)
 						Convey(testName, func() {

--- a/mongofiles/options_test.go
+++ b/mongofiles/options_test.go
@@ -443,15 +443,15 @@ func TestPositionalArgumentParsing(t *testing.T) {
 		},
 		{
 			InputArgs: []string{"get"},
-			ExpectErr: "'get' argument missing",
+			ExpectErr: "`get` argument missing",
 		},
 		{
 			InputArgs: []string{"get", "mongodb://foo"},
-			ExpectErr: "'get' argument missing",
+			ExpectErr: "`get` argument missing",
 		},
 		{
 			InputArgs: []string{"foo", "bar"},
-			ExpectErr: "'foo' is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
+			ExpectErr: "`foo` is not a valid command (If you are trying to specify a connection string, it must begin with mongodb:// or mongodb+srv://)",
 		},
 		{
 			InputArgs: []string{"list", "mongodb://foo", "--uri=mongodb://bar"},

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -363,7 +363,7 @@ func setNestedArrayValue(fieldParts []string, value any, array *bson.A) (err err
 	idx, ok := isNatNum(fieldParts[0])
 	if !ok {
 		return fmt.Errorf(
-			"setNestedArrayValue expected an integer field, but instead received %s",
+			"setNestedArrayValue expected an integer field, but instead received %#q",
 			fieldParts[0],
 		)
 	}
@@ -537,8 +537,8 @@ func tokensToBSON(
 					return nil, coercionError{}
 				case pgStop:
 					return nil, fmt.Errorf(
-						"type coercion failure in document #%d for column '%s', "+
-							"could not parse token '%s' to type %s",
+						"type coercion failure in document #%d for column %#q, "+
+							"could not parse token %#q to type %s",
 						numProcessed,
 						colSpecs[index].Name,
 						token,
@@ -555,7 +555,7 @@ func tokensToBSON(
 				)
 				if err != nil {
 					return nil, fmt.Errorf(
-						"can't set value for key %s: %s",
+						"can't set value for key %#q: %s",
 						colSpecs[index].Name,
 						err,
 					)
@@ -567,7 +567,7 @@ func tokensToBSON(
 			parsedValue = autoParse(token)
 			key := "field" + strconv.Itoa(index)
 			if util.StringSliceContains(ColumnNames(colSpecs), key) {
-				return nil, fmt.Errorf("duplicate field name - on %v - for token #%v ('%v') in document #%v",
+				return nil, fmt.Errorf("duplicate field name - on %v - for token #%v (%#q) in document #%v",
 					key, index+1, parsedValue, numProcessed)
 			}
 			document = append(document, bson.E{Key: key, Value: parsedValue})
@@ -596,16 +596,16 @@ func validateFields(inputFields []string, useArrayIndexFields bool) error {
 
 		// Here we check validity for case (1).
 		if strings.HasSuffix(field, ".") {
-			return fmt.Errorf("field '%v' cannot end with a '.'", field)
+			return fmt.Errorf("field %#q cannot end with a '.'", field)
 		}
 		if strings.HasPrefix(field, ".") {
-			return fmt.Errorf("field '%v' cannot start with a '.'", field)
+			return fmt.Errorf("field %#q cannot start with a '.'", field)
 		}
 		if strings.HasPrefix(field, "$") {
-			return fmt.Errorf("field '%v' cannot start with a '$'", field)
+			return fmt.Errorf("field %#q cannot start with a '$'", field)
 		}
 		if strings.Contains(field, "..") {
-			return fmt.Errorf("field '%v' cannot contain consecutive '.' characters", field)
+			return fmt.Errorf("field %#q cannot contain consecutive '.' characters", field)
 		}
 	}
 
@@ -722,7 +722,7 @@ func addFieldToArray(
 		// We shouldn't ever get here
 		panic(
 			fmt.Sprintf(
-				"addFieldToArray expected a natural number field, but instead received %s",
+				"addFieldToArray expected a natural number field, but instead received %#q",
 				fieldParts[0],
 			),
 		)
@@ -821,16 +821,16 @@ func findFirstField(i any) string {
 
 func incompatibleError(field string, fieldPrefix string, value any) error {
 	field2 := fieldPrefix + findFirstField(value)
-	return fmt.Errorf("fields '%v' and '%v' are incompatible", field2, field)
+	return fmt.Errorf("fields %#q and %#q are incompatible", field2, field)
 }
 
 func identicalError(field string) error {
-	return fmt.Errorf("fields cannot be identical: '%v' and '%v'", field, field)
+	return fmt.Errorf("fields cannot be identical: %#q and %#q", field, field)
 }
 
 func indexError(field string) error {
 	return fmt.Errorf(
-		"array index error with field '%v': array indexes in fields must start from 0 and increase sequentially",
+		"array index error with field %#q: array indexes in fields must start from 0 and increase sequentially",
 		field,
 	)
 }

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -1202,7 +1202,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.0,a.0\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'a.0': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `a.0`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1212,7 +1212,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.1,a.0\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'a.1': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `a.1`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1222,7 +1222,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.0,a.2\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'a.2': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `a.2`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1233,7 +1233,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.0.a,a.2.a\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'a.2.a': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `a.2.a`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1243,7 +1243,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a,a.0\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a' and 'a.0' are incompatible"),
+				fmt.Errorf("fields `a.a` and `a.0` are incompatible"),
 			),
 		)
 		Convey(
@@ -1252,7 +1252,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a.a.a,a.a.0.a\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a.a.a' and 'a.a.0.a' are incompatible"),
+				fmt.Errorf("fields `a.a.a.a` and `a.a.0.a` are incompatible"),
 			),
 		)
 		Convey(
@@ -1261,7 +1261,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.0,a.a\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.0' and 'a.a' are incompatible"),
+				fmt.Errorf("fields `a.0` and `a.a` are incompatible"),
 			),
 		)
 		Convey(
@@ -1270,7 +1270,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a.a.0,a.a.a.a\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a.a.0' and 'a.a.a.a' are incompatible"),
+				fmt.Errorf("fields `a.a.a.0` and `a.a.a.a` are incompatible"),
 			),
 		)
 		Convey(
@@ -1279,7 +1279,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a,a.0\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a' and 'a.0' are incompatible"),
+				fmt.Errorf("fields `a` and `a.0` are incompatible"),
 			),
 		)
 		Convey(
@@ -1288,7 +1288,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a.a,a.a.a.0\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a.a' and 'a.a.a.0' are incompatible"),
+				fmt.Errorf("fields `a.a.a` and `a.a.a.0` are incompatible"),
 			),
 		)
 		Convey(
@@ -1297,7 +1297,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a./,a.0\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a./' and 'a.0' are incompatible"),
+				fmt.Errorf("fields `a./` and `a.0` are incompatible"),
 			),
 		)
 		Convey("With --useArrayIndexFields: Indexes in fields must start from 0",
@@ -1306,7 +1306,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a,b.1\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'b.1': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `b.1`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1317,7 +1317,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.b,b.1\n1,2,3",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'b.1': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `b.1`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1327,7 +1327,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.b,a.b\n1,2,3",
 				nil,
-				fmt.Errorf("fields cannot be identical: 'a.b' and 'a.b'"),
+				fmt.Errorf("fields cannot be identical: `a.b` and `a.b`"),
 			),
 		)
 		Convey("With --useArrayIndexFields: Repeated array index should throw error",
@@ -1336,7 +1336,7 @@ func TestImportDocuments(t *testing.T) {
 				"_id,a.0,a.1,a.2,a.0\n1,2,3,4,5",
 				nil,
 				fmt.Errorf(
-					"array index error with field 'a.0': array indexes in fields must start from 0 and increase sequentially",
+					"array index error with field `a.0`: array indexes in fields must start from 0 and increase sequentially",
 				),
 			),
 		)
@@ -1345,7 +1345,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a.0.a,a.a.0.1\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a.0.a' and 'a.a.0.1' are incompatible"),
+				fmt.Errorf("fields `a.a.0.a` and `a.a.0.1` are incompatible"),
 			),
 		)
 		Convey(
@@ -1354,7 +1354,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.0.0,a.0.a\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.0.0' and 'a.0.a' are incompatible"),
+				fmt.Errorf("fields `a.0.0` and `a.0.a` are incompatible"),
 			),
 		)
 		Convey(
@@ -1363,7 +1363,7 @@ func TestImportDocuments(t *testing.T) {
 				t,
 				"_id,a.a.a.a,a.a\n1,2,3",
 				nil,
-				fmt.Errorf("fields 'a.a.a.a' and 'a.a' are incompatible"),
+				fmt.Errorf("fields `a.a.a.a` and `a.a` are incompatible"),
 			),
 		)
 	})

--- a/mongoimport/typed_fields.go
+++ b/mongoimport/typed_fields.go
@@ -93,12 +93,12 @@ func ColumnNames(fs []ColumnSpec) (s []string) {
 func ParseTypedHeader(header string, parseGrace ParseGrace) (f ColumnSpec, err error) {
 	match := columnTypeRE.FindStringSubmatch(header)
 	if len(match) != 4 {
-		err = fmt.Errorf("could not parse type from header %s", header)
+		err = fmt.Errorf("could not parse type from header %#q", header)
 		return
 	}
 	t, ok := columnTypeNameMap[match[2]]
 	if !ok {
-		err = fmt.Errorf("invalid type %s in header %s", match[2], header)
+		err = fmt.Errorf("invalid type %#q in header %#q", match[2], header)
 		return
 	}
 	p, err := NewFieldParser(t, match[3])
@@ -236,7 +236,7 @@ func (bp *FieldBinaryParser) Parse(in string) (any, error) {
 func NewFieldBinaryParser(arg string) (*FieldBinaryParser, error) {
 	enc, ok := binaryEncodingNameMap[arg]
 	if !ok {
-		return nil, fmt.Errorf("invalid binary encoding: %s", arg)
+		return nil, fmt.Errorf("invalid binary encoding: %#q", arg)
 	}
 	return &FieldBinaryParser{enc}, nil
 }

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -262,7 +262,7 @@ func (restore *MongoRestore) getInfoFromFile(filename string) (string, FileType,
 	unescapedCollName, err = util.UnescapeCollectionName(collName)
 	if err != nil {
 		return "", UnknownFileType, fmt.Errorf(
-			"error parsing collection name from filename \"%v\": %v",
+			"error parsing collection name from filename %#q: %v",
 			baseFileName,
 			err,
 		)
@@ -307,7 +307,7 @@ func (restore *MongoRestore) getCollectionNameFromMetadata(
 	// It's invalid for a current metadata file to have no collection name field.
 	if metadata.CollectionName == "" {
 		return "", fmt.Errorf("no collection name found in metadata file with "+
-			"truncated file name \"%s\"", metadataFullPath)
+			"truncated file name %#q", metadataFullPath)
 	}
 
 	// Return the non-empty collection name field from the metadata file with a truncated name.
@@ -364,7 +364,7 @@ func (restore *MongoRestore) CreateAllIntents(dir archive.DirLike) error {
 					if restore.InputOptions.Archive == "-" {
 						oplogIntent.Location = "archive on stdin"
 					} else {
-						oplogIntent.Location = fmt.Sprintf("archive '%v'", restore.InputOptions.Archive)
+						oplogIntent.Location = fmt.Sprintf("archive %#q", restore.InputOptions.Archive)
 					}
 
 					// no need to check that we want to cache here
@@ -489,7 +489,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 					if restore.InputOptions.Archive == "-" {
 						intent.Location = "archive on stdin"
 					} else {
-						intent.Location = fmt.Sprintf("archive '%v'", restore.InputOptions.Archive)
+						intent.Location = fmt.Sprintf("archive %#q", restore.InputOptions.Archive)
 					}
 					if skip {
 						// adding the DemuxOut to the demux, but not adding the intent to the manager
@@ -550,7 +550,7 @@ func (restore *MongoRestore) CreateIntentsForDB(db string, dir archive.DirLike) 
 					if restore.InputOptions.Archive == "-" {
 						intent.MetadataLocation = "archive on stdin"
 					} else {
-						intent.MetadataLocation = fmt.Sprintf("archive '%v'", restore.InputOptions.Archive)
+						intent.MetadataLocation = fmt.Sprintf("archive %#q", restore.InputOptions.Archive)
 					}
 					intent.MetadataFile = &archive.MetadataPreludeFile{Origin: sourceNS, Intent: intent, Prelude: restore.archive.Prelude}
 				} else {
@@ -644,7 +644,7 @@ func (restore *MongoRestore) CreateIntentForCollection(
 	if err != nil {
 		if isTimeseries {
 			return fmt.Errorf(
-				"could not find the timeseries collection metadata file for %s",
+				"could not find the timeseries collection metadata file for %#q",
 				db+"."+collection,
 			)
 		}
@@ -684,7 +684,7 @@ func (restore *MongoRestore) CreateIntentForCollection(
 	if intent.MetadataFile == nil {
 		if isTimeseries {
 			return fmt.Errorf(
-				"could not find the timeseries collection metadata file for %s",
+				"could not find the timeseries collection metadata file for %#q",
 				db+"."+collection,
 			)
 		}
@@ -728,7 +728,7 @@ func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 		restore.ToolOptions.Collection = newCollectionName
 		log.Logvf(
 			log.DebugLow,
-			"inferred collection '%v' from file",
+			"inferred collection %#q from file",
 			restore.ToolOptions.Collection,
 		)
 	}
@@ -743,7 +743,7 @@ func (restore *MongoRestore) handleBSONInsteadOfDirectory(path string) error {
 		restore.ToolOptions.DB = dirForFile
 		log.Logvf(
 			log.DebugLow,
-			"inferred db '%v' from the file's directory",
+			"inferred db %#q from the file's directory",
 			restore.ToolOptions.DB,
 		)
 	}

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -130,7 +130,7 @@ func (restore *MongoRestore) CollectionExists(dbName, coll string) (bool, error)
 			colNameRaw := collections.Current.Lookup("name")
 			colName, ok := colNameRaw.StringValueOK()
 			if !ok {
-				return false, fmt.Errorf("invalid collection name: %v", colNameRaw)
+				return false, fmt.Errorf("invalid collection name: %#q", colNameRaw)
 			}
 			restore.knownCollections[dbName] = append(restore.knownCollections[dbName], colName)
 		}
@@ -169,7 +169,7 @@ func (restore *MongoRestore) CreateIndexes(
 			fullIndexName := fmt.Sprintf("%v.$%v", index.Options["ns"], index.Options["name"])
 			if len(fullIndexName) > 127 {
 				return fmt.Errorf(
-					"cannot restore index with namespace '%v': "+
+					"cannot restore index with namespace %#q: "+
 						"namespace is too long (max size is 127 bytes)", fullIndexName)
 			}
 		}
@@ -416,7 +416,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 
 	if users != nil && roles != nil && users.DB != roles.DB {
 		return fmt.Errorf(
-			"can't restore users and roles to different databases, %v and %v",
+			"can't restore users and roles to different databases, %#q and %#q",
 			users.DB,
 			roles.DB,
 		)
@@ -482,7 +482,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 		if tempCollectionNameExists {
 			log.Logvf(
 				log.Info,
-				"dropping preexisting temporary collection admin.%v",
+				"dropping preexisting temporary collection admin.%#q",
 				arg.tempCollectionName,
 			)
 
@@ -491,7 +491,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 			cancel()
 			if err != nil {
 				return fmt.Errorf(
-					"error dropping preexisting temporary collection %v: %v",
+					"error dropping preexisting temporary collection %#q: %v",
 					arg.tempCollectionName,
 					err,
 				)
@@ -518,7 +518,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 				// logging errors here because this has no way of returning that doesn't mask other errors
 				log.Logvf(
 					log.Info,
-					"error establishing connection to drop temporary collection admin.%v: %v",
+					"error establishing connection to drop temporary collection admin.%#q: %v",
 					cleanupArg.tempCollectionName,
 					e,
 				)
@@ -526,7 +526,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 			}
 			log.Logvf(
 				log.DebugHigh,
-				"dropping temporary collection admin.%v",
+				"dropping temporary collection admin.%#q",
 				cleanupArg.tempCollectionName,
 			)
 			ctx, cancel := restore.writeContext()
@@ -537,7 +537,7 @@ func (restore *MongoRestore) RestoreUsersOrRoles(users, roles *intents.Intent) e
 			if e != nil {
 				log.Logvf(
 					log.Info,
-					"error dropping temporary collection admin.%v: %v",
+					"error dropping temporary collection admin.%#q: %v",
 					cleanupArg.tempCollectionName,
 					e,
 				)
@@ -609,7 +609,7 @@ func (restore *MongoRestore) GetDumpAuthVersion() (int, error) {
 			// so we can assume up to version 3.
 			log.Logvf(
 				log.Always,
-				"no system.version bson file found in '%v' database dump",
+				"no system.version bson file found in %#q database dump",
 				restore.ToolOptions.DB,
 			)
 			log.Logv(

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -366,27 +366,27 @@ func (restore *MongoRestore) Restore() Result {
 		}
 		log.Logvf(
 			log.DebugLow,
-			`archive format version "%v"`,
+			`archive format version %#q`,
 			restore.archive.Prelude.Header.FormatVersion,
 		)
 
 		dumpServerVersionStr := restore.archive.Prelude.Header.ServerVersion
 		log.Logvf(
 			log.DebugLow,
-			`archive server version "%v"`,
+			`archive server version %#q`,
 			dumpServerVersionStr,
 		)
 		restore.dumpServerVersion, _ = db.StrToVersion(dumpServerVersionStr)
 		log.Logvf(
 			log.DebugLow,
-			`archive tool version "%v"`,
+			`archive tool version %#q`,
 			restore.archive.Prelude.Header.ToolVersion,
 		)
 
 		if restore.dumpServerVersion.CmpMinor(restore.serverVersion) != 0 {
 			log.Logvf(
 				log.Always,
-				"WARNING: This archive came from MongoDB %s, but you are restoring to %s. Cross-version dump & restore is unsupported. The restored data may be corrupted.",
+				"WARNING: This archive came from MongoDB %#q, but you are restoring to %#q. Cross-version dump & restore is unsupported. The restored data may be corrupted.",
 				dumpServerVersionStr,
 				restore.serverVersion.String(),
 			)
@@ -472,7 +472,7 @@ func (restore *MongoRestore) Restore() Result {
 		err = restore.CreateAllIntents(target)
 	case restore.ToolOptions.DB != "" && restore.ToolOptions.Collection == "":
 		log.Logvf(log.Always,
-			"building a list of collections to restore from %v dir",
+			"building a list of collections to restore from %#q dir",
 			target.Path())
 		err = restore.CreateIntentsForDB(
 			restore.ToolOptions.DB,
@@ -778,7 +778,7 @@ func (restore *MongoRestore) preFlightChecks() error {
 
 				if timeseriesExists {
 					return fmt.Errorf(
-						"timeseries collection `%s` already exists on the destination. "+
+						"timeseries collection %#q already exists on the destination. "+
 							"You must remove this collection from the destination or use --drop",
 						intent.Namespace(),
 					)
@@ -791,8 +791,8 @@ func (restore *MongoRestore) preFlightChecks() error {
 
 				if bucketExists {
 					return fmt.Errorf(
-						"system.buckets collection `%v` already exists on the destination. "+
-							"You must remove this collection from the destination in order to restore %s",
+						"system.buckets collection %#q already exists on the destination. "+
+							"You must remove this collection from the destination in order to restore %#q",
 						intent.DataNamespace(),
 						intent.Namespace(),
 					)
@@ -814,7 +814,7 @@ func (restore *MongoRestore) preFlightChecks() error {
 			for _, index := range indexes {
 				for _, keyElement := range index.Key {
 					if keyElement.Value == "geoHaystack" {
-						return fmt.Errorf("found a geoHaystack index: %v on %s. "+
+						return fmt.Errorf("found a geoHaystack index: %v on %#q. "+
 							"geoHaystack indexes are not supported by the destination cluster. "+
 							"Remove the index from the source or use --noIndexRestore to skip all indexes.", index.Key, ns.String())
 					}

--- a/mongorestore/ns/ns.go
+++ b/mongorestore/ns/ns.go
@@ -95,14 +95,14 @@ func countDollarSigns(in string) int {
 func validateReplacement(from, to string) error {
 	if strings.Contains(from, "$") {
 		if countDollarSigns(from)%2 != 0 {
-			return fmt.Errorf("Odd number of dollar signs in from: '%s'", from)
+			return fmt.Errorf("Odd number of dollar signs in from: %#q", from)
 		}
 		if countDollarSigns(to)%2 != 0 {
-			return fmt.Errorf("Odd number of dollar signs in to: '%s'", to)
+			return fmt.Errorf("Odd number of dollar signs in to: %#q", to)
 		}
 	} else {
 		if countAsterisks(from) != countAsterisks(to) {
-			return fmt.Errorf("Different number of asterisks in from: '%s' and to: '%s'", from, to)
+			return fmt.Errorf("Different number of asterisks in from: %#q and to: %#q", from, to)
 		}
 	}
 	return nil
@@ -126,7 +126,7 @@ func processReplacement(from, to string) (re *regexp.Regexp, replacer string, er
 		if ok { // found variable
 			if _, ok := vars[varName]; ok {
 				// Cannot repeat the same variable in a 'from' string
-				err = fmt.Errorf("Variable name '%s' used more than once", varName)
+				err = fmt.Errorf("Variable name %#q used more than once", varName)
 				return
 			}
 			// Put the variable in the map with its index in the string
@@ -160,7 +160,7 @@ func processReplacement(from, to string) (re *regexp.Regexp, replacer string, er
 				replacer += fmt.Sprintf("${%d}", num)
 				to = rest
 			} else {
-				err = fmt.Errorf("Unknown variable '%s'", varName)
+				err = fmt.Errorf("Unknown variable %#q", varName)
 				return
 			}
 			continue
@@ -196,7 +196,7 @@ func NewRenamer(fromSlice, toSlice []string) (r *Renamer, err error) {
 		}
 		matcher, replacer, e := processReplacement(from, to)
 		if e != nil {
-			err = fmt.Errorf("Invalid replacement from '%s' to '%s': %s", from, to, e)
+			err = fmt.Errorf("Invalid replacement from %#q to %#q: %s", from, to, e)
 			return
 		}
 		r.matchers = append(r.matchers, matcher)

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -249,7 +249,7 @@ func (restore *MongoRestore) HandleNonTxnOp(oplogCtx *oplogContext, op db.Oplog)
 			collectionName, indexes := extractIndexDocumentFromCommitIndexBuilds(op)
 			if indexes == nil {
 				return fmt.Errorf(
-					"failed to parse IndexDocument from commitIndexBuild in %s, %v",
+					"failed to parse IndexDocument from commitIndexBuild in %#q, %v",
 					collectionName,
 					op,
 				)
@@ -272,7 +272,7 @@ func (restore *MongoRestore) HandleNonTxnOp(oplogCtx *oplogContext, op db.Oplog)
 			collectionName, index := extractIndexDocumentFromCreateIndexes(op)
 			if index.Key == nil {
 				return fmt.Errorf(
-					"failed to parse IndexDocument from createIndexes in %s, %v",
+					"failed to parse IndexDocument from createIndexes in %#q, %v",
 					collectionName,
 					op,
 				)

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -368,7 +368,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 	if !restore.OutputOptions.Drop && collectionExists {
 		log.Logvf(
 			log.Always,
-			"restoring to existing collection %v without dropping",
+			"restoring to existing collection %#q without dropping",
 			intent.Namespace(),
 		)
 	}
@@ -378,7 +378,7 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) Result {
 			if strings.HasPrefix(intent.C, "system.") {
 				log.Logvf(
 					log.Always,
-					"cannot drop system collection %v, skipping",
+					"cannot drop system collection %#q, skipping",
 					intent.Namespace(),
 				)
 			} else {

--- a/mongostat/mongostat.go
+++ b/mongostat/mongostat.go
@@ -281,19 +281,19 @@ func (node *NodeMonitor) Poll(
 	checkShards bool,
 ) (*status.ServerStatus, error) {
 	stat := &status.ServerStatus{}
-	log.Logvf(log.DebugHigh, "getting session on server: %v", node.host)
+	log.Logvf(log.DebugHigh, "getting session on server: %#q", node.host)
 	session, err := node.sessionProvider.GetSession()
 	if err != nil {
-		log.Logvf(log.DebugLow, "got error getting session to server %v", node.host)
+		log.Logvf(log.DebugLow, "got error getting session to server %#q", node.host)
 		return nil, err
 	}
-	log.Logvf(log.DebugHigh, "got session on server: %v", node.host)
+	log.Logvf(log.DebugHigh, "got session on server: %#q", node.host)
 
 	result := session.Database("admin").
 		RunCommand(context.TODO(), bson.D{{"serverStatus", 1}, {"recordStats", 0}})
 	err = result.Err()
 	if err != nil {
-		log.Logvf(log.DebugLow, "got error calling serverStatus against server %v", node.host)
+		log.Logvf(log.DebugLow, "got error calling serverStatus against server %#q", node.host)
 		return nil, err
 	}
 	tempBson, err := result.Raw()
@@ -362,11 +362,11 @@ func (node *NodeMonitor) Watch(sleep time.Duration, discover chan string, cluste
 	var cycle uint64
 	ticker := time.NewTicker(sleep)
 	for range ticker.C {
-		log.Logvf(log.DebugHigh, "polling server: %v", node.host)
+		log.Logvf(log.DebugHigh, "polling server: %#q", node.host)
 		stat, err := node.Poll(discover, cycle%10 == 0)
 
 		if stat != nil {
-			log.Logvf(log.DebugHigh, "successfully got statline from host: %v", node.host)
+			log.Logvf(log.DebugHigh, "successfully got statline from host: %#q", node.host)
 		}
 		var nodeError *status.NodeError
 		if err != nil {
@@ -402,7 +402,7 @@ func (mstat *MongoStat) AddNewNode(fullhost string) error {
 			return nil
 		}
 	}
-	log.Logvf(log.DebugLow, "adding new host to monitoring: %v", fullhost)
+	log.Logvf(log.DebugLow, "adding new host to monitoring: %#q", fullhost)
 	// Create a new node monitor for this host
 	node, err := NewNodeMonitor(*mstat.Options, fullhost)
 	if err != nil {

--- a/mongotop/mongotop.go
+++ b/mongotop/mongotop.go
@@ -72,7 +72,7 @@ func (mt *MongoTop) runTopDiff() (outDiff FormattableDiff, err error) {
 		}
 
 		if topinfo[elem.Key()] != (NSTopInfo{}) {
-			return nil, fmt.Errorf("duplicate namespace (%s) in top result", elem.Key())
+			return nil, fmt.Errorf("duplicate namespace %#q in top result", elem.Key())
 		}
 		info := NSTopInfo{}
 		if unmarshalErr := bson.Unmarshal(elem.Value().Document(), &info); unmarshalErr != nil {

--- a/test/qa-tests/jstests/dump/version_test.js
+++ b/test/qa-tests/jstests/dump/version_test.js
@@ -37,9 +37,9 @@
     out = rawMongoProgramOutput();
     return (out.match(/archive \w+ version/g) || []).length;
   }, "should see at least three version string in the output");
-  assert(/archive format version "\S+"/.test(out), "format version found");
-  assert(/archive server version "\S+"/.test(out), "server version found");
-  assert(/archive tool version "\S+"/.test(out), "tool version found");
+  assert(/archive format version `\S+`/.test(out), "format version found");
+  assert(/archive server version `\S+`/.test(out), "server version found");
+  assert(/archive tool version `\S+`/.test(out), "tool version found");
 
   toolTest.stop();
 }());


### PR DESCRIPTION
There were many places that could benefit from escaping, not just for DB and collection names