### PR TITLE
TOOLS-4148 Add a `BeforeTest` hook for integration suites that drops all existing DBs

### DIFF
--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -180,7 +180,6 @@ func runTests(ctx *task.Context, pkgs []string, testType string) error {
 		// Use the recursive wildcard (...) to run all tests
 		// of the provided testType for the current pkg.
 		args := []string{"test", "./" + pkg + "/..."}
-		args = append(args, buildFlags...)
 		if pkg == "integration" {
 			// We need to run the tests in these packages sequentially because they all share a
 			// single test cluster. When they're run in parallel, they can step on each other.

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -45,7 +45,6 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 	srcCollNames := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
 
 	db := sess.Database(uniqueDBName())
-	s.Require().NoError(db.Drop(ctx), "should pre-drop DB %#q", db.Name())
 
 	s.T().Logf("creating collections")
 
@@ -57,11 +56,6 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 					{"someNum", rand.Float64()},
 				}
 			},
-		)
-
-		s.Require().NoError(
-			db.Collection(collName).Drop(ctx),
-			"should drop %#q", collName,
 		)
 
 		_, err := db.Collection(collName).InsertMany(
@@ -330,10 +324,6 @@ func (s *DumpRestoreSuite) TestRestoreZeroTimestamp() {
 
 	dbName := uniqueDBName()
 	testDB := session.Database(dbName)
-	defer func() {
-		err = testDB.Drop(ctx)
-		s.Require().NoError(err, "Failed to drop test database")
-	}()
 
 	coll := testDB.Collection("mycoll")
 
@@ -396,10 +386,6 @@ func (s *DumpRestoreSuite) TestRestoreZeroTimestamp_NonClobber() {
 
 	dbName := uniqueDBName()
 	testDB := session.Database(dbName)
-	defer func() {
-		err = testDB.Drop(ctx)
-		s.Require().NoError(err, "Failed to drop test database")
-	}()
 
 	coll := testDB.Collection("mycoll")
 

--- a/integration/importexport/csv_test.go
+++ b/integration/importexport/csv_test.go
@@ -22,7 +22,7 @@ import (
 func (s *ImportExportSuite) TestRoundTripFieldFile() {
 	const dbName = "mongoimport_roundtrip_fieldfile_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 	_, err := db.Collection("source").InsertMany(s.Context(), []any{
@@ -101,7 +101,7 @@ func (s *ImportExportSuite) TestRoundTripFieldFile() {
 func (s *ImportExportSuite) TestRoundTripFieldsCSV() {
 	const dbName = "mongoimport_roundtrip_fieldscsv_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 	_, err := db.Collection("source").InsertMany(s.Context(), []any{
@@ -154,7 +154,7 @@ func (s *ImportExportSuite) TestRoundTripFieldsCSV() {
 func (s *ImportExportSuite) TestRoundTripNestedFieldsCSV() {
 	const dbName = "mongoimport_roundtrip_nestedcsv_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 	_, err := db.Collection("source").InsertMany(s.Context(), []any{

--- a/integration/importexport/data_test.go
+++ b/integration/importexport/data_test.go
@@ -23,7 +23,7 @@ func (s *ImportExportSuite) TestRoundTripBasicData() {
 	const dbName = "mongoimport_roundtrip_basic_test"
 	const collName = "data"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	var docs []bson.D
@@ -86,7 +86,7 @@ func (s *ImportExportSuite) TestRoundTripDataTypes() {
 	const dbName = "mongoimport_roundtrip_datatypes_test"
 	const collName = "data"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	docs := []any{
@@ -168,7 +168,7 @@ func (s *ImportExportSuite) TestRoundTripDecimal128() {
 	const dbName = "mongoimport_decimal128_test"
 	const collName = "dec128"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	dec, err := bson.ParseDecimal128("123456789012345678901234567890")
 	s.Require().NoError(err)
@@ -223,7 +223,7 @@ func (s *ImportExportSuite) TestRoundTripDecimal128() {
 func (s *ImportExportSuite) TestRoundTripViewExport() {
 	const dbName = "mongoimport_roundtrip_views_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 

--- a/integration/importexport/import_modes_test.go
+++ b/integration/importexport/import_modes_test.go
@@ -17,7 +17,7 @@ func (s *ImportExportSuite) TestImportModeUpsertIDSubdoc() {
 		collName = "c"
 	)
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	ns := &options.Namespace{DB: dbName, Collection: collName}

--- a/integration/importexport/import_validation_test.go
+++ b/integration/importexport/import_validation_test.go
@@ -25,7 +25,7 @@ func (s *ImportExportSuite) TestImportDocumentValidation() {
 	const dbName = "mongoimport_docvalidation_test"
 	const collName = "docvalidation"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 

--- a/integration/importexport/json_test.go
+++ b/integration/importexport/json_test.go
@@ -22,7 +22,7 @@ import (
 func (s *ImportExportSuite) TestRoundTripFieldsJSON() {
 	const dbName = "mongoimport_roundtrip_fieldsjson_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 	_, err := db.Collection("source").InsertMany(s.Context(), []any{
@@ -80,7 +80,7 @@ func (s *ImportExportSuite) TestRoundTripJSONArray() {
 	const dbName = "mongoimport_roundtrip_jsonarray_test"
 	const collName = "data"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	docs := make([]any, 20)

--- a/integration/importexport/query_test.go
+++ b/integration/importexport/query_test.go
@@ -25,7 +25,7 @@ func (s *ImportExportSuite) TestRoundTripLimit() {
 	const dbName = "mongoimport_roundtrip_limit_test"
 	const collName = "data"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	docs := make([]any, 50)
@@ -85,7 +85,7 @@ func (s *ImportExportSuite) TestRoundTripLimit() {
 func (s *ImportExportSuite) TestRoundTripQuery() {
 	const dbName = "mongoimport_roundtrip_query_test"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	db := client.Database(dbName)
 
@@ -151,7 +151,7 @@ func (s *ImportExportSuite) TestRoundTripSortAndSkip() {
 	const dbName = "mongoimport_roundtrip_sortskip_test"
 	const collName = "data"
 
-	client := s.newClient(dbName)
+	client := s.Client()
 
 	coll := client.Database(dbName).Collection(collName)
 	docs := make([]any, 50)

--- a/integration/importexport/suite_test.go
+++ b/integration/importexport/suite_test.go
@@ -76,14 +76,6 @@ func (s *ImportExportSuite) ImportOptions(dbName, collName string) mongoimport.O
 	}
 }
 
-func (s *ImportExportSuite) newClient(dbName string) *mongo.Client {
-	client := s.Client()
-	s.T().Cleanup(func() {
-		_ = client.Database(dbName).Drop(s.Context())
-	})
-	return client
-}
-
 func (s *ImportExportSuite) importCollection(
 	ns *options.Namespace,
 	filePath string,

--- a/integration/importexport/timeseries_test.go
+++ b/integration/importexport/timeseries_test.go
@@ -18,18 +18,6 @@ func (s *ImportExportSuite) TestTimeseries() {
 	serverVersion := s.ServerVersion()
 
 	fromDBName, toDBName, collName := "fromdb", "todb", "tscoll"
-
-	cleanup := func() {
-		err := client.Database(fromDBName).Drop(s.Context())
-		s.Require().NoError(err)
-
-		err = client.Database(toDBName).Drop(s.Context())
-		s.Require().NoError(err)
-	}
-
-	cleanup()
-	defer cleanup()
-
 	testutil.SetUpTimeseries(s.T(), fromDBName, collName)
 
 	s.Run("logical documents", func() {

--- a/integration/sharedsuite/suite.go
+++ b/integration/sharedsuite/suite.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"strings"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	testifySuite "github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
@@ -42,6 +44,25 @@ func (s *IntegrationSuite) DBName(prefix ...string) string {
 		name = name[:maxLen]
 	}
 	return p + name
+}
+
+var systemDBs = mapset.NewSet("admin", "local", "config")
+
+// BeforeTest drops all user databases before each test so every test starts
+// with a clean slate. System databases (admin, local, config) are preserved.
+func (s *IntegrationSuite) BeforeTest(_, _ string) {
+	client := s.Client()
+	defer client.Disconnect(context.Background()) //nolint:errcheck
+
+	names, err := client.ListDatabaseNames(context.Background(), bson.D{})
+	s.Require().NoError(err)
+
+	for _, name := range names {
+		if !systemDBs.Contains(name) {
+			err = client.Database(name).Drop(context.Background())
+			s.Require().NoError(err)
+		}
+	}
 }
 
 func (s *IntegrationSuite) RequireFCVAtLeast(wantFCV string) {


### PR DESCRIPTION
This ensures that the cluster is free of stuff created by previous tests. But this means that we must run these tests sequentially, so that the `BeforeTest` hook doesn't delete the data for another test running at the same time.

This PR also removes a lot of ad-hoc cleanup that was being done in individual test methods.