### PR TITLE
TOOLS-4237 Replace most uses of the `PauseBeforeDumping` with `PauseUntilResumed`

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/mongodb/mongo-tools/common"
 	"github.com/mongodb/mongo-tools/common/archive"
@@ -1428,26 +1427,27 @@ func TestMongoDumpTOOLS2498(t *testing.T) {
 		err = md.Init()
 		So(err, ShouldBeNil)
 
-		require.NoError(t, failpoint.DefaultManager.Parse("PauseBeforeDumping"))
+		require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 		defer failpoint.DefaultManager.Reset()
 
-		var disconnectErr error
-		canCheckErr := make(chan struct{})
-		// with the failpoint PauseBeforeDumping, Mongodump will pause 15 seconds before starting dumping. We will close the connection
-		// during this period. Before the fix, the process will panic with Nil pointer error since it fails to getCollectionInfo.
-		go func() {
-			time.Sleep(2 * time.Second)
-			session, _ := md.SessionProvider.GetSession()
-			disconnectErr = session.Disconnect(t.Context())
-			close(canCheckErr)
-		}()
+		dumpErrCh := make(chan error, 1)
+		go func() { dumpErrCh <- md.Dump() }()
 
-		err = md.Dump()
+		// With the PauseUntilResumed failpoint, mongodump pauses before it starts
+		// dumping. We close the connection while it is paused. Before the fix, the
+		// process would panic with a nil pointer error because it failed to
+		// getCollectionInfo.
+		fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+		So(ok, ShouldBeTrue)
+		fp.Reached()
+		session, _ := md.SessionProvider.GetSession()
+		disconnectErr := session.Disconnect(t.Context())
+		fp.Signal()
+
+		err = <-dumpErrCh
 		// Mongodump should not panic, but return correct error if failed to getCollectionInfo
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "client is disconnected")
-
-		<-canCheckErr
 		So(disconnectErr, ShouldBeNil)
 	})
 }
