### PR TITLE
TOOLS-7512 Upgrade to Go 1.26.4

### DIFF
--- a/SARIF.json
+++ b/SARIF.json
@@ -1,7 +1,72 @@
 {
 	"runs": [
 		{
-			"results": [],
+			"results": [
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "bindata.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 41,
+									"snippet": {
+										"text": "arg0 := byte(args[0].Uint())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 41
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint64 -\u003e byte"
+					},
+					"ruleId": "G115",
+					"suppressions": [
+						{
+							"justification": "args[0] was constructed with reflect type byteType, so\nits Kind is always Uint8 and Uint() can only return a byte-range value.",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "bsondump.go"
+								},
+								"region": {
+									"endColumn": 64,
+									"endLine": 245,
+									"snippet": {
+										"text": "fmt.Fprintf(out, \"%v\\t\\t\\ttype: %4d size: %v\\n\", indent, int8(value.Type), len(rawElem))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 64,
+									"startLine": 245
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion byte -\u003e int8"
+					},
+					"ruleId": "G115",
+					"suppressions": [
+						{
+							"justification": "the bson.Type type always fits in an int8",
+							"kind": "inSource"
+						}
+					]
+				}
+			],
 			"taxonomies": [
 				{
 					"downloadUri": "https://cwe.mitre.org/data/xml/cwec_v4.4.xml.zip",
@@ -16,6 +81,19 @@
 					"shortDescription": {
 						"text": "The MITRE Common Weakness Enumeration"
 					},
+					"taxa": [
+						{
+							"fullDescription": {
+								"text": "The software performs a calculation that can produce an integer overflow or wraparound, when the logic assumes that the resulting value will always be larger than the original value. This can introduce other weaknesses when the calculation is used for resource management or execution control."
+							},
+							"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+							"helpUri": "https://cwe.mitre.org/data/definitions/190.html",
+							"id": "190",
+							"shortDescription": {
+								"text": "Integer Overflow or Wraparound"
+							}
+						}
+					],
 					"version": "4.4"
 				}
 			],
@@ -24,14 +102,54 @@
 					"guid": "8b518d5f-906d-39f9-894b-d327b1a421c5",
 					"informationUri": "https://github.com/securego/gosec/",
 					"name": "gosec",
-					"semanticVersion": "2.22.10",
+					"rules": [
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "integer overflow conversion uint64 -\u003e byte"
+							},
+							"help": {
+								"text": "integer overflow conversion uint64 -\u003e byte\nSeverity: HIGH\nConfidence: MEDIUM\n"
+							},
+							"id": "G115",
+							"name": "Integer Overflow or Wraparound",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+										"id": "190",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "integer overflow conversion uint64 -\u003e byte"
+							}
+						}
+					],
+					"semanticVersion": "2.27.1",
 					"supportedTaxonomies": [
 						{
 							"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
 							"name": "CWE"
 						}
 					],
-					"version": "2.22.10"
+					"version": "2.27.1"
 				}
 			}
 		}

