### PR TITLE
TOOLS-4148 Pass the errgroup created in `streamDocuments` to `doSequentialStreaming`

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -154,6 +154,7 @@ func constructUpsertDocument(upsertFields []string, document bson.D) bson.D {
 // from each worker before passing it on to the output channel.
 func doSequentialStreaming(
 	ctx context.Context,
+	eg *errgroup.Group,
 	workers []*importWorker,
 	readDocs chan Converter,
 	outputChan chan bson.D,
@@ -162,13 +163,13 @@ func doSequentialStreaming(
 
 	// feed in the data to be processed and do round-robin
 	// reads from each worker once processing is completed
-	go func() {
+	eg.Go(func() error {
 		i := 0
 		for doc := range readDocs {
 			select {
 			case workers[i].unprocessedDataChan <- doc:
 			case <-ctx.Done():
-				return
+				return nil
 			}
 			i = (i + 1) % numWorkers
 		}
@@ -177,7 +178,8 @@ func doSequentialStreaming(
 		for i := 0; i < numWorkers; i++ {
 			close(workers[i].unprocessedDataChan)
 		}
-	}()
+		return nil
+	})
 
 	// coordinate the order in which the documents are sent over to the
 	// main output channel
@@ -489,7 +491,7 @@ func streamDocuments(
 	// if ordered, we have to coordinate the sequence in which processed
 	// documents are passed to the main read channel
 	if ordered {
-		doSequentialStreaming(ctx, importWorkers, docsInChan, streamOutChan)
+		doSequentialStreaming(ctx, eg, importWorkers, docsInChan, streamOutChan)
 	}
 	err := eg.Wait()
 	close(streamOutChan)

--- a/mongoimport/common_test.go
+++ b/mongoimport/common_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"golang.org/x/sync/errgroup"
 )
 
 func init() {
@@ -513,17 +514,20 @@ func TestDoSequentialStreaming(t *testing.T) {
 			Convey(
 				"documents moving through the input channel should be processed and returned in sequence",
 				func() {
+					eg, ctx := errgroup.WithContext(t.Context())
+
 					// start goroutines to do sequential processing
 					for _, iw := range importWorkers {
-						//nolint:errcheck
-						go iw.processDocuments(t.Context(), true)
+						eg.Go(
+							func() error { return iw.processDocuments(ctx, true) },
+						)
 					}
 					// feed in a bunch of documents
 					for _, inputCSVDocument := range csvConverters {
 						docsInChan <- inputCSVDocument
 					}
 					close(docsInChan)
-					doSequentialStreaming(t.Context(), importWorkers, docsInChan, streamOutChan)
+					doSequentialStreaming(ctx, eg, importWorkers, docsInChan, streamOutChan)
 					for _, document := range expectedDocuments {
 						So(<-streamOutChan, ShouldResemble, document)
 					}


### PR DESCRIPTION
This removes the last bare `go func` in mongoimport.