### PR TITLE
Increase OP_MSG overhead margin from 100 bytes to 4 MiB

### DIFF
--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -16,9 +16,18 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/xoptions"
 )
 
-// The default value of maxMessageSizeBytes
+// MAX_MESSAGE_SIZE_BYTES default value of maxMessageSizeBytes
 // See: https://docs.mongodb.com/manual/reference/command/hello/#mongodb-data-hello.maxMessageSizeBytes
 const MAX_MESSAGE_SIZE_BYTES = 48000000
+
+// MSG_OVERHEAD_BYTES Overhead budget for the OP_MSG wire message wrapping a bulk write.
+// The Go driver v2 Batches.AppendBatchSequence checks only the cumulative
+// document size against MaxMessageSize without subtracting the
+// already-written command header, so we must reserve enough room for the
+// wire message header, command body (insert command, $db, collection name,
+// session, clusterTime, ordered, additionalCmd fields), and
+// document-sequence framing.
+const MSG_OVERHEAD_BYTES = 4 * 1024 * 1024
 
 // BufferedBulkInserter implements a bufio.Writer-like design for queuing up
 // documents and inserting them in bulk when the given doc limit (or max
@@ -71,14 +80,11 @@ func newBufferedBulkInserter(
 	}
 
 	bb := &BufferedBulkInserter{
-		serverVersion: serverVersion,
-		collection:    collection,
-		bulkWriteOpts: bulkOpts,
-		docLimit:      docLimit,
-		// We set the byte limit to be slightly lower than maxMessageSizeBytes so it can fit in one OP_MSG.
-		// This may not always be perfect, e.g. we don't count update selectors in byte totals, but it should
-		// be good enough to keep memory consumption in check.
-		byteLimit:          MAX_MESSAGE_SIZE_BYTES - 100,
+		serverVersion:      serverVersion,
+		collection:         collection,
+		bulkWriteOpts:      bulkOpts,
+		docLimit:           docLimit,
+		byteLimit:          MAX_MESSAGE_SIZE_BYTES - MSG_OVERHEAD_BYTES,
 		writeModels:        make([]mongo.WriteModel, 0, docLimit),
 		canDoZeroTimestamp: zeroTimestampOk,
 	}


### PR DESCRIPTION
## Summary

- Increase the byte limit margin from 100 bytes to 4 MiB (`MSG_OVERHEAD_BYTES`) to account for wire message overhead not tracked by `BufferedBulkInserter.byteCount`
- The Go driver v2 `Batches.AppendBatchSequence` checks only cumulative document size against `MaxMessageSize` (48 MB) without subtracting the already-written command header, session metadata, and framing — so the tool-side limit must reserve enough room
- The previous 100-byte margin was sufficient with driver v1 (which split batches at 16 MB), but caused `ProtocolError: msgLen is invalid` after the driver v2 upgrade (TOOLS-3968)

## Test plan

- [ ] Restore a backup with collections large enough to produce batches near the 48 MB limit — previously failing restores should now succeed
- [ ] Verify no regression with small backups that fit in a single batch
- [ ] Run existing `TestBufferedBulkInserterInserts` integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)