### PR TITLE
TOOLS-4148 Rename the `importexport` dir to `exportimport`

### DIFF
--- a/integration/exportimport/csv_test.go
+++ b/integration/exportimport/csv_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package importexport
+package exportimport
 
 import (
 	"os"
@@ -19,7 +19,7 @@ import (
 
 // TestRoundTripFieldFile verifies that mongoexport --fieldFile limits exported
 // fields, and that mongoimport correctly restores the filtered data.
-func (s *ImportExportSuite) TestRoundTripFieldFile() {
+func (s *ExportImportSuite) TestRoundTripFieldFile() {
 	const dbName = "mongoimport_roundtrip_fieldfile_test"
 
 	client := s.Client()
@@ -98,7 +98,7 @@ func (s *ImportExportSuite) TestRoundTripFieldFile() {
 
 // TestRoundTripFieldsCSV verifies that mongoexport --csv --fields limits which
 // fields are exported, and that mongoimport correctly restores the filtered data.
-func (s *ImportExportSuite) TestRoundTripFieldsCSV() {
+func (s *ExportImportSuite) TestRoundTripFieldsCSV() {
 	const dbName = "mongoimport_roundtrip_fieldscsv_test"
 
 	client := s.Client()
@@ -151,7 +151,7 @@ func (s *ImportExportSuite) TestRoundTripFieldsCSV() {
 
 // TestRoundTripNestedFieldsCSV verifies that mongoexport correctly exports
 // nested dotted field paths to CSV and that mongoimport restores them.
-func (s *ImportExportSuite) TestRoundTripNestedFieldsCSV() {
+func (s *ExportImportSuite) TestRoundTripNestedFieldsCSV() {
 	const dbName = "mongoimport_roundtrip_nestedcsv_test"
 
 	client := s.Client()
@@ -223,7 +223,7 @@ func (s *ImportExportSuite) TestRoundTripNestedFieldsCSV() {
 	}
 }
 
-func (s *ImportExportSuite) exportCSVAndImport(dbName, exportFields string, db *mongo.Database) {
+func (s *ExportImportSuite) exportCSVAndImport(dbName, exportFields string, db *mongo.Database) {
 	s.Require().NoError(db.Collection("dest").Drop(s.Context()))
 
 	exportTarget, err := os.CreateTemp(s.T().TempDir(), "export-*.csv")

--- a/integration/exportimport/data_test.go
+++ b/integration/exportimport/data_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package importexport
+package exportimport
 
 import (
 	"os"
@@ -19,7 +19,7 @@ import (
 
 // TestRoundTripBasicData verifies that data exported by mongoexport can be
 // fully restored by mongoimport with all documents intact.
-func (s *ImportExportSuite) TestRoundTripBasicData() {
+func (s *ExportImportSuite) TestRoundTripBasicData() {
 	const dbName = "mongoimport_roundtrip_basic_test"
 	const collName = "data"
 
@@ -82,7 +82,7 @@ func (s *ImportExportSuite) TestRoundTripBasicData() {
 
 // TestRoundTripDataTypes verifies that documents with diverse BSON types
 // survive an export-then-import round-trip intact.
-func (s *ImportExportSuite) TestRoundTripDataTypes() {
+func (s *ExportImportSuite) TestRoundTripDataTypes() {
 	const dbName = "mongoimport_roundtrip_datatypes_test"
 	const collName = "data"
 
@@ -164,7 +164,7 @@ func (s *ImportExportSuite) TestRoundTripDataTypes() {
 
 // TestRoundTripDecimal128 verifies that a Decimal128 value survives an
 // export-then-import round-trip.
-func (s *ImportExportSuite) TestRoundTripDecimal128() {
+func (s *ExportImportSuite) TestRoundTripDecimal128() {
 	const dbName = "mongoimport_decimal128_test"
 	const collName = "dec128"
 
@@ -220,7 +220,7 @@ func (s *ImportExportSuite) TestRoundTripDecimal128() {
 
 // TestRoundTripViewExport verifies that mongoexport correctly exports documents
 // from a MongoDB view, and that mongoimport can restore them.
-func (s *ImportExportSuite) TestRoundTripViewExport() {
+func (s *ExportImportSuite) TestRoundTripViewExport() {
 	const dbName = "mongoimport_roundtrip_views_test"
 
 	client := s.Client()

--- a/integration/exportimport/import_modes_test.go
+++ b/integration/exportimport/import_modes_test.go
@@ -1,4 +1,4 @@
-package importexport
+package exportimport
 
 import (
 	"os"
@@ -11,7 +11,7 @@ import (
 // TestImportModeUpsertIDSubdoc verifies that --mode=upsert uses the full
 // subdocument _id as the upsert key, preserving field order through a
 // round-trip of export → upsert-replace → re-import.
-func (s *ImportExportSuite) TestImportModeUpsertIDSubdoc() {
+func (s *ExportImportSuite) TestImportModeUpsertIDSubdoc() {
 	const (
 		dbName   = "mongoimport_upsert_subdoc_test"
 		collName = "c"
@@ -58,7 +58,7 @@ func (s *ImportExportSuite) TestImportModeUpsertIDSubdoc() {
 	})
 }
 
-func (s *ImportExportSuite) writeSubdocIDFile(xFieldValue string) string {
+func (s *ExportImportSuite) writeSubdocIDFile(xFieldValue string) string {
 	f, err := os.CreateTemp(s.T().TempDir(), "subdoc-*.json")
 	s.Require().NoError(err, "create temp file")
 	for _, doc := range subdocIDDocs(xFieldValue) {

--- a/integration/exportimport/import_validation_test.go
+++ b/integration/exportimport/import_validation_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package importexport
+package exportimport
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 // validators: normal import skips invalid docs, --bypassDocumentValidation
 // imports all, --stopOnError and --maintainInsertionOrder fail on validation
 // errors.
-func (s *ImportExportSuite) TestImportDocumentValidation() {
+func (s *ExportImportSuite) TestImportDocumentValidation() {
 	const dbName = "mongoimport_docvalidation_test"
 	const collName = "docvalidation"
 

--- a/integration/exportimport/json_test.go
+++ b/integration/exportimport/json_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package importexport
+package exportimport
 
 import (
 	"os"
@@ -19,7 +19,7 @@ import (
 
 // TestRoundTripFieldsJSON verifies that mongoexport --fields limits which fields
 // appear in JSON export output, and that _id is included (unlike CSV).
-func (s *ImportExportSuite) TestRoundTripFieldsJSON() {
+func (s *ExportImportSuite) TestRoundTripFieldsJSON() {
 	const dbName = "mongoimport_roundtrip_fieldsjson_test"
 
 	client := s.Client()
@@ -76,7 +76,7 @@ func (s *ImportExportSuite) TestRoundTripFieldsJSON() {
 // TestRoundTripJSONArray verifies that mongoexport --jsonArray produces a JSON
 // array, that mongoimport rejects it without --jsonArray, and accepts it with
 // --jsonArray.
-func (s *ImportExportSuite) TestRoundTripJSONArray() {
+func (s *ExportImportSuite) TestRoundTripJSONArray() {
 	const dbName = "mongoimport_roundtrip_jsonarray_test"
 	const collName = "data"
 
@@ -155,7 +155,7 @@ func (s *ImportExportSuite) TestRoundTripJSONArray() {
 	}
 }
 
-func (s *ImportExportSuite) exportJSONAndImport(dbName, fields string, db *mongo.Database) {
+func (s *ExportImportSuite) exportJSONAndImport(dbName, fields string, db *mongo.Database) {
 	s.Require().NoError(db.Collection("dest").Drop(s.Context()))
 
 	tmpFile, err := os.CreateTemp(s.T().TempDir(), "export-*.json")

--- a/integration/exportimport/query_test.go
+++ b/integration/exportimport/query_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package importexport
+package exportimport
 
 import (
 	"math/rand"
@@ -21,7 +21,7 @@ import (
 
 // TestRoundTripLimit verifies that mongoexport --limit restricts the number of
 // exported documents, and that the correct documents are restored.
-func (s *ImportExportSuite) TestRoundTripLimit() {
+func (s *ExportImportSuite) TestRoundTripLimit() {
 	const dbName = "mongoimport_roundtrip_limit_test"
 	const collName = "data"
 
@@ -82,7 +82,7 @@ func (s *ImportExportSuite) TestRoundTripLimit() {
 
 // TestRoundTripQuery verifies that mongoexport --query and --queryFile filter
 // export output correctly across multiple query types.
-func (s *ImportExportSuite) TestRoundTripQuery() {
+func (s *ExportImportSuite) TestRoundTripQuery() {
 	const dbName = "mongoimport_roundtrip_query_test"
 
 	client := s.Client()
@@ -147,7 +147,7 @@ func (s *ImportExportSuite) TestRoundTripQuery() {
 
 // TestRoundTripSortAndSkip verifies that mongoexport --sort and --skip
 // correctly affect which documents are exported.
-func (s *ImportExportSuite) TestRoundTripSortAndSkip() {
+func (s *ExportImportSuite) TestRoundTripSortAndSkip() {
 	const dbName = "mongoimport_roundtrip_sortskip_test"
 	const collName = "data"
 
@@ -209,7 +209,7 @@ func (s *ImportExportSuite) TestRoundTripSortAndSkip() {
 	}
 }
 
-func (s *ImportExportSuite) exportAndImportWithQuery(
+func (s *ExportImportSuite) exportAndImportWithQuery(
 	db *mongo.Database,
 	sourceDocs []any,
 	query, queryFile string,

--- a/integration/exportimport/suite_test.go
+++ b/integration/exportimport/suite_test.go
@@ -1,4 +1,4 @@
-package importexport
+package exportimport
 
 import (
 	"os"
@@ -18,18 +18,18 @@ import (
 	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-type ImportExportSuite struct {
+type ExportImportSuite struct {
 	sharedsuite.IntegrationSuite
 }
 
 func TestImportExport(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	ts := new(ImportExportSuite)
+	ts := new(ExportImportSuite)
 	suite.Run(t, ts)
 }
 
-func (s *ImportExportSuite) ExportOptions() mongoexport.Options {
+func (s *ExportImportSuite) ExportOptions() mongoexport.Options {
 	toolOptions, err := testutil.GetToolOptions()
 	s.Require().NoError(err)
 
@@ -47,7 +47,7 @@ func (s *ImportExportSuite) ExportOptions() mongoexport.Options {
 	return opts
 }
 
-func (s *ImportExportSuite) ImportOptions(dbName, collName string) mongoimport.Options {
+func (s *ExportImportSuite) ImportOptions(dbName, collName string) mongoimport.Options {
 	ssl := testutil.GetSSLOptions()
 	auth := testutil.GetAuthOptions()
 
@@ -76,7 +76,7 @@ func (s *ImportExportSuite) ImportOptions(dbName, collName string) mongoimport.O
 	}
 }
 
-func (s *ImportExportSuite) importCollection(
+func (s *ExportImportSuite) importCollection(
 	ns *options.Namespace,
 	filePath string,
 	ingestOpts mongoimport.IngestOptions,
@@ -97,7 +97,7 @@ func (s *ImportExportSuite) importCollection(
 	return err
 }
 
-func (s *ImportExportSuite) exportCollectionToFile(ns *options.Namespace) string {
+func (s *ExportImportSuite) exportCollectionToFile(ns *options.Namespace) string {
 	exportFile, err := os.CreateTemp(s.T().TempDir(), "export-*.json")
 	s.Require().NoError(err)
 	exportToolOptions, err := testutil.GetToolOptions()
@@ -119,7 +119,7 @@ func (s *ImportExportSuite) exportCollectionToFile(ns *options.Namespace) string
 	return exportFile.Name()
 }
 
-func (s *ImportExportSuite) recreateWithValidator(coll *mongo.Collection, validator any) {
+func (s *ExportImportSuite) recreateWithValidator(coll *mongo.Collection, validator any) {
 	s.Require().NoError(coll.Database().Drop(s.Context()))
 	s.Require().NoError(coll.Database().CreateCollection(
 		s.Context(),
@@ -128,7 +128,7 @@ func (s *ImportExportSuite) recreateWithValidator(coll *mongo.Collection, valida
 	))
 }
 
-func (s *ImportExportSuite) assertValidationError(err error, msg string) {
+func (s *ExportImportSuite) assertValidationError(err error, msg string) {
 	var bwe mongo.BulkWriteException
 	if s.Assert().ErrorAs(err, &bwe, msg) {
 		s.Assert().NotEmpty(bwe.WriteErrors, "should have at least one write error")

--- a/integration/exportimport/timeseries_test.go
+++ b/integration/exportimport/timeseries_test.go
@@ -1,4 +1,4 @@
-package importexport
+package exportimport
 
 import (
 	"bytes"
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-func (s *ImportExportSuite) TestTimeseries() {
+func (s *ExportImportSuite) TestTimeseries() {
 	s.RequireFCVAtLeast("5.0")
 
 	client := s.Client()


### PR DESCRIPTION
This matches the `dumprestore` naming.