### PR TITLE
Remove the `mongo_os` expansion

### DIFF
--- a/PLATFORMSUPPORT.md
+++ b/PLATFORMSUPPORT.md
@@ -23,7 +23,6 @@ In this tutorial, we will add a new platform support for Ubuntu2004-arm64.
     <<: *mongo_ssl_startup_args
     <<: *mongod_tls_startup_args
     <<: *mongo_tls_startup_args
-    mongo_os: "ubuntu2004"
     mongo_edition: "targeted"
     mongo_arch: "aarch64"
     build_tags: "failpoints"

--- a/common.yml
+++ b/common.yml
@@ -467,7 +467,6 @@ functions:
           GARASIGN_USERNAME: ${garasign_username}
           MACOS_NOTARY_KEY: ${MACOS_NOTARY_KEY}
           MACOS_NOTARY_SECRET: ${MACOS_NOTARY_SECRET}
-          MONGO_OS: ${mongo_os}
 
   "upload signed release artifacts":
     # temporary workaround for TOOLS-2606
@@ -2642,8 +2641,6 @@ buildvariants:
 
   - name: macos
     display_name: MacOS 14 x86_64
-    expansions:
-      mongo_os: "osx"
     run_on:
       - macos-14
     tasks:
@@ -2658,8 +2655,6 @@ buildvariants:
 
   - name: macos-arm64
     display_name: MacOS 14 ARM
-    expansions:
-      mongo_os: "osx"
     run_on:
       - macos-14-arm64
     tasks:
@@ -2696,7 +2691,6 @@ buildvariants:
           *mongod_tls_startup_args,
           *mongo_tls_startup_args,
         ]
-      mongo_os: "rhel80"
       mongo_edition: "enterprise"
       resmoke_use_tls: _tls
       edition: enterprise
@@ -2733,7 +2727,6 @@ buildvariants:
           *mongod_tls_startup_args,
           *mongo_tls_startup_args,
         ]
-      mongo_os: "rhel80"
       mongo_edition: "enterprise"
       testArgs: "-race=true"
       resmoke_use_tls: _tls
@@ -2912,7 +2905,6 @@ buildvariants:
           *mongod_tls_startup_args,
           *mongo_tls_startup_args,
         ]
-      mongo_os: "windows-64"
       mongo_edition: "enterprise"
       mongo_target: "windows"
       python_binary: "/cygdrive/c/python/Python311/python"

--- a/scripts/sign_artifacts.sh
+++ b/scripts/sign_artifacts.sh
@@ -96,27 +96,27 @@ macos_sign_maybe_notarize() {
         --out-path "$PWD/$pkgname.zip"
 }
 
-case $MONGO_OS in
-"osx")
-    macos_sign_maybe_notarize
-    ;;
-
-"windows-64")
+# The signing task doesn't always run on the same OS as the artifacts it signs:
+# Windows (and every Linux) variant signs on a Linux host, while the macOS
+# variants sign on a Mac. So we can't rely on `uname` alone to pick the signing
+# mode. Instead we detect the target from the artifacts present: only Windows
+# builds produce a .msi; the macOS signer is the only one running on Darwin;
+# everything else is a Linux package set signed with PGP.
+if ls mongodb-database-tools*.msi >/dev/null 2>&1; then
     setup_garasign_authentication
     msifile=$(ls mongodb-database-tools*.msi)
     authenticode_sign "$msifile"
     zipfile=$(ls mongodb-database-tools*.zip)
     pgp_sign "$zipfile" "$zipfile.sig"
-    ;;
-
-*)
+elif [ "$(uname -s)" = "Darwin" ]; then
+    macos_sign_maybe_notarize
+else
     setup_garasign_authentication
     for file in mongodb-database-tools*.{tgz,deb,rpm}; do
         [ -e "$file" ] || continue
 
         pgp_sign "$file" "$file.sig"
     done
-    ;;
-esac
+fi
 
 ls -la


### PR DESCRIPTION
This was only used in the sign script, but we can have that script check the artifacts to be signed or the OS we're on in order to have it pick the right type of signing.