### PR TITLE
timeseries tests: skip for now pending TOOLS-4228

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -321,12 +321,10 @@ func setupTimeseriesWithMixedSchema(t *testing.T, dbName string, collName string
 	bucketName := timeseriesCollName(serverVersion, collName)
 	bucketColl := sessionProvider.DB(dbName).Collection(bucketName)
 	bucketJSON := `{"_id":{"$oid":"65a6eb806ffc9fa4280ecac4"},"control":{"version":1,"min":{"_id":{"$oid":"65a6eba7e6d2e848e08c3750"},"t":{"$date":"2024-01-16T20:48:00Z"},"a":1},"max":{"_id":{"$oid":"65a6eba7e6d2e848e08c3751"},"t":{"$date":"2024-01-16T20:48:39.448Z"},"a":"a"}},"meta":0,"data":{"_id":{"0":{"$oid":"65a6eba7e6d2e848e08c3750"},"1":{"$oid":"65a6eba7e6d2e848e08c3751"}},"t":{"0":{"$date":"2024-01-16T20:48:39.448Z"},"1":{"$date":"2024-01-16T20:48:39.448Z"}},"a":{"0":"a","1":1}}}`
-	var bucketMap map[string]any
-	err = json.Unmarshal([]byte(bucketJSON), &bucketMap)
-	require.NoError(t, err, "unmarshal json")
 
-	err = bsonutil.ConvertLegacyExtJSONDocumentToBSON(bucketMap)
-	require.NoError(t, err, "convert extjson to bson")
+	var bucketDoc bson.D
+	err = bson.UnmarshalExtJSON([]byte(bucketJSON), false, &bucketDoc)
+	require.NoError(t, err, "unmarshal ext json")
 
 	opts := mopt.InsertOne()
 	if serverVersion.SupportsRawData() {
@@ -334,7 +332,7 @@ func setupTimeseriesWithMixedSchema(t *testing.T, dbName string, collName string
 		require.NoError(t, err)
 	}
 
-	_, err = bucketColl.InsertOne(t.Context(), bucketMap, opts)
+	_, err = bucketColl.InsertOne(t.Context(), bucketDoc, opts)
 	require.NoError(t, err, "insert bucket doc")
 }
 

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1890,6 +1890,8 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 		t.Skip("Requires server with FCV 5.0 or later")
 	}
 
+	t.Skip("TODO (TOOLS-4228): these tests broken by recent server CVE fixes")
+
 	testdb := session.Database(dbName)
 	dataColl := testdb.Collection("foo_ts")
 	bucketsColl := testdb.Collection(common.TimeseriesBucketPrefix + "foo_ts")


### PR DESCRIPTION
Recent CVE fixes in the server have broken these tests; it's not clear if the server needs to fix these or we do, but they're just causing noise in the meantime.

Also: unbreak a different timeseries test that was broken by the same strict validation. We were unmarshaling a JSON blob into a map and then inserting it, but doing so can affect the order, which stricter validation rejected.