### PR TITLE
TOOLS-4233 Enable govet in golangci-lint and remove redundant Evergreen vet task

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - errcheck
     - gocheckcompilerdirectives
     - godot
+    - govet
     - ineffassign
     - misspell
     - nolintlint
@@ -17,6 +18,10 @@ linters:
   settings:
     errcheck:
       check-type-assertions: true
+
+    govet:
+      disable:
+        - composites
 
     misspell:
       locale: US
@@ -50,6 +55,10 @@ linters:
         text: is deprecated
       - path: (.+)\.go$
         text: "composites: .+(bson.(Binary|Decimal128|E|Timestamp)|types.(Destination|Source)(Client|Database)) struct literal uses unkeyed fields"
+      - linters:
+          - govet
+        path: \.go$
+        text: "inline: cannot inline: type parameter inference is not yet supported"
     paths:
       - third_party$
       - builtin$

--- a/common.yml
+++ b/common.yml
@@ -2645,23 +2645,6 @@ tasks:
         vars:
           target: test:unit ${testArgs}
 
-  - name: vet
-    commands:
-      - func: "fetch source"
-      - func: "install mise and go"
-      - command: shell.exec
-        type: test
-        params:
-          shell: bash
-          working_dir: src/github.com/mongodb/mongo-tools
-          script: |
-            set -o errexit
-            set -o pipefail
-            set -o verbose
-
-            ${_set_shell_env}
-            mise exec go -- go vet -composites=false ./bsondump ./mongo*
-
   - name: check-third-party-notices
     commands:
       - func: "fetch source"
@@ -2709,7 +2692,6 @@ buildvariants:
       - name: lint
       - name: mod-tidy
       - name: evergreen-validate
-      - name: vet
       - name: check-third-party-notices
       - name: check-sbom-lite
       - name: check-sarif-report

--- a/common/failpoint/failpoint.go
+++ b/common/failpoint/failpoint.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build failpoints
-// +build failpoints
 
 // Package failpoint implements triggers for custom debugging behavior.
 package failpoint

--- a/common/failpoint/failpoint_disabled.go
+++ b/common/failpoint/failpoint_disabled.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build !failpoints
-// +build !failpoints
 
 package failpoint
 

--- a/common/failpoint/failpoint_test.go
+++ b/common/failpoint/failpoint_test.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build failpoints
-// +build failpoints
 
 package failpoint
 

--- a/common/json/decode.go
+++ b/common/json/decode.go
@@ -146,7 +146,7 @@ func (e *InvalidUnmarshalError) Error() string {
 		return "json: Unmarshal(nil)"
 	}
 
-	if e.Type.Kind() != reflect.Ptr {
+	if e.Type.Kind() != reflect.Pointer {
 		return "json: Unmarshal(non-pointer " + e.Type.String() + ")"
 	}
 	return "json: Unmarshal(nil " + e.Type.String() + ")"
@@ -200,7 +200,7 @@ func (d *decodeState) unmarshal(v any) (err error) {
 	}()
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return &InvalidUnmarshalError{reflect.TypeOf(v)}
 	}
 
