### PR TITLE
TOOLS-4199 Clear AWS_SESSION_TOKEN when assuming role in e2e tests

### DIFF
--- a/common/testdata/lib/aws_assume_role.py
+++ b/common/testdata/lib/aws_assume_role.py
@@ -6,6 +6,7 @@ Script for assuming an aws role.
 import argparse
 import uuid
 import logging
+import os
 
 import boto3
 
@@ -14,6 +15,9 @@ LOGGER = logging.getLogger(__name__)
 STS_DEFAULT_ROLE_NAME = "arn:aws:iam::579766882180:role/mark.benvenuto"
 
 def _assume_role(role_name):
+    # Clear any inherited session token so it doesn't contaminate the long-term
+    # IAM user credentials set in the environment by the caller.
+    os.environ.pop('AWS_SESSION_TOKEN', None)
     sts_client = boto3.client("sts")
 
     response = sts_client.assume_role(RoleArn=role_name, RoleSessionName=str(uuid.uuid4()), DurationSeconds=900)

--- a/common/testdata/lib/aws_assume_role.py
+++ b/common/testdata/lib/aws_assume_role.py
@@ -6,8 +6,6 @@ Script for assuming an aws role.
 import argparse
 import uuid
 import logging
-import os
-import sys
 
 import boto3
 
@@ -16,19 +14,7 @@ LOGGER = logging.getLogger(__name__)
 STS_DEFAULT_ROLE_NAME = "arn:aws:iam::579766882180:role/mark.benvenuto"
 
 def _assume_role(role_name):
-    # Pass credentials explicitly to bypass boto3's credential chain (IMDS, files, inherited tokens).
-    access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
-    secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-
-    if not access_key_id or not secret_access_key:
-        LOGGER.error("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set in the environment")
-        sys.exit(1)
-
-    sts_client = boto3.client(
-        "sts",
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
-    )
+    sts_client = boto3.client("sts")
 
     response = sts_client.assume_role(RoleArn=role_name, RoleSessionName=str(uuid.uuid4()), DurationSeconds=900)
 

--- a/common/testdata/lib/aws_assume_role.py
+++ b/common/testdata/lib/aws_assume_role.py
@@ -16,7 +16,19 @@ LOGGER = logging.getLogger(__name__)
 STS_DEFAULT_ROLE_NAME = "arn:aws:iam::579766882180:role/mark.benvenuto"
 
 def _assume_role(role_name):
-    sts_client = boto3.client("sts")
+    # Pass credentials explicitly to bypass boto3's credential chain (IMDS, files, inherited tokens).
+    access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
+    secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+
+    if not access_key_id or not secret_access_key:
+        LOGGER.error("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set in the environment")
+        sys.exit(1)
+
+    sts_client = boto3.client(
+        "sts",
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
 
     response = sts_client.assume_role(RoleArn=role_name, RoleSessionName=str(uuid.uuid4()), DurationSeconds=900)
 

--- a/common/testdata/lib/aws_e2e_assume_role.js
+++ b/common/testdata/lib/aws_e2e_assume_role.js
@@ -12,17 +12,12 @@ load("aws_e2e_lib.js");
   function getAssumeCredentials() {
     const config = readSetupJson();
 
-    const env = {
-      AWS_ACCESS_KEY_ID: config["iam_auth_assume_aws_account"],
-      AWS_SECRET_ACCESS_KEY: config["iam_auth_assume_aws_secret_access_key"],
-    };
-
     const role_name = config["iam_auth_assume_role_name"];
 
     const python_command = getPython3Binary() +
       ` -u aws_assume_role.py --role_name=${role_name} > creds.json`;
 
-    const ret = runShellCmdWithEnv(python_command, env);
+    const ret = runShellCmdWithEnv(python_command, {});
     assert.eq(ret, 0, "Failed to assume role on the current machine");
 
     const result = cat("creds.json");

--- a/common/testdata/lib/aws_e2e_assume_role.js
+++ b/common/testdata/lib/aws_e2e_assume_role.js
@@ -15,6 +15,7 @@ load("aws_e2e_lib.js");
     const env = {
       AWS_ACCESS_KEY_ID: config["iam_auth_assume_aws_account"],
       AWS_SECRET_ACCESS_KEY: config["iam_auth_assume_aws_secret_access_key"],
+      AWS_SESSION_TOKEN: "",
     };
 
     const role_name = config["iam_auth_assume_role_name"];

--- a/common/testdata/lib/aws_e2e_assume_role.js
+++ b/common/testdata/lib/aws_e2e_assume_role.js
@@ -15,7 +15,6 @@ load("aws_e2e_lib.js");
     const env = {
       AWS_ACCESS_KEY_ID: config["iam_auth_assume_aws_account"],
       AWS_SECRET_ACCESS_KEY: config["iam_auth_assume_aws_secret_access_key"],
-      AWS_SESSION_TOKEN: "",
     };
 
     const role_name = config["iam_auth_assume_role_name"];

--- a/common/testdata/lib/aws_e2e_assume_role.js
+++ b/common/testdata/lib/aws_e2e_assume_role.js
@@ -12,12 +12,17 @@ load("aws_e2e_lib.js");
   function getAssumeCredentials() {
     const config = readSetupJson();
 
+    const env = {
+      AWS_ACCESS_KEY_ID: config["iam_auth_assume_aws_account"],
+      AWS_SECRET_ACCESS_KEY: config["iam_auth_assume_aws_secret_access_key"],
+    };
+
     const role_name = config["iam_auth_assume_role_name"];
 
     const python_command = getPython3Binary() +
       ` -u aws_assume_role.py --role_name=${role_name} > creds.json`;
 
-    const ret = runShellCmdWithEnv(python_command, {});
+    const ret = runShellCmdWithEnv(python_command, env);
     assert.eq(ret, 0, "Failed to assume role on the current machine");
 
     const result = cat("creds.json");


### PR DESCRIPTION
## Summary

- Fixes `InvalidClientTokenId` failure in `aws-auth-*` tasks on Evergreen CI hosts with EC2 instance profiles (e.g. `rhel88-race`)
- Adds `AWS_SESSION_TOKEN: ""` to the env passed to the Python subprocess in `aws_e2e_assume_role.js`

## Root Cause

Evergreen CI EC2 runners have an IAM instance profile, which causes `AWS_SESSION_TOKEN` to be present in the environment. `_startMongoProgram` **merges** the provided `env` dict with the parent process environment rather than replacing it. As a result, the Python subprocess that calls `boto3`/STS inherited the EC2 instance's session token while having `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` overridden with the Evergreen IAM user's long-term credentials.

`boto3` then sent this mismatched pair (IAM user access key + EC2 instance session token) to `sts:AssumeRole`, and AWS rejected it with:

```
botocore.exceptions.ClientError: An error occurred (InvalidClientTokenId) when calling
the AssumeRole operation: The security token included in the request is invalid.
```

## Fix

Explicitly set `AWS_SESSION_TOKEN: ""` in the `env` object passed to `runShellCmdWithEnv` so any inherited session token is cleared before the Python subprocess starts. Long-term IAM user credentials don't require a session token, so this is correct behavior.

## Testing

The fix should be verified by re-running the `aws-auth-*` task on an EC2-backed variant (e.g. `rhel88-race`). The `InvalidClientTokenId` error should no longer occur.