--- a/bsondump/bsondump.go
+++ b/bsondump/bsondump.go
@@ -240,7 +240,9 @@ func printBSON(raw bson.Raw, indentLevel int, out io.Writer) error {
 		// 3. The BSON value
 		// So size == 1 [size of type byte] +  1 [null byte for cstring key] + len(bson key) + len(bson value)
 		// see http://bsonspec.org/spec.html for more details
-		fmt.Fprintf(out, "%v\t\t\ttype: %4v size: %v\n", indent, int8(value.Type), len(rawElem))
+		//
+		// #nosec #G115 -- the bson.Type type always fits in an int8
+		fmt.Fprintf(out, "%v\t\t\ttype: %4d size: %v\n", indent, int8(value.Type), len(rawElem))
 
 		//For nested objects or arrays, recurse.
 		if value.Type == bson.TypeEmbeddedDocument || value.Type == bson.TypeArray {

--- a/common/json/bindata.go
+++ b/common/json/bindata.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateBi is the state after reading `Bi`.
-func stateBi(s *scanner, c int) int {
+func stateBi(s *scanner, c byte) int {
 	if c == 'n' {
 		s.step = generateState("BinData", []byte("Data"), stateConstructor)
 		return scanContinue
@@ -36,6 +36,8 @@ func (d *decodeState) storeBinData(v reflect.Value) {
 	}
 	switch kind := v.Kind(); kind {
 	case reflect.Interface:
+		// #nosec G115 -- args[0] was constructed with reflect type byteType, so
+		// its Kind is always Uint8 and Uint() can only return a byte-range value.
 		arg0 := byte(args[0].Uint())
 		arg1 := args[1].String()
 		v.Set(reflect.ValueOf(BinData{arg0, arg1}))

--- a/common/json/boolean.go
+++ b/common/json/boolean.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateBo is the state after reading `Bo`.
-func stateBo(s *scanner, c int) int {
+func stateBo(s *scanner, c byte) int {
 	if c == 'o' {
 		s.step = generateState("Boolean", []byte("lean"), stateConstructor)
 		return scanContinue

--- a/common/json/constructor.go
+++ b/common/json/constructor.go
@@ -17,7 +17,7 @@ const CtorNumArgsErrorf = "expected %v argument%v to %v constructor, but %v rece
 // Adapted from encoding/json/scanner.go.
 
 // stateConstructor is the state after reading a constructor name.
-func stateConstructor(s *scanner, c int) int {
+func stateConstructor(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -30,7 +30,7 @@ func stateConstructor(s *scanner, c int) int {
 }
 
 // stateBeginCtorOrEmpty is the state after reading `(`.
-func stateBeginCtorOrEmpty(s *scanner, c int) int {
+func stateBeginCtorOrEmpty(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}

--- a/common/json/date.go
+++ b/common/json/date.go
@@ -17,7 +17,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateDa is the state after reading `Da`.
-func stateDa(s *scanner, c int) int {
+func stateDa(s *scanner, c byte) int {
 	if c == 't' {
 		s.step = stateDat
 		return scanContinue
@@ -26,7 +26,7 @@ func stateDa(s *scanner, c int) int {
 }
 
 // stateDat is the state after reading `Dat`.
-func stateDat(s *scanner, c int) int {
+func stateDat(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = stateConstructor
 		return scanContinue

--- a/common/json/dbpointer.go
+++ b/common/json/dbpointer.go
@@ -17,7 +17,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateDB is the state after reading `DB`.
-func stateDBP(s *scanner, c int) int {
+func stateDBP(s *scanner, c byte) int {
 	if c == 'o' {
 		s.step = generateState("DBPointer", []byte("inter"), stateConstructor)
 		return scanContinue

--- a/common/json/dbref.go
+++ b/common/json/dbref.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateDB is the state after reading `DB`.
-func stateDBR(s *scanner, c int) int {
+func stateDBR(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = generateState("DBRef", []byte("f"), stateConstructor)
 		return scanContinue
@@ -24,7 +24,7 @@ func stateDBR(s *scanner, c int) int {
 }
 
 // stateDb is the state after reading `Db`.
-func stateDb(s *scanner, c int) int {
+func stateDb(s *scanner, c byte) int {
 	if c == 'r' {
 		s.step = generateState("Dbref", []byte("ef"), stateConstructor)
 		return scanContinue

--- a/common/json/decode.go
+++ b/common/json/decode.go
@@ -341,7 +341,7 @@ func (d *decodeState) scanWhile(op int) int {
 			newOp = d.scan.eof()
 			d.off = len(d.data) + 1 // mark processed EOF with len+1
 		} else {
-			c := int(d.data[d.off])
+			c := d.data[d.off]
 			d.off++
 			newOp = d.scan.step(&d.scan, c)
 		}
@@ -1199,7 +1199,7 @@ func getu4(s []byte) rune {
 	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
 		return -1
 	}
-	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 16)
 	if err != nil {
 		return -1
 	}

--- a/common/json/helpers.go
+++ b/common/json/helpers.go
@@ -42,13 +42,17 @@ func isHexPrefix(s string) bool {
 // Otherwise returns a function that upon matching the first element
 // of x will generate another function to match the second, etc.
 // (or accept if no remaining elements).
-func generateState(name string, x []byte, accept func(*scanner, int) int) func(*scanner, int) int {
+func generateState(
+	name string,
+	x []byte,
+	accept func(*scanner, byte) int,
+) func(*scanner, byte) int {
 	if len(x) == 0 {
 		return accept
 	}
 
-	return func(s *scanner, c int) int {
-		if c == int(x[0]) {
+	return func(s *scanner, c byte) int {
+		if c == x[0] {
 			s.step = generateState(name, x[1:], accept)
 			return scanContinue
 		}
@@ -57,7 +61,7 @@ func generateState(name string, x []byte, accept func(*scanner, int) int) func(*
 }
 
 // stateOptionalConstructor is the state where there is the possibility of entering an empty constructor.
-func stateOptionalConstructor(s *scanner, c int) int {
+func stateOptionalConstructor(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanContinue
 	}
@@ -69,7 +73,7 @@ func stateOptionalConstructor(s *scanner, c int) int {
 }
 
 // stateInParen is the state when inside a `(` waiting for a `)`.
-func stateInParen(s *scanner, c int) int {
+func stateInParen(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanContinue
 	}

--- a/common/json/hex.go
+++ b/common/json/hex.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateHex is the state after reading `0x` or `0X`.
-func stateHex(s *scanner, c int) int {
+func stateHex(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateHex
 		return scanContinue

--- a/common/json/indent.go
+++ b/common/json/indent.go
@@ -41,7 +41,7 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 			dst.WriteByte(hex[src[i+2]&0xF])
 			start = i + 3
 		}
-		v := scan.step(&scan, int(c))
+		v := scan.step(&scan, c)
 		if v >= scanSkipSpace {
 			if v == scanError {
 				break
@@ -85,7 +85,7 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 	depth := 0
 	for _, c := range src {
 		scan.bytes++
-		v := scan.step(&scan, int(c))
+		v := scan.step(&scan, c)
 		if v == scanSkipSpace {
 			continue
 		}

--- a/common/json/infinity.go
+++ b/common/json/infinity.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateI is the state after reading `In`.
-func stateIn(s *scanner, c int) int {
+func stateIn(s *scanner, c byte) int {
 	if c == 'f' {
 		s.step = generateState("Infinity", []byte("inity"), stateEndValue)
 		return scanContinue

--- a/common/json/iso_date.go
+++ b/common/json/iso_date.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateIS is the state after reading `IS`.
-func stateIS(s *scanner, c int) int {
+func stateIS(s *scanner, c byte) int {
 	if c == 'O' {
 		s.step = stateISO
 		return scanContinue
@@ -24,7 +24,7 @@ func stateIS(s *scanner, c int) int {
 }
 
 // stateISO is the state after reading `ISO`.
-func stateISO(s *scanner, c int) int {
+func stateISO(s *scanner, c byte) int {
 	if c == 'D' {
 		s.step = stateD
 		return scanContinue

--- a/common/json/maxkey.go
+++ b/common/json/maxkey.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateUpperMa is the state after reading `Ma`.
-func stateUpperMa(s *scanner, c int) int {
+func stateUpperMa(s *scanner, c byte) int {
 	if c == 'x' {
 		s.step = generateState("MaxKey", []byte("Key"), stateOptionalConstructor)
 		return scanContinue

--- a/common/json/minkey.go
+++ b/common/json/minkey.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateUpperMi is the state after reading `Mi`.
-func stateUpperMi(s *scanner, c int) int {
+func stateUpperMi(s *scanner, c byte) int {
 	if c == 'n' {
 		s.step = generateState("MinKey", []byte("Key"), stateOptionalConstructor)
 		return scanContinue

--- a/common/json/mongo_extjson.go
+++ b/common/json/mongo_extjson.go
@@ -108,7 +108,7 @@ func (d Date) isFormatable() bool {
 	return int64(d) < int64(32535215999000)
 }
 
-func stateBeginExtendedValue(s *scanner, c int) int {
+func stateBeginExtendedValue(s *scanner, c byte) int {
 	switch c {
 	case 'u': // beginning of undefined
 		s.step = stateU
@@ -138,7 +138,7 @@ func stateBeginExtendedValue(s *scanner, c int) int {
 }
 
 // stateB is the state after reading `B`.
-func stateB(s *scanner, c int) int {
+func stateB(s *scanner, c byte) int {
 	if c == 'i' {
 		s.step = stateBi
 		return scanContinue
@@ -151,7 +151,7 @@ func stateB(s *scanner, c int) int {
 }
 
 // stateUpperN is the state after reading `N`.
-func stateUpperN(s *scanner, c int) int {
+func stateUpperN(s *scanner, c byte) int {
 	if c == 'a' {
 		s.step = stateUpperNa
 		return scanContinue
@@ -164,7 +164,7 @@ func stateUpperN(s *scanner, c int) int {
 }
 
 // stateM is the state after reading `M`.
-func stateM(s *scanner, c int) int {
+func stateM(s *scanner, c byte) int {
 	if c == 'a' {
 		s.step = stateUpperMa
 		return scanContinue
@@ -177,7 +177,7 @@ func stateM(s *scanner, c int) int {
 }
 
 // stateD is the state after reading `D`.
-func stateD(s *scanner, c int) int {
+func stateD(s *scanner, c byte) int {
 	switch c {
 	case 'a':
 		s.step = stateDa
@@ -192,7 +192,7 @@ func stateD(s *scanner, c int) int {
 }
 
 // stateDB is the state after reading `DB`.
-func stateDB(s *scanner, c int) int {
+func stateDB(s *scanner, c byte) int {
 	if c == 'R' {
 		s.step = stateDBR
 		return scanContinue
@@ -205,7 +205,7 @@ func stateDB(s *scanner, c int) int {
 }
 
 // stateI is the state after reading `I`.
-func stateI(s *scanner, c int) int {
+func stateI(s *scanner, c byte) int {
 	switch c {
 	case 'n':
 		s.step = stateIn

--- a/common/json/nan.go
+++ b/common/json/nan.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateUpperNa is the state after reading `Na`.
-func stateUpperNa(s *scanner, c int) int {
+func stateUpperNa(s *scanner, c byte) int {
 	if c == 'N' {
 		s.step = stateEndValue
 		return scanContinue

--- a/common/json/new.go
+++ b/common/json/new.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateNe is the state after reading `ne`.
-func stateNe(s *scanner, c int) int {
+func stateNe(s *scanner, c byte) int {
 	if c == 'w' {
 		s.step = stateNew
 		return scanContinue
@@ -25,7 +25,7 @@ func stateNe(s *scanner, c int) int {
 
 // stateNew is the state after reading `new`.
 // Ensures that there is a space after the new keyword.
-func stateNew(s *scanner, c int) int {
+func stateNew(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		s.step = stateBeginObjectValue
 		return scanContinue
@@ -34,7 +34,7 @@ func stateNew(s *scanner, c int) int {
 }
 
 // stateBeginObjectValue is the state after reading `new`.
-func stateBeginObjectValue(s *scanner, c int) int {
+func stateBeginObjectValue(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -59,7 +59,7 @@ func stateBeginObjectValue(s *scanner, c int) int {
 }
 
 // stateNumberUpperN is the state after reading `N`.
-func stateNumberUpperN(s *scanner, c int) int {
+func stateNumberUpperN(s *scanner, c byte) int {
 	if c == 'u' {
 		s.step = stateUpperNu
 		return scanContinue

--- a/common/json/number.go
+++ b/common/json/number.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateUpperNu is the state after reading `Nu`.
-func stateUpperNu(s *scanner, c int) int {
+func stateUpperNu(s *scanner, c byte) int {
 	if c == 'm' {
 		s.step = generateState("Number", []byte("ber"), stateUpperNumber)
 		return scanContinue
@@ -24,7 +24,7 @@ func stateUpperNu(s *scanner, c int) int {
 }
 
 // stateUpperNumber is the state after reading `Number`.
-func stateUpperNumber(s *scanner, c int) int {
+func stateUpperNumber(s *scanner, c byte) int {
 	if c == 'I' {
 		s.step = generateState("NumberInt", []byte("nt"), stateConstructor)
 		return scanContinue

--- a/common/json/objectid.go
+++ b/common/json/objectid.go
@@ -15,7 +15,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateO is the state after reading `O`.
-func stateO(s *scanner, c int) int {
+func stateO(s *scanner, c byte) int {
 	if c == 'b' {
 		s.step = generateState("ObjectId", []byte("jectId"), stateConstructor)
 		return scanContinue

--- a/common/json/regexp.go
+++ b/common/json/regexp.go
@@ -18,7 +18,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateR is the state after reading `R`.
-func stateR(s *scanner, c int) int {
+func stateR(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = generateState("RegExp", []byte("gExp"), stateConstructor)
 		return scanContinue
@@ -27,7 +27,7 @@ func stateR(s *scanner, c int) int {
 }
 
 // stateInRegexpPattern is the state after reading `/`.
-func stateInRegexpPattern(s *scanner, c int) int {
+func stateInRegexpPattern(s *scanner, c byte) int {
 	if c == '/' {
 		s.step = stateInRegexpOptions
 		return scanRegexpOptions
@@ -43,7 +43,7 @@ func stateInRegexpPattern(s *scanner, c int) int {
 }
 
 // stateInRegexpPatternEsc is the state after reading `'\` during a regex pattern.
-func stateInRegexpPatternEsc(s *scanner, c int) int {
+func stateInRegexpPatternEsc(s *scanner, c byte) int {
 	switch c {
 	case 'b', 'f', 'n', 'r', 't', '\\', '/', '\'':
 		s.step = stateInRegexpPattern
@@ -57,7 +57,7 @@ func stateInRegexpPatternEsc(s *scanner, c int) int {
 }
 
 // stateInRegexpPatternEscU is the state after reading `'\u` during a regex pattern.
-func stateInRegexpPatternEscU(s *scanner, c int) int {
+func stateInRegexpPatternEscU(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInRegexpPatternEscU1
 		return scanRegexpPattern
@@ -67,7 +67,7 @@ func stateInRegexpPatternEscU(s *scanner, c int) int {
 }
 
 // stateInRegexpPatternEscU1 is the state after reading `'\u1` during a regex pattern.
-func stateInRegexpPatternEscU1(s *scanner, c int) int {
+func stateInRegexpPatternEscU1(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInRegexpPatternEscU12
 		return scanRegexpPattern
@@ -77,7 +77,7 @@ func stateInRegexpPatternEscU1(s *scanner, c int) int {
 }
 
 // stateInRegexpPatternEscU12 is the state after reading `'\u12` during a regex pattern.
-func stateInRegexpPatternEscU12(s *scanner, c int) int {
+func stateInRegexpPatternEscU12(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInRegexpPatternEscU123
 		return scanRegexpPattern
@@ -87,7 +87,7 @@ func stateInRegexpPatternEscU12(s *scanner, c int) int {
 }
 
 // stateInRegexpPatternEscU123 is the state after reading `'\u123` during a regex pattern.
-func stateInRegexpPatternEscU123(s *scanner, c int) int {
+func stateInRegexpPatternEscU123(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInRegexpPattern
 		return scanRegexpPattern
@@ -97,7 +97,7 @@ func stateInRegexpPatternEscU123(s *scanner, c int) int {
 }
 
 // stateInRegexpOptions is the state after reading `/foo/`.
-func stateInRegexpOptions(s *scanner, c int) int {
+func stateInRegexpOptions(s *scanner, c byte) int {
 	switch c {
 	case 'g', 'i', 'm', 's':
 		return scanRegexpOptions

--- a/common/json/scanner.go
+++ b/common/json/scanner.go
@@ -26,7 +26,7 @@ func checkValid(data []byte, scan *scanner) error {
 	scan.reset()
 	for _, c := range data {
 		scan.bytes++
-		if scan.step(scan, int(c)) == scanError {
+		if scan.step(scan, c) == scanError {
 			return scan.err
 		}
 	}
@@ -42,7 +42,7 @@ func checkValid(data []byte, scan *scanner) error {
 func nextValue(data []byte, scan *scanner) (value, rest []byte, err error) {
 	scan.reset()
 	for i, c := range data {
-		v := scan.step(scan, int(c))
+		v := scan.step(scan, c)
 		if v >= scanEnd {
 			switch v {
 			case scanError:
@@ -83,7 +83,7 @@ type scanner struct {
 	// Also tried using an integer constant and a single func
 	// with a switch, but using the func directly was 10% faster
 	// on a 64-bit Mac Mini, and it's nicer to read.
-	step func(*scanner, int) int
+	step func(*scanner, byte) int
 
 	// Reached end of top-level value.
 	endTop bool
@@ -97,7 +97,7 @@ type scanner struct {
 	// 1-byte redo (see undo method)
 	redo      bool
 	redoCode  int
-	redoState func(*scanner, int) int
+	redoState func(*scanner, byte) int
 
 	// total bytes consumed, updated by decoder.Decode
 	bytes int64
@@ -197,7 +197,7 @@ func isSpace(c rune) bool {
 }
 
 // stateBeginValueOrEmpty is the state after reading `[`.
-func stateBeginValueOrEmpty(s *scanner, c int) int {
+func stateBeginValueOrEmpty(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -208,7 +208,7 @@ func stateBeginValueOrEmpty(s *scanner, c int) int {
 }
 
 // stateBeginValue is the state at the beginning of the input.
-func stateBeginValue(s *scanner, c int) int {
+func stateBeginValue(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -254,7 +254,7 @@ func stateBeginValue(s *scanner, c int) int {
 }
 
 // stateBeginStringOrEmpty is the state after reading `{`.
-func stateBeginStringOrEmpty(s *scanner, c int) int {
+func stateBeginStringOrEmpty(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -267,7 +267,7 @@ func stateBeginStringOrEmpty(s *scanner, c int) int {
 }
 
 // stateBeginString is the state after reading `{"key": value,`.
-func stateBeginString(s *scanner, c int) int {
+func stateBeginString(s *scanner, c byte) int {
 	if c <= ' ' && isSpace(rune(c)) {
 		return scanSkipSpace
 	}
@@ -288,7 +288,7 @@ func stateBeginString(s *scanner, c int) int {
 
 // stateEndValue is the state after completing a value,
 // such as after reading `{}` or `true` or `["x"`.
-func stateEndValue(s *scanner, c int) int {
+func stateEndValue(s *scanner, c byte) int {
 	n := len(s.parseState)
 	if n == 0 {
 		// Completed top-level before the current byte.
@@ -347,7 +347,7 @@ func stateEndValue(s *scanner, c int) int {
 // stateEndTop is the state after finishing the top-level value,
 // such as after reading `{}` or `[1,2,3]`.
 // Only space characters should be seen now.
-func stateEndTop(s *scanner, c int) int {
+func stateEndTop(s *scanner, c byte) int {
 	if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
 		// Complain about non-space byte on next call.
 		s.error(c, "after top-level value")
@@ -356,7 +356,7 @@ func stateEndTop(s *scanner, c int) int {
 }
 
 // stateInString is the state after reading `"`.
-func stateInString(s *scanner, c int) int {
+func stateInString(s *scanner, c byte) int {
 	if c == '"' {
 		s.step = stateEndValue
 		return scanContinue
@@ -372,7 +372,7 @@ func stateInString(s *scanner, c int) int {
 }
 
 // stateInStringEsc is the state after reading `"\` during a quoted string.
-func stateInStringEsc(s *scanner, c int) int {
+func stateInStringEsc(s *scanner, c byte) int {
 	switch c {
 	case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
 		s.step = stateInString
@@ -386,7 +386,7 @@ func stateInStringEsc(s *scanner, c int) int {
 }
 
 // stateInStringEscU is the state after reading `"\u` during a quoted string.
-func stateInStringEscU(s *scanner, c int) int {
+func stateInStringEscU(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInStringEscU1
 		return scanContinue
@@ -396,7 +396,7 @@ func stateInStringEscU(s *scanner, c int) int {
 }
 
 // stateInStringEscU1 is the state after reading `"\u1` during a quoted string.
-func stateInStringEscU1(s *scanner, c int) int {
+func stateInStringEscU1(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInStringEscU12
 		return scanContinue
@@ -406,7 +406,7 @@ func stateInStringEscU1(s *scanner, c int) int {
 }
 
 // stateInStringEscU12 is the state after reading `"\u12` during a quoted string.
-func stateInStringEscU12(s *scanner, c int) int {
+func stateInStringEscU12(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInStringEscU123
 		return scanContinue
@@ -416,7 +416,7 @@ func stateInStringEscU12(s *scanner, c int) int {
 }
 
 // stateInStringEscU123 is the state after reading `"\u123` during a quoted string.
-func stateInStringEscU123(s *scanner, c int) int {
+func stateInStringEscU123(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInString
 		return scanContinue
@@ -426,7 +426,7 @@ func stateInStringEscU123(s *scanner, c int) int {
 }
 
 // stateSign is the state after reading `+` or `-` during a number.
-func stateSign(s *scanner, c int) int {
+func stateSign(s *scanner, c byte) int {
 	if c == '0' {
 		s.step = state0
 		return scanContinue
@@ -448,7 +448,7 @@ func stateSign(s *scanner, c int) int {
 
 // state1 is the state after reading a non-zero integer during a number,
 // such as after reading `1` or `100` but not `0`.
-func state1(s *scanner, c int) int {
+func state1(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' {
 		s.step = state1
 		return scanContinue
@@ -457,7 +457,7 @@ func state1(s *scanner, c int) int {
 }
 
 // state0 is the state after reading `0` during a number.
-func state0(s *scanner, c int) int {
+func state0(s *scanner, c byte) int {
 	if c == '.' {
 		s.step = stateDot
 		return scanContinue
@@ -475,7 +475,7 @@ func state0(s *scanner, c int) int {
 
 // stateDot is the state after reading the integer and decimal point in a number,
 // such as after reading `1.`.
-func stateDot(s *scanner, c int) int {
+func stateDot(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' {
 		s.step = stateDot0
 		return scanContinue
@@ -485,7 +485,7 @@ func stateDot(s *scanner, c int) int {
 
 // stateDot0 is the state after reading the integer, decimal point, and subsequent
 // digits of a number, such as after reading `3.14`.
-func stateDot0(s *scanner, c int) int {
+func stateDot0(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' {
 		s.step = stateDot0
 		return scanContinue
@@ -499,7 +499,7 @@ func stateDot0(s *scanner, c int) int {
 
 // stateE is the state after reading the mantissa and e in a number,
 // such as after reading `314e` or `0.314e`.
-func stateE(s *scanner, c int) int {
+func stateE(s *scanner, c byte) int {
 	if c == '+' {
 		s.step = stateESign
 		return scanContinue
@@ -513,7 +513,7 @@ func stateE(s *scanner, c int) int {
 
 // stateESign is the state after reading the mantissa, e, and sign in a number,
 // such as after reading `314e-` or `0.314e+`.
-func stateESign(s *scanner, c int) int {
+func stateESign(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' {
 		s.step = stateE0
 		return scanContinue
@@ -524,7 +524,7 @@ func stateESign(s *scanner, c int) int {
 // stateE0 is the state after reading the mantissa, e, optional sign,
 // and at least one digit of the exponent in a number,
 // such as after reading `314e-2` or `0.314e+1` or `3.14e0`.
-func stateE0(s *scanner, c int) int {
+func stateE0(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' {
 		s.step = stateE0
 		return scanContinue
@@ -533,7 +533,7 @@ func stateE0(s *scanner, c int) int {
 }
 
 // stateT is the state after reading `t`.
-func stateT(s *scanner, c int) int {
+func stateT(s *scanner, c byte) int {
 	if c == 'r' {
 		s.step = stateTr
 		return scanContinue
@@ -542,7 +542,7 @@ func stateT(s *scanner, c int) int {
 }
 
 // stateTr is the state after reading `tr`.
-func stateTr(s *scanner, c int) int {
+func stateTr(s *scanner, c byte) int {
 	if c == 'u' {
 		s.step = stateTru
 		return scanContinue
@@ -551,7 +551,7 @@ func stateTr(s *scanner, c int) int {
 }
 
 // stateTru is the state after reading `tru`.
-func stateTru(s *scanner, c int) int {
+func stateTru(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = stateEndValue
 		return scanContinue
@@ -560,7 +560,7 @@ func stateTru(s *scanner, c int) int {
 }
 
 // stateF is the state after reading `f`.
-func stateF(s *scanner, c int) int {
+func stateF(s *scanner, c byte) int {
 	if c == 'a' {
 		s.step = stateFa
 		return scanContinue
@@ -569,7 +569,7 @@ func stateF(s *scanner, c int) int {
 }
 
 // stateFa is the state after reading `fa`.
-func stateFa(s *scanner, c int) int {
+func stateFa(s *scanner, c byte) int {
 	if c == 'l' {
 		s.step = stateFal
 		return scanContinue
@@ -578,7 +578,7 @@ func stateFa(s *scanner, c int) int {
 }
 
 // stateFal is the state after reading `fal`.
-func stateFal(s *scanner, c int) int {
+func stateFal(s *scanner, c byte) int {
 	if c == 's' {
 		s.step = stateFals
 		return scanContinue
@@ -587,7 +587,7 @@ func stateFal(s *scanner, c int) int {
 }
 
 // stateFals is the state after reading `fals`.
-func stateFals(s *scanner, c int) int {
+func stateFals(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = stateEndValue
 		return scanContinue
@@ -596,7 +596,7 @@ func stateFals(s *scanner, c int) int {
 }
 
 // stateN is the state after reading `n`.
-func stateN(s *scanner, c int) int {
+func stateN(s *scanner, c byte) int {
 	if c == 'e' {
 		s.step = stateNe
 		return scanContinue
@@ -609,7 +609,7 @@ func stateN(s *scanner, c int) int {
 }
 
 // stateNu is the state after reading `nu`.
-func stateNu(s *scanner, c int) int {
+func stateNu(s *scanner, c byte) int {
 	if c == 'l' {
 		s.step = stateNul
 		return scanContinue
@@ -618,7 +618,7 @@ func stateNu(s *scanner, c int) int {
 }
 
 // stateNul is the state after reading `nul`.
-func stateNul(s *scanner, c int) int {
+func stateNul(s *scanner, c byte) int {
 	if c == 'l' {
 		s.step = stateEndValue
 		return scanContinue
@@ -628,19 +628,19 @@ func stateNul(s *scanner, c int) int {
 
 // stateError is the state after reaching a syntax error,
 // such as after reading `[1}` or `5.1.2`.
-func stateError(s *scanner, c int) int {
+func stateError(s *scanner, c byte) int {
 	return scanError
 }
 
 // error records an error and switches to the error state.
-func (s *scanner) error(c int, context string) int {
+func (s *scanner) error(c byte, context string) int {
 	s.step = stateError
 	s.err = &SyntaxError{"invalid character " + quoteChar(c) + " " + context, s.bytes}
 	return scanError
 }
 
 // quoteChar formats c as a quoted character literal.
-func quoteChar(c int) string {
+func quoteChar(c byte) string {
 	// special cases - different from quoted strings
 	if c == '\'' {
 		return `'\''`
@@ -667,7 +667,7 @@ func (s *scanner) undo(scanCode int) {
 }
 
 // stateRedo helps implement the scanner's 1-byte undo.
-func stateRedo(s *scanner, c int) int {
+func stateRedo(s *scanner, c byte) int {
 	s.redo = false
 	s.step = s.redoState
 	return s.redoCode

--- a/common/json/single_quoted.go
+++ b/common/json/single_quoted.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateInSingleQuotedString is the state after reading `'`.
-func stateInSingleQuotedString(s *scanner, c int) int {
+func stateInSingleQuotedString(s *scanner, c byte) int {
 	if c == '\'' {
 		s.step = stateEndValue
 		return scanContinue
@@ -26,7 +26,7 @@ func stateInSingleQuotedString(s *scanner, c int) int {
 }
 
 // stateInSingleQuotedStringEsc is the state after reading `'\` during a quoted string.
-func stateInSingleQuotedStringEsc(s *scanner, c int) int {
+func stateInSingleQuotedStringEsc(s *scanner, c byte) int {
 	switch c {
 	case 'b', 'f', 'n', 'r', 't', '\\', '/', '\'':
 		s.step = stateInSingleQuotedString
@@ -40,7 +40,7 @@ func stateInSingleQuotedStringEsc(s *scanner, c int) int {
 }
 
 // stateInSingleQuotedStringEscU is the state after reading `'\u` during a quoted string.
-func stateInSingleQuotedStringEscU(s *scanner, c int) int {
+func stateInSingleQuotedStringEscU(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInSingleQuotedStringEscU1
 		return scanContinue
@@ -50,7 +50,7 @@ func stateInSingleQuotedStringEscU(s *scanner, c int) int {
 }
 
 // stateInSingleQuotedStringEscU1 is the state after reading `'\u1` during a quoted string.
-func stateInSingleQuotedStringEscU1(s *scanner, c int) int {
+func stateInSingleQuotedStringEscU1(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInSingleQuotedStringEscU12
 		return scanContinue
@@ -60,7 +60,7 @@ func stateInSingleQuotedStringEscU1(s *scanner, c int) int {
 }
 
 // stateInSingleQuotedStringEscU12 is the state after reading `'\u12` during a quoted string.
-func stateInSingleQuotedStringEscU12(s *scanner, c int) int {
+func stateInSingleQuotedStringEscU12(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInSingleQuotedStringEscU123
 		return scanContinue
@@ -70,7 +70,7 @@ func stateInSingleQuotedStringEscU12(s *scanner, c int) int {
 }
 
 // stateInSingleQuotedStringEscU123 is the state after reading `'\u123` during a quoted string.
-func stateInSingleQuotedStringEscU123(s *scanner, c int) int {
+func stateInSingleQuotedStringEscU123(s *scanner, c byte) int {
 	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
 		s.step = stateInSingleQuotedString
 		return scanContinue

--- a/common/json/stream.go
+++ b/common/json/stream.go
@@ -124,7 +124,7 @@ Input:
 		// Look in the buffer for a new value.
 		for i, c := range dec.Buf[scanp:] {
 			dec.scan.bytes++
-			v := dec.scan.step(&dec.scan, int(c))
+			v := dec.scan.step(&dec.scan, c)
 			if v == scanEnd {
 				scanp += i
 				break Input

--- a/common/json/timestamp.go
+++ b/common/json/timestamp.go
@@ -17,7 +17,7 @@ import (
 // Adapted from encoding/json/scanner.go.
 
 // stateUpperT is the state after reading `T`.
-func stateUpperT(s *scanner, c int) int {
+func stateUpperT(s *scanner, c byte) int {
 	if c == 'i' {
 		s.step = generateState("Timestamp", []byte("mestamp"), stateConstructor)
 		return scanContinue

--- a/common/json/undefined.go
+++ b/common/json/undefined.go
@@ -10,7 +10,7 @@ package json
 // Adapted from encoding/json/scanner.go.
 
 // stateU is the state after reading `u`.
-func stateU(s *scanner, c int) int {
+func stateU(s *scanner, c byte) int {
 	if c == 'n' {
 		s.step = generateState("undefined", []byte("defined"), stateEndValue)
 		return scanContinue

--- a/common/json/unquoted.go
+++ b/common/json/unquoted.go
@@ -9,15 +9,15 @@ package json
 // Transition function for recognizing unquoted strings.
 // Adapted from encoding/json/scanner.go.
 
-func isBeginUnquotedString(c int) bool {
+func isBeginUnquotedString(c byte) bool {
 	return c == '$' || c == '_' || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z'
 }
 
-func isInUnquotedString(c int) bool {
+func isInUnquotedString(c byte) bool {
 	return isBeginUnquotedString(c) || '0' <= c && c <= '9'
 }
 
-func stateInUnquotedString(s *scanner, c int) int {
+func stateInUnquotedString(s *scanner, c byte) int {
 	if isInUnquotedString(c) {
 		return scanContinue
 	}

--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -750,17 +750,17 @@
       "version": "v2.4.0"
     },
     {
-      "bom-ref": "pkg:golang/std@go1.25.11",
+      "bom-ref": "pkg:golang/std@go1.26.4",
       "externalReferences": [
         {
           "type": "website",
-          "url": "https://pkg.go.dev/None/std@go1.25.11"
+          "url": "https://pkg.go.dev/None/std@go1.26.4"
         }
       ],
       "name": "std",
-      "purl": "pkg:golang/std@go1.25.11",
+      "purl": "pkg:golang/std@go1.26.4",
       "type": "library",
-      "version": "go1.25.11"
+      "version": "go1.26.4"
     }
   ],
   "dependencies": [
@@ -855,7 +855,7 @@
       "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
     },
     {
-      "ref": "pkg:golang/std@go1.25.11"
+      "ref": "pkg:golang/std@go1.26.4"
     }
   ],
   "metadata": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongo-tools
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/mise.toml
+++ b/mise.toml
@@ -6,11 +6,11 @@
 
 [tools]
 # Go and Go tools
-go = "1.25.11"
+go = "1.26.4"
 "go:golang.org/x/tools/cmd/goimports" = "0.29.0"
 "go:golang.org/x/tools/gopls" = "0.21.1"
-"github:golangci/golangci-lint" = "2.6.2"
-"github:securego/gosec" = "2.22.10"
+"github:golangci/golangci-lint" = "2.12.2"
+"github:securego/gosec" = "2.27.1"
 "github:segmentio/golines" = "0.12.2"
 "github:houseabsolute/precious" = "0.10.2"
 


### PR DESCRIPTION
This also includes updates to `gosec` and `golangci-lint` to versions compatible with Go 1.26.4. The new `gosec` found a few issues that this PR either corrects or maks with a `#nosec` comment.