### PR TITLE
TOOLS-4148 Replace waitgroup + tomb with an errgroup in `streamDocuments`

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -14,14 +14,13 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
 	"go.mongodb.org/mongo-driver/v2/bson"
-	"gopkg.in/tomb.v2"
+	"golang.org/x/sync/errgroup"
 )
 
 type ParseGrace int
@@ -71,9 +70,6 @@ type importWorker struct {
 
 	// used to stream the processed document back to the caller
 	processedDocumentChan chan bson.D
-
-	// used to synchronize all worker goroutines
-	tomb *tomb.Tomb
 }
 
 // an interface for tracking the number of bytes, which is used in mongoimport to feed
@@ -458,13 +454,13 @@ func streamDocuments(
 	numDecoders int,
 	docsInChan chan Converter,
 	streamOutChan chan bson.D,
-) (retErr error) {
+) error {
 	if numDecoders == 0 {
 		numDecoders = 1
 	}
 	var importWorkers []*importWorker
-	wg := new(sync.WaitGroup)
-	importTomb := new(tomb.Tomb)
+
+	eg, ctx := errgroup.WithContext(ctx)
 	// workerInChan and workerOutChan are the channels each worker reads from and writes to. With
 	// ordered=true, workers use intermediate buffered channels so doSequentialStreaming can
 	// coordinate output order; docsInChan and streamOutChan are passed unchanged to
@@ -474,6 +470,7 @@ func streamDocuments(
 	// from the pipeline.
 	workerInChan := docsInChan
 	workerOutChan := streamOutChan
+
 	for i := 0; i < numDecoders; i++ {
 		if ordered {
 			workerInChan = make(chan Converter, workerBufferSize)
@@ -482,20 +479,11 @@ func streamDocuments(
 		iw := &importWorker{
 			unprocessedDataChan:   workerInChan,
 			processedDocumentChan: workerOutChan,
-			tomb:                  importTomb,
 		}
 		importWorkers = append(importWorkers, iw)
-		wg.Add(1)
-		go func(iw importWorker) {
-			defer wg.Done()
-			// only set the first worker error and cause sibling goroutines
-			// to terminate immediately
-			err := iw.processDocuments(ctx, ordered)
-			if err != nil && retErr == nil {
-				retErr = err
-				iw.tomb.Kill(err)
-			}
-		}(*iw)
+		eg.Go(func() error {
+			return iw.processDocuments(ctx, ordered)
+		})
 	}
 
 	// if ordered, we have to coordinate the sequence in which processed
@@ -503,9 +491,10 @@ func streamDocuments(
 	if ordered {
 		doSequentialStreaming(ctx, importWorkers, docsInChan, streamOutChan)
 	}
-	wg.Wait()
+	err := eg.Wait()
 	close(streamOutChan)
-	return
+
+	return err
 }
 
 // coercionError should only be used as a specific error type to check
@@ -882,11 +871,7 @@ func (iw *importWorker) processDocuments(ctx context.Context, ordered bool) erro
 			case iw.processedDocumentChan <- document:
 			case <-ctx.Done():
 				return nil
-			case <-iw.tomb.Dying():
-				return nil
 			}
-		case <-iw.tomb.Dying():
-			return nil
 		case <-ctx.Done():
 			return nil
 		}

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/v2/bson"
-	"gopkg.in/tomb.v2"
 )
 
 func init() {
@@ -446,7 +445,6 @@ func TestProcessDocuments(t *testing.T) {
 			iw := &importWorker{
 				unprocessedDataChan:   docsInChan,
 				processedDocumentChan: streamOutChan,
-				tomb:                  &tomb.Tomb{},
 			}
 			docsInChan <- csvConverters[0]
 			docsInChan <- csvConverters[1]
@@ -468,7 +466,6 @@ func TestProcessDocuments(t *testing.T) {
 			iw := &importWorker{
 				unprocessedDataChan:   docsInChan,
 				processedDocumentChan: streamOutChan,
-				tomb:                  &tomb.Tomb{},
 			}
 			docsInChan <- csvConverters[0]
 			docsInChan <- csvConverters[1]
@@ -507,12 +504,10 @@ func TestDoSequentialStreaming(t *testing.T) {
 				{
 					unprocessedDataChan:   workerInputChannel[0],
 					processedDocumentChan: workerOutputChannel[0],
-					tomb:                  &tomb.Tomb{},
 				},
 				{
 					unprocessedDataChan:   workerInputChannel[1],
 					processedDocumentChan: workerOutputChannel[1],
-					tomb:                  &tomb.Tomb{},
 				},
 			}
 			Convey(


### PR DESCRIPTION
We used `tomb.Tomb` to do the same thing as an errgroup. Killing the tomb was a way to signal that sibling goroutines should exit early. That's what `errgroup.WithContext` does via context cancellation.