### PR TITLE
TOOLS-4235 More Evergreen config cleanup

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -31,17 +31,16 @@ variables:
         "--sslMode requireSSL --sslCAFile common/db/testdata/ca-ia.pem --sslPEMKeyFile
         common/db/testdata/test-server.pem"
       replsettest_ssl_config:
-        "sslMode: \\\"requireSSL\\\",sslPEMKeyFile: \\\"common/db/testdata/test-server.pem\\\",
-        sslCAFile: \\\"common/db/testdata/ca-ia.pem\\\", sslAllowInvalidHostnames: \\\"\\\""
+        'sslMode: "requireSSL",sslPEMKeyFile: "common/db/testdata/test-server.pem", sslCAFile:
+        "common/db/testdata/ca-ia.pem", sslAllowInvalidHostnames: ""'
       mongod_port: 33333
     tls: &mongod_tls_startup_args
       mongod_args_tls:
         "--tlsMode requireTLS --tlsCAFile common/db/testdata/ca-ia.pem --tlsCertificateKeyFile
         common/db/testdata/test-server.pem"
       replsettest_tls_config:
-        "tlsMode: \\\"requireTLS\\\",tlsCertificateKeyFile:
-        \\\"common/db/testdata/test-server.pem\\\", tlsCAFile: \\\"common/db/testdata/ca-ia.pem\\\",
-        tlsAllowInvalidHostnames: \\\"\\\""
+        'tlsMode: "requireTLS",tlsCertificateKeyFile: "common/db/testdata/test-server.pem",
+        tlsCAFile: "common/db/testdata/ca-ia.pem", tlsAllowInvalidHostnames: ""'
       mongod_port: 33333
 
   mongo_arguments:
@@ -648,10 +647,10 @@ functions:
           NODE_OPTIONS=""
           mkdir -p /data/db/
           if [ "${USE_TLS}" = "true" ]; then
-            NODE_OPTIONS="${replsettest_tls_config}"
+            NODE_OPTIONS='${replsettest_tls_config}'
             MONGO_ARGS="${mongo_args_tls}"
           elif [ "${USE_SSL}" = "true" ]; then
-            NODE_OPTIONS="${replsettest_ssl_config}"
+            NODE_OPTIONS='${replsettest_ssl_config}'
           fi
           # use jsconfig.json to set baseUrl to find libs
           mv test/shell_common/jsconfig.json ./

--- a/etc/evergreen-validate-wrapper.sh
+++ b/etc/evergreen-validate-wrapper.sh
@@ -30,9 +30,6 @@ if grep --quiet "is valid with warnings" "$TEMP_FILE"; then
         "WARNING: task 'commit-queue-workaround' defined but not used by any variants; consider using or disabling")
             continue
             ;;
-        "WARNING: task 'deliberate_fail_to_test_build_baron_context_rules' defined but not used by any variants; consider using or disabling")
-            continue
-            ;;
         "WARNING: task 't_resmoke_setup' defined but not used by any variants; consider using or disabling")
             continue
             ;;

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -22,16 +22,6 @@ tasks:
           script: |
             echo "This task is a no-op to work around evergreen's commit queue behavior"
 
-  - name: deliberate_fail_to_test_build_baron_context_rules
-    commands:
-      - command: shell.exec
-        params:
-          script: |
-            echo "Deliberate fail test should give BF on mongodump_passthrough context"
-            echo "exit 1"
-            exit 1
-    patch_only: true
-
   # For mongodump passthrough, this builds and uploads the mongodump and mongorestore
   # binaries (but without coverage), and uploads them.  The name "compile_coverage"
   # is misleading, but that task name is used in the generated tasks from mongodump-task-gen


### PR DESCRIPTION
This removes the `deliberate_fail_to_test_build_baron_context_rules` task and cleans up some escaping in the Evergreen config.

It also removes the need for escaping a string in YAML by interpolating it into bash code with single quotes instead of double.