### PR TITLE
TOOLS-4264 Add guards to shell scripts to ensure that expected env vars are set

### DIFF
--- a/scripts/download-mongod-and-shell.sh
+++ b/scripts/download-mongod-and-shell.sh
@@ -9,4 +9,6 @@ SCRIPT_DIR=$(dirname "$0")
 # shellcheck source=scripts/release-env.sh
 . "$SCRIPT_DIR/release-env.sh"
 
+: "${MONGO_VERSION:?}"
+
 $GO_EXEC_PREFIX go run release/release.go download-mongod-and-shell --server-version "$MONGO_VERSION"

--- a/scripts/run-make-target.sh
+++ b/scripts/run-make-target.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR=$(dirname "$0")
 # shellcheck source=scripts/ci-env.sh
 . "$SCRIPT_DIR/ci-env.sh"
 
+: "${TARGET:?}"
+
 # $TARGET can be multiple space-separated arguments (e.g. "test:integration
 # -ssl=true -auth=true"), so it must be word-split rather than quoted.
 # shellcheck disable=SC2086

--- a/scripts/run_qa.sh
+++ b/scripts/run_qa.sh
@@ -4,6 +4,9 @@ set -x
 set -v
 set -e
 
+# shellcheck disable=SC2154 # resmoke_suite is an Evergreen expansion (add_expansions_to_env)
+: "${resmoke_suite:?}"
+
 chmod +x bin/*
 mv bin/* test/qa-tests/
 cd test/qa-tests

--- a/scripts/write-evergreen-config-file.sh
+++ b/scripts/write-evergreen-config-file.sh
@@ -4,6 +4,8 @@
 # by Evergreen anyway).
 set +x
 
+: "${EVG_USER:?}" "${EVG_KEY:?}"
+
 cat <<EOF >"$HOME/.evergreen.yml"
 user: "$EVG_USER"
 api_key: "$EVG_KEY"


### PR DESCRIPTION
These scripts were converted previously, but we didn't add any guards at the time.