### PR TITLE
TOOLS-4189 release: fix artifact download for 8.2

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1672,7 +1672,14 @@ func downloadArtifacts(v string, artifactNames []string) {
 	)
 	check(err, "git clone")
 
-	githash, err := run("git", "-C", "mongo-release", "log", "--pretty=format:%H", grepArg)
+	githash, err := run(
+		"git",
+		"-C", "mongo-release",
+		"log",
+		"-n", "1",
+		"--pretty=format:%H",
+		grepArg,
+	)
 
 	check(err, "get git hash")
 	fmt.Printf("Git hash: %s\n", githash)


### PR DESCRIPTION
For whatever reason, there are two git hashes for the commit "add release config for 8.2.7"; this means that we try to construct an evergreen URL with two hashes joined by a newline. This causes url.Parse to error with "invalid control character in URL," meaning that all the 8.2 tests are failing on the waterfall.