### PR TITLE
TOOLS-4148 Add a context to `processDocuments` and `doSequentialStreaming`

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -9,6 +9,7 @@ package mongoimport
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -156,6 +157,7 @@ func constructUpsertDocument(upsertFields []string, document bson.D) bson.D {
 // the input channel to each worker and then sequentially reads the processed data
 // from each worker before passing it on to the output channel.
 func doSequentialStreaming(
+	ctx context.Context,
 	workers []*importWorker,
 	readDocs chan Converter,
 	outputChan chan bson.D,
@@ -167,7 +169,11 @@ func doSequentialStreaming(
 	go func() {
 		i := 0
 		for doc := range readDocs {
-			workers[i].unprocessedDataChan <- doc
+			select {
+			case workers[i].unprocessedDataChan <- doc:
+			case <-ctx.Done():
+				return
+			}
 			i = (i + 1) % numWorkers
 		}
 
@@ -182,11 +188,19 @@ func doSequentialStreaming(
 	numDoneWorkers := 0
 	i := 0
 	for {
-		processedDocument, open := <-workers[i].processedDocumentChan
-		if open {
-			outputChan <- processedDocument
-		} else {
-			numDoneWorkers++
+		select {
+		case processedDocument, open := <-workers[i].processedDocumentChan:
+			if open {
+				select {
+				case outputChan <- processedDocument:
+				case <-ctx.Done():
+					return
+				}
+			} else {
+				numDoneWorkers++
+			}
+		case <-ctx.Done():
+			return
 		}
 		if numDoneWorkers == numWorkers {
 			break
@@ -439,6 +453,7 @@ func isNatNum(s string) (int, bool) {
 // channel - either in sequence or concurrently (depending on the value of
 // ordered) - in which the data was received.
 func streamDocuments(
+	ctx context.Context,
 	ordered bool,
 	numDecoders int,
 	docsInChan chan Converter,
@@ -475,7 +490,7 @@ func streamDocuments(
 			defer wg.Done()
 			// only set the first worker error and cause sibling goroutines
 			// to terminate immediately
-			err := iw.processDocuments(ordered)
+			err := iw.processDocuments(ctx, ordered)
 			if err != nil && retErr == nil {
 				retErr = err
 				iw.tomb.Kill(err)
@@ -486,7 +501,7 @@ func streamDocuments(
 	// if ordered, we have to coordinate the sequence in which processed
 	// documents are passed to the main read channel
 	if ordered {
-		doSequentialStreaming(importWorkers, docsInChan, streamOutChan)
+		doSequentialStreaming(ctx, importWorkers, docsInChan, streamOutChan)
 	}
 	wg.Wait()
 	close(streamOutChan)
@@ -846,7 +861,7 @@ func validateReaderFields(fields []string, useArrayIndexFields bool) error {
 // to a bson.D document before sending it on the processedDocumentChan channel. Once the
 // input channel is closed the processed channel is also closed if the worker streams its
 // reads in order.
-func (iw *importWorker) processDocuments(ordered bool) error {
+func (iw *importWorker) processDocuments(ctx context.Context, ordered bool) error {
 	if ordered {
 		defer close(iw.processedDocumentChan)
 	}
@@ -863,8 +878,16 @@ func (iw *importWorker) processDocuments(ordered bool) error {
 			if document == nil {
 				continue
 			}
-			iw.processedDocumentChan <- document
+			select {
+			case iw.processedDocumentChan <- document:
+			case <-ctx.Done():
+				return nil
+			case <-iw.tomb.Dying():
+				return nil
+			}
 		case <-iw.tomb.Dying():
+			return nil
+		case <-ctx.Done():
 			return nil
 		}
 	}

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -451,7 +451,7 @@ func TestProcessDocuments(t *testing.T) {
 			docsInChan <- csvConverters[0]
 			docsInChan <- csvConverters[1]
 			close(docsInChan)
-			So(iw.processDocuments(true), ShouldBeNil)
+			So(iw.processDocuments(t.Context(), true), ShouldBeNil)
 			doc1, open := <-streamOutChan
 			So(doc1, ShouldResemble, expectedDocuments[0])
 			So(open, ShouldEqual, true)
@@ -473,7 +473,7 @@ func TestProcessDocuments(t *testing.T) {
 			docsInChan <- csvConverters[0]
 			docsInChan <- csvConverters[1]
 			close(docsInChan)
-			So(iw.processDocuments(false), ShouldBeNil)
+			So(iw.processDocuments(t.Context(), false), ShouldBeNil)
 			doc1, open := <-streamOutChan
 			So(doc1, ShouldResemble, expectedDocuments[0])
 			So(open, ShouldEqual, true)
@@ -521,14 +521,14 @@ func TestDoSequentialStreaming(t *testing.T) {
 					// start goroutines to do sequential processing
 					for _, iw := range importWorkers {
 						//nolint:errcheck
-						go iw.processDocuments(true)
+						go iw.processDocuments(t.Context(), true)
 					}
 					// feed in a bunch of documents
 					for _, inputCSVDocument := range csvConverters {
 						docsInChan <- inputCSVDocument
 					}
 					close(docsInChan)
-					doSequentialStreaming(importWorkers, docsInChan, streamOutChan)
+					doSequentialStreaming(t.Context(), importWorkers, docsInChan, streamOutChan)
 					for _, document := range expectedDocuments {
 						So(<-streamOutChan, ShouldResemble, document)
 					}
@@ -556,7 +556,7 @@ func TestStreamDocuments(t *testing.T) {
 					docsInChan <- csvConverter
 				}
 				close(docsInChan)
-				So(streamDocuments(true, 3, docsInChan, streamOutChan), ShouldBeNil)
+				So(streamDocuments(t.Context(), true, 3, docsInChan, streamOutChan), ShouldBeNil)
 
 				// ensure documents are streamed out and processed in the correct manner
 				for _, expectedDocument := range expectedDocuments {
@@ -578,7 +578,7 @@ func TestStreamDocuments(t *testing.T) {
 			close(docsInChan)
 
 			// ensure that an error is returned on the error channel
-			So(streamDocuments(true, 3, docsInChan, streamOutChan), ShouldNotBeNil)
+			So(streamDocuments(t.Context(), true, 3, docsInChan, streamOutChan), ShouldNotBeNil)
 		})
 	})
 }

--- a/mongoimport/csv.go
+++ b/mongoimport/csv.go
@@ -151,7 +151,7 @@ func (r *CSVInputReader) StreamDocument(
 	})
 
 	eg.Go(func() error {
-		return streamDocuments(ordered, r.numDecoders, docsInChan, streamOutChan)
+		return streamDocuments(ctx, ordered, r.numDecoders, docsInChan, streamOutChan)
 	})
 
 	return eg.Wait()

--- a/mongoimport/json.go
+++ b/mongoimport/json.go
@@ -154,7 +154,7 @@ func (r *JSONInputReader) StreamDocument(
 	})
 
 	eg.Go(func() error {
-		return streamDocuments(ordered, r.numDecoders, docsInChan, streamOutChan)
+		return streamDocuments(ctx, ordered, r.numDecoders, docsInChan, streamOutChan)
 	})
 
 	return eg.Wait()

--- a/mongoimport/json_test.go
+++ b/mongoimport/json_test.go
@@ -42,10 +42,7 @@ func TestJSONArrayStreamDocument(t *testing.T) {
 			"error out", func() {
 			contents := `[{"a": "ae"}`
 			r := NewJSONInputReader(true, true, bytes.NewReader([]byte(contents)), 1)
-			streamOutChan := make(chan bson.D, 1)
-			So(r.StreamDocument(t.Context(), true, streamOutChan), ShouldNotBeNil)
-			// though first read should be fine
-			So(<-streamOutChan, ShouldResemble, bson.D{{"a", "ae"}})
+			So(r.StreamDocument(t.Context(), true, make(chan bson.D, 1)), ShouldNotBeNil)
 		})
 
 		Convey("an error should be thrown if a plain JSON file is supplied", func() {

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -1463,10 +1463,6 @@ func generateTestData() error {
 
 // test --maintainInsertionOrder and --stopOnError behavior.
 func TestImportMIOSOE(t *testing.T) {
-	t.Skip(
-		"temporarily skipping this until the full context handling behavior is added in the next PR",
-	)
-
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
 	if err := generateTestData(); err != nil {

--- a/mongoimport/tsv.go
+++ b/mongoimport/tsv.go
@@ -161,7 +161,7 @@ func (r *TSVInputReader) StreamDocument(
 	})
 
 	eg.Go(func() error {
-		return streamDocuments(ordered, r.numDecoders, docsInChan, streamOutChan)
+		return streamDocuments(ctx, ordered, r.numDecoders, docsInChan, streamOutChan)
 	})
 
 	return eg.Wait()


### PR DESCRIPTION
Both functions now accept a `context.Context` and wrap channel reads or writes in a select with `ctx.Done()` so they exit on cancellation.

This undoes the skip added to `TestImportMIOSOE` in the previous PR.