### PR TITLE
TOOLS-4142 Estimate 1 MB for message overhead

### DIFF
--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -77,8 +77,10 @@ func newBufferedBulkInserter(
 		docLimit:      docLimit,
 		// We set the byte limit to be slightly lower than maxMessageSizeBytes so it can fit in one OP_MSG.
 		// This may not always be perfect, e.g. we don't count update selectors in byte totals, but it should
-		// be good enough to keep memory consumption in check.
-		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 100,
+		// be good enough to keep memory consumption in check. Because we cannot reliably predict the total
+		// size of the message that will be sent by the go-driver, the 1MB buffer for message overhead is
+		// a conservative estimate chosen arbitrarily.
+		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 1_000_000,
 		writeModels:        make([]mongo.WriteModel, 0, docLimit),
 		canDoZeroTimestamp: zeroTimestampOk,
 	}


### PR DESCRIPTION
A previous fix to cap the total size of inserted documents to 48MB does not seem to fix the issue for some users. This commit adds another fix in the `BufferedBulkInserter` to always reserve 1 MB for message overhead.