### PR TITLE
TOOLS-4184 Use simple MarshalExtJSON in mongoexport

### DIFF
--- a/mongoexport/json.go
+++ b/mongoexport/json.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/json"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -98,7 +97,7 @@ func (jsonExporter *JSONExportOutput) ExportDocument(document bson.D) error {
 			}
 		}
 
-		jsonOut, err := bsonutil.MarshalExtJSONReversible(
+		jsonOut, err := bson.MarshalExtJSON(
 			document,
 			jsonExporter.JSONFormat == Canonical,
 			false,
@@ -119,7 +118,7 @@ func (jsonExporter *JSONExportOutput) ExportDocument(document bson.D) error {
 			return err
 		}
 	} else {
-		extendedDoc, err := bsonutil.MarshalExtJSONReversible(document, jsonExporter.JSONFormat == Canonical, false)
+		extendedDoc, err := bson.MarshalExtJSON(document, jsonExporter.JSONFormat == Canonical, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit reverts a change made in TOOLS-3611 for mongoexport. Mongoexport will run the simple `MarshalExtJSON` without validation for BSON-JSON-BSON round tripping. This will result in faster export but might produce JSON files that are not restorable by mongoimport.