### PR TITLE
Add a context to `failpoint.Wait` and `failpoint.Signal`

### DIFF
--- a/common/failpoint/failpoint.go
+++ b/common/failpoint/failpoint.go
@@ -7,7 +7,11 @@
 // Package failpoint implements triggers for custom debugging behavior.
 package failpoint
 
-import "sync"
+import (
+	"context"
+	"fmt"
+	"sync"
+)
 
 // pauseSignal coordinates a single pause: reached is closed by wait to
 // signal that the paused code has arrived at its pause point, and signal is
@@ -30,19 +34,31 @@ func newPauseSignal() *pauseSignal {
 
 // wait closes reachedCh (so a concurrent call to reached returns) and then
 // blocks until signal is called.
-func (p *pauseSignal) wait() {
+func (p *pauseSignal) wait(ctx context.Context) error {
 	p.mu.Lock()
 	p.reachedOnce.Do(func() {
 		close(p.reachedCh)
 	})
 	p.mu.Unlock()
 
-	<-p.signalCh
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled while waiting for signal to be called: %w", ctx.Err())
+	case <-p.signalCh:
+	}
+
+	return nil
 }
 
 // reached blocks until wait has been called.
-func (p *pauseSignal) reached() {
-	<-p.reachedCh
+func (p *pauseSignal) reached(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled while waiting for wait to be called: %w", ctx.Err())
+	case <-p.reachedCh:
+	}
+
+	return nil
 }
 
 // signal releases a call blocked in wait. Safe to call more than once.
@@ -69,13 +85,19 @@ func newFailpoint() *Failpoint {
 
 // Wait signals that the caller has reached this pause point (so a concurrent
 // call to Reached returns) and then blocks until Signal is called.
-func (fp *Failpoint) Wait() { fp.pause.wait() }
+func (fp *Failpoint) Wait(ctx context.Context) error {
+	return fp.pause.wait(ctx)
+}
 
 // Reached blocks until Wait has been called.
-func (fp *Failpoint) Reached() { fp.pause.reached() }
+func (fp *Failpoint) Reached(ctx context.Context) error {
+	return fp.pause.reached(ctx)
+}
 
 // Signal releases a call blocked in Wait. Safe to call more than once.
-func (fp *Failpoint) Signal() { fp.pause.signal() }
+func (fp *Failpoint) Signal() {
+	fp.pause.signal()
+}
 
 // Manager tracks which failpoints are currently enabled.
 type Manager interface {

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -347,7 +347,9 @@ func (dump *MongoDump) Dump() (err error) {
 		time.Sleep(15 * time.Second)
 	} else if fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed); ok {
 		log.Logvf(log.Info, "failpoint.PauseUntilResumed: waiting for resume signal")
-		fp.Wait()
+		if err := fp.Wait(context.TODO()); err != nil {
+			return err
+		}
 	}
 
 	// switch on what kind of execution to do

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1433,22 +1433,18 @@ func TestMongoDumpTOOLS2498(t *testing.T) {
 		dumpErrCh := make(chan error, 1)
 		go func() { dumpErrCh <- md.Dump() }()
 
-		// With the PauseUntilResumed failpoint, mongodump pauses before it starts
-		// dumping. We close the connection while it is paused. Before the fix, the
-		// process would panic with a nil pointer error because it failed to
-		// getCollectionInfo.
 		fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 		So(ok, ShouldBeTrue)
-		fp.Reached()
+		require.NoError(t, fp.Reached(context.TODO()))
 		session, _ := md.SessionProvider.GetSession()
 		disconnectErr := session.Disconnect(t.Context())
+		So(disconnectErr, ShouldBeNil)
 		fp.Signal()
 
 		err = <-dumpErrCh
-		// Mongodump should not panic, but return correct error if failed to getCollectionInfo
+		// Mongodump should not panic, but return correct the error if getCollectionInfo failed.
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "client is disconnected")
-		So(disconnectErr, ShouldBeNil)
 	})
 }
 
@@ -2361,7 +2357,7 @@ func TestFailDuringResharding(t *testing.T) {
 
 			fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 			So(ok, ShouldBeTrue)
-			fp.Reached()
+			require.NoError(t, fp.Reached(context.TODO()))
 			sessErr1 := session.Database("config").CreateCollection(ctx, "reshardingOperations")
 			sessErr2 := session.Database("config").Collection("reshardingOperations").Drop(ctx)
 			fp.Signal()
@@ -2388,7 +2384,7 @@ func TestFailDuringResharding(t *testing.T) {
 
 				fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 				So(ok, ShouldBeTrue)
-				fp.Reached()
+				require.NoError(t, fp.Reached(context.TODO()))
 				sessErr1 := session.Database("config").
 					CreateCollection(ctx, "localReshardingOperations.donor")
 				sessErr2 := session.Database("config").
@@ -2419,7 +2415,7 @@ func TestFailDuringResharding(t *testing.T) {
 
 				fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 				So(ok, ShouldBeTrue)
-				fp.Reached()
+				require.NoError(t, fp.Reached(context.TODO()))
 				sessErr1 := session.Database("config").
 					CreateCollection(ctx, "localReshardingOperations.recipient")
 				sessErr2 := session.Database("config").

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -84,7 +84,7 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
-	fp.Reached()
+	require.NoError(t, fp.Reached(context.TODO()))
 	require.NoError(t, vectoredInsert(ctx))
 	fp.Signal()
 
@@ -113,7 +113,6 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 	foundMultiOpInsert := false
 	var entry bson.M
 	for bsonSrc.Next(&entry) {
-		require.NoError(t, bsonSrc.Err())
 		if entry["multiOpType"] == int32(1) {
 			foundMultiOpInsert = true
 			break
@@ -206,7 +205,7 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
-	fp.Reached()
+	require.NoError(t, fp.Reached(context.TODO()))
 	require.NoError(t, createIndexesAndCollModIndexUniqueness(ctx))
 	fp.Signal()
 
@@ -370,7 +369,7 @@ func TestOplogDumpBypassDocumentValidation(t *testing.T) {
 
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
-	fp.Reached()
+	require.NoError(t, fp.Reached(context.TODO()))
 	createCollectionWithValidatorAndInsertBypassValidation(ctx, t)
 	fp.Signal()
 
@@ -526,7 +525,7 @@ func TestOplogDumpCollModTTL(t *testing.T) {
 
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
-	fp.Reached()
+	require.NoError(t, fp.Reached(context.TODO()))
 	convertIndexToTTL(ctx, t)
 	fp.Signal()
 
@@ -632,7 +631,7 @@ func TestOplogRollover(t *testing.T) {
 
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
-	fp.Reached()
+	require.NoError(t, fp.Reached(context.TODO()))
 	md.oplogStart = bson.Timestamp{T: 1, I: 1}
 	fp.Signal()
 


### PR DESCRIPTION
This makes it possible to cancel these calls, though right now they always get `context.TODO()`.