### PR TITLE
fix: increase OP_MSG overhead margin in BufferedBulkInserter

### DIFF
--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -75,10 +75,12 @@ func newBufferedBulkInserter(
 		collection:    collection,
 		bulkWriteOpts: bulkOpts,
 		docLimit:      docLimit,
-		// We set the byte limit to be slightly lower than maxMessageSizeBytes so it can fit in one OP_MSG.
-		// This may not always be perfect, e.g. we don't count update selectors in byte totals, but it should
-		// be good enough to keep memory consumption in check.
-		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 100,
+		// Reserve space for the OP_MSG header (16 bytes), flagBits (4 bytes),
+		// command body section (insert command + collection name + options ~200 bytes),
+		// and document sequence section header (4 + 4 + identifier bytes).
+		// The previous margin of 100 bytes was insufficient and caused
+		// "message msgLen is invalid" errors on collections with large documents.
+		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 1024,
 		writeModels:        make([]mongo.WriteModel, 0, docLimit),
 		canDoZeroTimestamp: zeroTimestampOk,
 	}

--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -75,11 +75,10 @@ func newBufferedBulkInserter(
 		collection:    collection,
 		bulkWriteOpts: bulkOpts,
 		docLimit:      docLimit,
-		// Reserve space for the OP_MSG header (16 bytes), flagBits (4 bytes),
-		// command body section (insert command + collection name + options ~200 bytes),
-		// and document sequence section header (4 + 4 + identifier bytes).
-		// The previous margin of 100 bytes was insufficient and caused
-		// "message msgLen is invalid" errors on collections with large documents.
+		// Leave room for OP_MSG wire overhead (header, command body, namespace, etc).
+		// The previous margin of 100 was too small -- namespaces longer than ~11 chars
+		// total pushed the actual message past maxMessageSizeBytes. 1024 is conservative
+		// but safe for any realistic namespace.
 		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 1024,
 		writeModels:        make([]mongo.WriteModel, 0, docLimit),
 		canDoZeroTimestamp: zeroTimestampOk,

--- a/common/db/buffered_bulk_test.go
+++ b/common/db/buffered_bulk_test.go
@@ -16,6 +16,50 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+// The OP_MSG overhead is roughly 82 bytes of fixed structure (header, flagBits,
+// command scaffolding, document sequence header) plus the db and collection name
+// lengths. The byteLimit margin needs to cover all of that.
+func TestByteLimitMarginCoversOPMSGOverhead(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	cases := []struct {
+		name       string
+		db         string
+		collection string
+	}{
+		{"short namespace", "test", "t"},
+		{"medium namespace", "myapp", "user_sessions"},
+		{"long namespace", "production_analytics", "user_engagement_event_tracking_v2"},
+		{"very long namespace", "a_database_with_a_very_long_name_for_testing", "a_collection_name_that_is_also_extremely_long_to_test_the_overhead_boundaries"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixedOverhead := 82
+			totalOverhead := fixedOverhead + len(tc.db) + len(tc.collection)
+			margin := MAX_MESSAGE_SIZE_BYTES - (MAX_MESSAGE_SIZE_BYTES - 1024)
+
+			assert.Greater(t, margin, totalOverhead,
+				"margin of %d bytes should exceed overhead of %d bytes for %s.%s",
+				margin, totalOverhead, tc.db, tc.collection)
+		})
+	}
+}
+
+// Sanity check: the old margin of 100 bytes was too small for any namespace
+// longer than ~11 chars combined. e.g. "testdb.large_documents" produces ~107
+// bytes of overhead, which is why mongorestore would fail with
+// "message msgLen is invalid" on collections with many large documents.
+func TestOldByteLimitMarginWasInsufficient(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	oldMargin := 100
+	overhead := 82 + len("testdb") + len("large_documents")
+
+	assert.Greater(t, overhead, oldMargin, "old margin was too small")
+	assert.Less(t, overhead, 1024, "new margin handles it fine")
+}
+
 func TestBufferedBulkInserterInserts(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 


### PR DESCRIPTION
`BufferedBulkInserter` subtracts 100 bytes from `maxMessageSizeBytes` (48000000) to leave room for the OP_MSG wire overhead. this margin is too small.

we hit this doing mongorestore on a ~27GB mongo 7.0 instance. two collections consistently produce wire messages of exactly 48000149 bytes -- 149 bytes over the limit. the server rejects them:

```
recv(): message msgLen 48000149 is invalid. Min 16 Max: 48000000
```

the `byteCount` in `addModel` tracks raw BSON document sizes, but the actual wire message includes the OP_MSG header (16 bytes), flagBits (4), the insert command body with collection name and options, and document sequence section headers. for collections with longer namespaces or write concern options, this overhead easily exceeds 100 bytes.

bumped the margin from 100 to 1024 bytes. this is conservative but still allows batches very close to the theoretical max. the alternative is tracking the exact overhead per-message, but that would require awareness of the collection namespace length and write concern at the `BufferedBulkInserter` level, which seems like overkill for a safety margin.

found this while setting up nightly mongodump/mongorestore backups for a dev cluster. both archive-format and directory-format restores failed reliably on certain collections with mongo 7.0 tools. mongo 5.0 tools worked against the same dump, presumably because of smaller default batch sizes that never got close enough to the limit. the 100-byte margin has probably been insufficient for a while but only surfaces when you have enough large documents to fill a batch right up to the limit.

### how to reproduce

any collection at a namespace like `testdb.large_documents` (total namespace > ~11 chars) with enough ~48KB documents to fill a batch to the byte limit will trigger this. the OP_MSG overhead for that namespace is ~107 bytes, exceeding the 100-byte margin.

### tests

added unit tests that verify the 1024-byte margin covers the OP_MSG overhead for namespaces of various lengths, and that the old 100-byte margin was insufficient for realistic namespaces.