@@ -431,7 +431,7 @@ func (d *decodeState) indirect(
 	// If v is a named type and is addressable,
 	// start with its address, so that if the type has pointer methods,
 	// we find them.
-	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+	if v.Kind() != reflect.Pointer && v.Type().Name() != "" && v.CanAddr() {
 		v = v.Addr()
 	}
 	for {
@@ -439,18 +439,18 @@ func (d *decodeState) indirect(
 		// usefully addressable.
 		if v.Kind() == reflect.Interface && !v.IsNil() {
 			e := v.Elem()
-			if e.Kind() == reflect.Ptr && !e.IsNil() &&
-				(!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+			if e.Kind() == reflect.Pointer && !e.IsNil() &&
+				(!decodingNull || e.Elem().Kind() == reflect.Pointer) {
 				v = e
 				continue
 			}
 		}
 
-		if v.Kind() != reflect.Ptr {
+		if v.Kind() != reflect.Pointer {
 			break
 		}
 
-		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+		if v.Elem().Kind() != reflect.Pointer && decodingNull && v.CanSet() {
 			break
 		}
 		if v.IsNil() {
@@ -692,7 +692,7 @@ func (d *decodeState) object(v reflect.Value) {
 				subv = v
 				destring = f.quoted
 				for _, i := range f.index {
-					if subv.Kind() == reflect.Ptr {
+					if subv.Kind() == reflect.Pointer {
 						if subv.IsNil() {
 							subv.Set(reflect.New(subv.Type().Elem()))
 						}
@@ -846,7 +846,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 	switch c := item[0]; {
 	case isNull(item): // null
 		switch v.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
 			v.Set(reflect.Zero(v.Type()))
 			// otherwise, ignore null for primitives/string
 		}

--- a/common/json/encode.go
+++ b/common/json/encode.go
@@ -302,7 +302,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	}
 	return false
@@ -371,7 +371,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 	if t.Implements(marshalerType) {
 		return marshalerEncoder
 	}
-	if t.Kind() != reflect.Ptr && allowAddr {
+	if t.Kind() != reflect.Pointer && allowAddr {
 		if reflect.PointerTo(t).Implements(marshalerType) {
 			return newCondAddrEncoder(addrMarshalerEncoder, newTypeEncoder(t, false))
 		}
@@ -380,7 +380,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 	if t.Implements(textMarshalerType) {
 		return textMarshalerEncoder
 	}
-	if t.Kind() != reflect.Ptr && allowAddr {
+	if t.Kind() != reflect.Pointer && allowAddr {
 		if reflect.PointerTo(t).Implements(textMarshalerType) {
 			return newCondAddrEncoder(addrTextMarshalerEncoder, newTypeEncoder(t, false))
 		}
@@ -414,7 +414,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 		return newSliceEncoder(t)
 	case reflect.Array:
 		return newArrayEncoder(t)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return newPtrEncoder(t)
 	default:
 		return unsupportedTypeEncoder
@@ -426,7 +426,7 @@ func invalidValueEncoder(e *encodeState, v reflect.Value, quoted bool) {
 }
 
 func marshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		e.WriteString("null")
 		return
 	}
@@ -461,7 +461,7 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
 }
 
 func textMarshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		e.WriteString("null")
 		return
 	}
@@ -788,7 +788,7 @@ func isValidTag(s string) bool {
 
 func fieldByIndex(v reflect.Value, index []int) reflect.Value {
 	for _, i := range index {
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return reflect.Value{}
 			}
@@ -801,7 +801,7 @@ func fieldByIndex(v reflect.Value, index []int) reflect.Value {
 
 func typeByIndex(t reflect.Type, index []int) reflect.Type {
 	for _, i := range index {
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		t = t.Field(i).Type
@@ -1075,7 +1075,7 @@ func typeFields(t reflect.Type) []field {
 				index[len(f.index)] = i
 
 				ft := sf.Type
-				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+				if ft.Name() == "" && ft.Kind() == reflect.Pointer {
 					// Follow pointer.
 					ft = ft.Elem()
 				}

--- a/common/options/options_fp.go
+++ b/common/options/options_fp.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build failpoints
-// +build failpoints
 
 package options
 

--- a/common/options/options_fp_disabled.go
+++ b/common/options/options_fp_disabled.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build !failpoints
-// +build !failpoints
 
 package options
 

--- a/common/password/pass_util.go
+++ b/common/password/pass_util.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build !solaris
-// +build !solaris
 
 package password
 

--- a/common/progress/progress_bar_test.go
+++ b/common/progress/progress_bar_test.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build !race
-// +build !race
 
 // Disable race detector since these tests are inherently racy
 package progress

--- a/mongostat/stat_consumer/interactive_line_formatter.go
+++ b/mongostat/stat_consumer/interactive_line_formatter.go
@@ -5,7 +5,6 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 //go:build !solaris
-// +build !solaris
 
 package stat_consumer
 


### PR DESCRIPTION
This removes the `vet` CI task and adds `govet` to the list of linters run by `golangci-lint`. This also surfaced some new linting issues that are fixed I fixed in this PR.