### PR TITLE
TOOLS-4238 Start moving inline shell to scripts and use env vars to pass expansions

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -229,19 +229,23 @@ functions:
       add_expansions_to_env: true
 
   "run make target":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        shell: bash
+        # binary must be bash (with the script passed via args), not the script
+        # directly: Windows can't execute a shebang script as a native binary.
+        binary: bash
         working_dir: src/github.com/mongodb/mongo-tools
-        script: |
-          set -o errexit
-          set -o pipefail
-          set -o verbose
-
-          ${_set_shell_env}
-          ${_maybe_enable_devtoolset_7}
-          $GO_EXEC_PREFIX go run build.go -v ${target}
+        args:
+          - "./scripts/run-make-target.sh"
+        env:
+          EVG_BUILD_VARIANT: ${build_variant}
+          EVG_PLATFORM: ${_platform}
+          EVG_WORKDIR: ${workdir}
+          TARGET: ${target}
+          TOOLS_TESTING_AUTH_PASSWORD: ${auth_password}
+          TOOLS_TESTING_AUTH_USERNAME: ${auth_username}
+          TOOLS_TESTING_PKCS8_PASSWORD: ${pkcs8_password}
 
   "download mongod and shell":
     - command: github.generate_token
@@ -397,7 +401,6 @@ functions:
           set -o pipefail
           set -o verbose
 
-          ${_set_shell_env}
           MONGO_ARGS="${mongo_args}"
           if [ "${USE_TLS}" = "true" ]; then
             MONGO_ARGS="${mongo_args_tls}"

--- a/scripts/ci-env.sh
+++ b/scripts/ci-env.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Sets standard CI environment variables for build and test tasks.
+# Requires $EVG_WORKDIR to be set in the environment before sourcing.
+
+# cgo needs a mingw-w64 toolchain and some Windows-specific flags on Windows.
+# We also normalize the working directory through cygpath here, since
+# Evergreen's workdir expansion on Windows sometimes lacks a drive letter,
+# and Go's os/exec refuses to run an executable found via a PATH entry it
+# can't prove is absolute.
+case "$(PATH=/usr/bin:/bin uname -s)" in
+CYGWIN*)
+    EVG_WORKDIR="$(cygpath -am "$EVG_WORKDIR")"
+    export CGO_CFLAGS="-D_WIN32_WINNT=0x0601 -DNTDDI_VERSION=0x06010000"
+    export GOCACHE="C:/windows/temp"
+    export PATH="$PATH:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin"
+    ;;
+esac
+
+# mise has no builds at all for ppc64le or s390x. On those architectures we
+# download Go ourselves instead (see install-go-without-mise.sh), so shared
+# scripts that need to run go use GO_EXEC_PREFIX rather than hardcoding
+# "mise exec go --".
+case "$(uname -m)" in
+ppc64le | s390x)
+    export PATH="${EVG_WORKDIR:?}/.local/share/go-toolchain/go/bin:$PATH"
+    export GO_EXEC_PREFIX=""
+    # We're managing the toolchain ourselves on these architectures, so don't
+    # let Go silently fetch a different version on its own (e.g. because
+    # go.mod requires a newer version than what we've provisioned).
+    export GOTOOLCHAIN=local
+    ;;
+*)
+    export GO_EXEC_PREFIX="mise exec go --"
+    ;;
+esac
+
+# We add $HOME to PATH because the evergreen client binary lives at ~/evergreen.
+export PATH="${EVG_WORKDIR:?}/.local/bin:$HOME:$PATH"
+export MISE_DATA_DIR="${EVG_WORKDIR:?}/.local/share/mise"
+
+# build.go's getPlatform() reads EVG_VARIANT (whenever CI is set) to choose the per-platform build
+# tags -- notably "failpoints", which several integration tests depend on
+# (e.g. TestMongoDumpTOOLS2498's PauseBeforeDumping failpoint). If EVG_VARIANT is missing the tags
+# are dropped and those tests break. Most variants use the build variant name directly; a few
+# (e.g. "static") override it via $EVG_PLATFORM, matching the old _set_shell_env logic.
+if [ -n "${EVG_PLATFORM:-}" ] || [ -n "${EVG_BUILD_VARIANT:-}" ]; then
+    export EVG_VARIANT="${EVG_PLATFORM:-$EVG_BUILD_VARIANT}"
+fi
+
+if [ -f /opt/rh/devtoolset-7/enable ]; then
+    # shellcheck disable=SC1091
+    source /opt/rh/devtoolset-7/enable
+fi

--- a/scripts/run-make-target.sh
+++ b/scripts/run-make-target.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o verbose
+
+SCRIPT_DIR=$(dirname "$0")
+# shellcheck source=scripts/ci-env.sh
+. "$SCRIPT_DIR/ci-env.sh"
+
+# $TARGET can be multiple space-separated arguments (e.g. "test:integration
+# -ssl=true -auth=true"), so it must be word-split rather than quoted.
+# shellcheck disable=SC2086
+$GO_EXEC_PREFIX go run build.go -v $TARGET


### PR DESCRIPTION
This is the first of a series of PRs to change how we execute shell code in the Evergreen config. The ultimate goal is to remove the `_set_shell-env` expansion. This wil be replaced by the `env` key for each comand. We will turn expansions into env vars this way.

This first PR only updates the "run make target" function as an example.