@@ -2353,17 +2353,20 @@ func TestFailDuringResharding(t *testing.T) {
 		)
 
 		Convey("dump should fail if config.reshardingOperations created in oplog", func() {
-			require.NoError(t, failpoint.DefaultManager.Parse("PauseBeforeDumping"))
+			require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 			defer failpoint.DefaultManager.Reset()
 
-			var sessErr1, sessErr2 error
-			go func() {
-				time.Sleep(2 * time.Second)
-				sessErr1 = session.Database("config").CreateCollection(ctx, "reshardingOperations")
-				sessErr2 = session.Database("config").Collection("reshardingOperations").Drop(ctx)
-			}()
+			dumpErrCh := make(chan error, 1)
+			go func() { dumpErrCh <- md.Dump() }()
 
-			err = md.Dump()
+			fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+			So(ok, ShouldBeTrue)
+			fp.Reached()
+			sessErr1 := session.Database("config").CreateCollection(ctx, "reshardingOperations")
+			sessErr2 := session.Database("config").Collection("reshardingOperations").Drop(ctx)
+			fp.Signal()
+
+			err = <-dumpErrCh
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
@@ -2374,20 +2377,26 @@ func TestFailDuringResharding(t *testing.T) {
 		Convey(
 			"dump should fail if config.localReshardingOperations.donor created in oplog",
 			func() {
-				require.NoError(t, failpoint.DefaultManager.Parse("PauseBeforeDumping"))
+				require.NoError(
+					t,
+					failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()),
+				)
 				defer failpoint.DefaultManager.Reset()
 
-				var sessErr1, sessErr2 error
-				go func() {
-					time.Sleep(2 * time.Second)
-					sessErr1 = session.Database("config").
-						CreateCollection(ctx, "localReshardingOperations.donor")
-					sessErr2 = session.Database("config").
-						Collection("localReshardingOperations.donor").
-						Drop(ctx)
-				}()
+				dumpErrCh := make(chan error, 1)
+				go func() { dumpErrCh <- md.Dump() }()
 
-				err = md.Dump()
+				fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+				So(ok, ShouldBeTrue)
+				fp.Reached()
+				sessErr1 := session.Database("config").
+					CreateCollection(ctx, "localReshardingOperations.donor")
+				sessErr2 := session.Database("config").
+					Collection("localReshardingOperations.donor").
+					Drop(ctx)
+				fp.Signal()
+
+				err = <-dumpErrCh
 
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldContainSubstring, OplogErrorMsg)
@@ -2399,20 +2408,26 @@ func TestFailDuringResharding(t *testing.T) {
 		Convey(
 			"dump should fail if config.localReshardingOperations.recipient created in oplog",
 			func() {
-				require.NoError(t, failpoint.DefaultManager.Parse("PauseBeforeDumping"))
+				require.NoError(
+					t,
+					failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()),
+				)
 				defer failpoint.DefaultManager.Reset()
 
-				var sessErr1, sessErr2 error
-				go func() {
-					time.Sleep(2 * time.Second)
-					sessErr1 = session.Database("config").
-						CreateCollection(ctx, "localReshardingOperations.recipient")
-					sessErr2 = session.Database("config").
-						Collection("localReshardingOperations.recipient").
-						Drop(ctx)
-				}()
+				dumpErrCh := make(chan error, 1)
+				go func() { dumpErrCh <- md.Dump() }()
 
-				err = md.Dump()
+				fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+				So(ok, ShouldBeTrue)
+				fp.Reached()
+				sessErr1 := session.Database("config").
+					CreateCollection(ctx, "localReshardingOperations.recipient")
+				sessErr2 := session.Database("config").
+					Collection("localReshardingOperations.recipient").
+					Drop(ctx)
+				fp.Signal()
+
+				err = <-dumpErrCh
 
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldContainSubstring, OplogErrorMsg)

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -70,15 +70,25 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 
 	require.NoError(t, md.Init())
 
-	// Enable a failpoint so that the test can create oplogs during dump.
-	require.NoError(t, failpoint.DefaultManager.Parse("PauseBeforeDumping"))
+	// Pause mongodump right after it captures the oplog start time so that the
+	// test can create oplog entries that are guaranteed to fall inside the dump
+	// window, then let it resume.
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 	defer failpoint.DefaultManager.Reset()
 
-	require.NoError(t, vectoredInsert(ctx))
 	//nolint:errcheck
 	defer tearDownMongoDumpTestData(t)
 
-	require.NoError(t, md.Dump())
+	dumpErrCh := make(chan error, 1)
+	go func() { dumpErrCh <- md.Dump() }()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
+	fp.Reached()
+	require.NoError(t, vectoredInsert(ctx))
+	fp.Signal()
+
+	require.NoError(t, <-dumpErrCh)
 
 	path, err := os.Getwd()
 	require.NoError(t, err)
@@ -96,13 +106,25 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 	require.NoError(t, err)
 	defer oplogFile.Close()
 
-	contents, err := io.ReadAll(oplogFile)
-	require.NoError(t, err)
-
-	var oplog bson.D
-	require.NoError(t, bson.Unmarshal(contents, &oplog))
-
-	require.Equal(t, int32(1), bsonutil.ToMap(oplog)["multiOpType"])
+	// The vectored insert happens during the dump window, so its oplog entry is
+	// somewhere in the dumped oplog but not necessarily the first entry. Scan all
+	// entries and assert that one of them is the vectored (multiOp) insert.
+	bsonSrc := db.NewDecodedBSONSource(db.NewBufferlessBSONSource(oplogFile))
+	foundMultiOpInsert := false
+	var entry bson.M
+	for bsonSrc.Next(&entry) {
+		require.NoError(t, bsonSrc.Err())
+		if entry["multiOpType"] == int32(1) {
+			foundMultiOpInsert = true
+			break
+		}
+	}
+	require.NoError(t, bsonSrc.Err())
+	require.True(
+		t,
+		foundMultiOpInsert,
+		"oplog dump should contain a vectored insert entry with multiOpType == 1",
+	)
 }
 
 func vectoredInsert(ctx context.Context) error {
@@ -171,18 +193,24 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 
 	require.NoError(t, md.Init())
 
-	// Enable a failpoint so that the test can create oplogs during dump.
-	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseBeforeDumping.String()))
+	// Pause mongodump right after it captures the oplog start time so that the
+	// test can create oplog entries during the dump window, then let it resume.
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 	defer failpoint.DefaultManager.Reset()
-
-	go func() {
-		require.NoError(t, createIndexesAndCollModIndexUniqueness(ctx))
-	}()
 
 	//nolint:errcheck
 	defer tearDownMongoDumpTestData(t)
 
-	require.NoError(t, md.Dump())
+	dumpErrCh := make(chan error, 1)
+	go func() { dumpErrCh <- md.Dump() }()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
+	fp.Reached()
+	require.NoError(t, createIndexesAndCollModIndexUniqueness(ctx))
+	fp.Signal()
+
+	require.NoError(t, <-dumpErrCh)
 
 	path, err := os.Getwd()
 	require.NoError(t, err)
@@ -329,18 +357,24 @@ func TestOplogDumpBypassDocumentValidation(t *testing.T) {
 
 	require.NoError(t, md.Init())
 
-	// Enable a failpoint so that the test can create oplogs during dump.
-	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseBeforeDumping.String()))
+	// Pause mongodump right after it captures the oplog start time so that the
+	// test can create oplog entries during the dump window, then let it resume.
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 	defer failpoint.DefaultManager.Reset()
-
-	go func() {
-		createCollectionWithValidatorAndInsertBypassValidation(ctx, t)
-	}()
 
 	//nolint:errcheck
 	defer tearDownMongoDumpTestData(t)
 
-	require.NoError(t, md.Dump())
+	dumpErrCh := make(chan error, 1)
+	go func() { dumpErrCh <- md.Dump() }()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
+	fp.Reached()
+	createCollectionWithValidatorAndInsertBypassValidation(ctx, t)
+	fp.Signal()
+
+	require.NoError(t, <-dumpErrCh)
 
 	path, err := os.Getwd()
 	require.NoError(t, err)
@@ -479,18 +513,24 @@ func TestOplogDumpCollModTTL(t *testing.T) {
 
 	require.NoError(t, md.Init())
 
-	// Enable a failpoint so that the test can create oplogs during dump.
-	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseBeforeDumping.String()))
+	// Pause mongodump right after it captures the oplog start time so that the
+	// test can create oplog entries during the dump window, then let it resume.
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.PauseUntilResumed.String()))
 	defer failpoint.DefaultManager.Reset()
-
-	go func() {
-		convertIndexToTTL(ctx, t)
-	}()
 
 	//nolint:errcheck
 	defer tearDownMongoDumpTestData(t)
 
-	require.NoError(t, md.Dump())
+	dumpErrCh := make(chan error, 1)
+	go func() { dumpErrCh <- md.Dump() }()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
+	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
+	fp.Reached()
+	convertIndexToTTL(ctx, t)
+	fp.Signal()
+
+	require.NoError(t, <-dumpErrCh)
 
 	path, err := os.Getwd()
 	require.NoError(t, err)


### PR DESCRIPTION
For Go code, we can use `PauseUntilResumed`, which is deterministic and race-free, unlike `PauseBeforeDumping`.