### PR TITLE
TOOLS-4275 Remove pointless stdlib wrappers in util package

### DIFF
--- a/bsondump/bsondump.go
+++ b/bsondump/bsondump.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/json"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/util"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -60,7 +60,7 @@ func (WriteNopCloser) Close() error { return nil }
 // or nil if none is set. The caller is responsible for closing it.
 func (oo *OutputOptions) GetWriter() (io.WriteCloser, error) {
 	if oo.OutFileName != "" {
-		file, err := os.Create(util.ToUniversalPath(oo.OutFileName))
+		file, err := os.Create(filepath.FromSlash(oo.OutFileName))
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +74,7 @@ func (oo *OutputOptions) GetWriter() (io.WriteCloser, error) {
 // or nil if none is set. The caller is responsible for closing it.
 func (oo *OutputOptions) GetBSONReader() (io.ReadCloser, error) {
 	if oo.BSONFileName != "" {
-		file, err := os.Open(util.ToUniversalPath(oo.BSONFileName))
+		file, err := os.Open(filepath.FromSlash(oo.BSONFileName))
 		if err != nil {
 			return nil, fmt.Errorf("couldn't open BSON file: %v", err)
 		}

--- a/common/archive/prelude.go
+++ b/common/archive/prelude.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"net/url"
 	"path/filepath"
 	"sync/atomic"
 
@@ -236,9 +237,9 @@ func (pe *PreludeExplorer) Name() string {
 		return pe.database
 	}
 	if pe.isMetadata {
-		return util.EscapeCollectionName(pe.collection) + ".metadata.json"
+		return url.QueryEscape(pe.collection) + ".metadata.json"
 	}
-	return util.EscapeCollectionName(pe.collection) + ".bson"
+	return url.QueryEscape(pe.collection) + ".bson"
 }
 
 // Path is part of the DirLike interface. It creates the full path for the "location" in the prelude.

--- a/common/util/file.go
+++ b/common/util/file.go
@@ -10,9 +10,7 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"net/url"
 	"os"
-	"path/filepath"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
@@ -35,21 +33,6 @@ func GetFieldsFromFile(path string) ([]string, error) {
 		return nil, err
 	}
 	return fields, nil
-}
-
-// ToUniversalPath returns the result of replacing each slash ('/') character
-// in "path" with an OS-specific separator character. Multiple slashes are
-// replaced by multiple separators.
-func ToUniversalPath(path string) string {
-	return filepath.FromSlash(path)
-}
-
-func EscapeCollectionName(collName string) string {
-	return url.QueryEscape(collName)
-}
-
-func UnescapeCollectionName(escapedCollName string) (string, error) {
-	return url.QueryUnescape(escapedCollName)
 }
 
 type WrappedReadCloser struct {

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,7 +33,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -204,7 +204,7 @@ func readBSONIntoDatabase(t *testing.T, dir, restoreDBName string) error {
 			continue
 		}
 
-		collectionName, err := util.UnescapeCollectionName(
+		collectionName, err := url.QueryUnescape(
 			fileName[:strings.LastIndex(fileName, ".bson")],
 		)
 		if err != nil {
@@ -505,8 +505,8 @@ func testQuery(t *testing.T, md *MongoDump, session *mongo.Client) string {
 	path, err := os.Getwd()
 	So(err, ShouldBeNil)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+	dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 	So(fileDirExists(dumpDir), ShouldBeTrue)
 	So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
@@ -534,11 +534,11 @@ func testDumpOneCollection(t *testing.T, md *MongoDump, dumpDir string) {
 	path, err := os.Getwd()
 	So(err, ShouldBeNil)
 
-	absDumpDir := util.ToUniversalPath(filepath.Join(path, dumpDir))
+	absDumpDir := filepath.FromSlash(filepath.Join(path, dumpDir))
 	So(os.RemoveAll(absDumpDir), ShouldBeNil)
 	So(fileDirExists(absDumpDir), ShouldBeFalse)
 
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 	So(fileDirExists(dumpDBDir), ShouldBeFalse)
 
 	md.OutputOptions.Out = dumpDir
@@ -747,8 +747,8 @@ func TestMongoDumpBSON(t *testing.T) {
 							path, err := os.Getwd()
 							So(err, ShouldBeNil)
 
-							dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-							dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+							dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+							dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 							So(fileDirExists(dumpDir), ShouldBeTrue)
 							So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
@@ -774,8 +774,8 @@ func TestMongoDumpBSON(t *testing.T) {
 							path, err := os.Getwd()
 							So(err, ShouldBeNil)
 
-							dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-							dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, "nottestdb"))
+							dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+							dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, "nottestdb"))
 
 							So(fileDirExists(dumpDir), ShouldBeFalse)
 							So(fileDirExists(dumpDBDir), ShouldBeFalse)
@@ -891,11 +891,11 @@ func TestMongoDumpBSONLongCollectionName(t *testing.T) {
 				path, err := os.Getwd()
 				So(err, ShouldBeNil)
 
-				absDumpDir := util.ToUniversalPath(filepath.Join(path, "dump_slash"))
+				absDumpDir := filepath.FromSlash(filepath.Join(path, "dump_slash"))
 				So(os.RemoveAll(absDumpDir), ShouldBeNil)
 				So(fileDirExists(absDumpDir), ShouldBeFalse)
 
-				dumpDBDir := util.ToUniversalPath(filepath.Join("dump_slash", testDB))
+				dumpDBDir := filepath.FromSlash(filepath.Join("dump_slash", testDB))
 				So(fileDirExists(dumpDBDir), ShouldBeFalse)
 
 				md.OutputOptions.Out = "dump_slash"
@@ -905,7 +905,7 @@ func TestMongoDumpBSONLongCollectionName(t *testing.T) {
 
 				Convey("to a bson file", func() {
 					oneBsonFile, err := os.Open(
-						util.ToUniversalPath(filepath.Join(dumpDBDir, longBsonName)),
+						filepath.FromSlash(filepath.Join(dumpDBDir, longBsonName)),
 					)
 					So(err, ShouldBeNil)
 					oneBsonFile.Close()
@@ -913,7 +913,7 @@ func TestMongoDumpBSONLongCollectionName(t *testing.T) {
 
 				Convey("to a metadata file", func() {
 					oneMetaFile, err := os.Open(
-						util.ToUniversalPath(filepath.Join(dumpDBDir, longMetadataName)),
+						filepath.FromSlash(filepath.Join(dumpDBDir, longMetadataName)),
 					)
 					So(err, ShouldBeNil)
 					oneMetaFile.Close()
@@ -941,7 +941,7 @@ func testPreludeMetadata(md *MongoDump, dir string, serverVersion string) {
 	}
 	So(fileDirExists(preludeFilepath), ShouldBeTrue)
 	var reader io.Reader
-	preludeFile, err := os.Open(util.ToUniversalPath(preludeFilepath))
+	preludeFile, err := os.Open(filepath.FromSlash(preludeFilepath))
 	So(err, ShouldBeNil)
 	reader = preludeFile
 	defer preludeFile.Close()
@@ -983,7 +983,7 @@ func TestDumpPreludeMetadataJson(t *testing.T) {
 			md.ToolOptions.Collection = ""
 
 			Convey("when dumping to the default directory", func() {
-				dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
+				dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
 				So(os.RemoveAll(dumpDir), ShouldBeNil)
 
 				Convey("writes prelude.json to dump directory", func() {
@@ -1001,7 +1001,7 @@ func TestDumpPreludeMetadataJson(t *testing.T) {
 			})
 
 			Convey("when output directory is specified", func() {
-				dumpDir := util.ToUniversalPath(filepath.Join(path, "dump_output"))
+				dumpDir := filepath.FromSlash(filepath.Join(path, "dump_output"))
 				So(os.RemoveAll(dumpDir), ShouldBeNil)
 
 				Convey("writes prelude.json to output directory", func() {
@@ -1019,8 +1019,8 @@ func TestDumpPreludeMetadataJson(t *testing.T) {
 			md, err := simpleMongoDumpInstance()
 			So(err, ShouldBeNil)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 			So(os.RemoveAll(dumpDir), ShouldBeNil)
 
 			Convey("writes prelude.json to dump directory", func() {
@@ -1034,8 +1034,8 @@ func TestDumpPreludeMetadataJson(t *testing.T) {
 
 		Convey("when the dump directory is not created", func() {
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, "nottestdb"))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, "nottestdb"))
 
 			Convey("the dump does not fail and prelude.json should not be created", func() {
 				md, err := simpleMongoDumpInstance()
@@ -1092,8 +1092,8 @@ func TestMongoDumpMetaData(t *testing.T) {
 
 			path, err := os.Getwd()
 			So(err, ShouldBeNil)
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 			So(fileDirExists(dumpDir), ShouldBeTrue)
 			So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
@@ -1112,7 +1112,7 @@ func TestMongoDumpMetaData(t *testing.T) {
 					So(len(metaFiles), ShouldBeGreaterThan, 0)
 
 					oneMetaFile, err := os.Open(
-						util.ToUniversalPath(filepath.Join(dumpDBDir, metaFiles[0])),
+						filepath.FromSlash(filepath.Join(dumpDBDir, metaFiles[0])),
 					)
 					defer oneMetaFile.Close()
 					So(err, ShouldBeNil)
@@ -1192,8 +1192,8 @@ func TestMongoDumpOplog(t *testing.T) {
 			path, err := os.Getwd()
 			So(err, ShouldBeNil)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpOplogFile := util.ToUniversalPath(filepath.Join(dumpDir, "oplog.bson"))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpOplogFile := filepath.FromSlash(filepath.Join(dumpDir, "oplog.bson"))
 
 			err = os.RemoveAll(dumpDir)
 			So(err, ShouldBeNil)
@@ -1457,7 +1457,7 @@ func TestMongoDumpOrderedQuery(t *testing.T) {
 		So(err, ShouldBeNil)
 		path, err := os.Getwd()
 		So(err, ShouldBeNil)
-		dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
+		dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
 
 		Convey("testing that --query is order-preserving", func() {
 			// If order is not preserved, probabilistically, some of these
@@ -1477,7 +1477,7 @@ func TestMongoDumpOrderedQuery(t *testing.T) {
 				err = md.Dump()
 				So(err, ShouldBeNil)
 
-				dumpBSON := util.ToUniversalPath(
+				dumpBSON := filepath.FromSlash(
 					filepath.Join(dumpDir, testDB, testCollectionNames[0]+".bson"),
 				)
 
@@ -1540,8 +1540,8 @@ func TestMongoDumpViewsAsCollections(t *testing.T) {
 			path, err := os.Getwd()
 			So(err, ShouldBeNil)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 			So(fileDirExists(dumpDir), ShouldBeTrue)
 			So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
@@ -1612,8 +1612,8 @@ func TestMongoDumpViews(t *testing.T) {
 			path, err := os.Getwd()
 			So(err, ShouldBeNil)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 			So(fileDirExists(dumpDir), ShouldBeTrue)
 			So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
@@ -1726,7 +1726,7 @@ func TestMongoDumpCollectionOutputPath(t *testing.T) {
 			assert.Len(t, fileComponents, 3)
 
 			filePath := fileComponents[len(fileComponents)-1]
-			assert.Equal(t, util.EscapeCollectionName(colName)[:208]+"%24", filePath[:211])
+			assert.Equal(t, url.QueryEscape(colName)[:208]+"%24", filePath[:211])
 
 			hashDecoded, _ := base64.RawURLEncoding.DecodeString(filePath[211:])
 			hash := sha1.Sum([]byte(colName))
@@ -1839,7 +1839,7 @@ func TestTimeseriesCollections(t *testing.T) {
 			path, err := os.Getwd()
 			require.NoError(t, err)
 
-			archiveFilePath := util.ToUniversalPath(filepath.Join(path, "dump.archive"))
+			archiveFilePath := filepath.FromSlash(filepath.Join(path, "dump.archive"))
 
 			archiveFile, err := os.Open(archiveFilePath)
 			require.NoError(t, err)
@@ -1928,14 +1928,14 @@ func TestTimeseriesCollections(t *testing.T) {
 			path, err := os.Getwd()
 			require.NoError(t, err)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, dbName))
-			metadataFile := util.ToUniversalPath(
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, dbName))
+			metadataFile := filepath.FromSlash(
 				filepath.Join(dumpDBDir, colName+".metadata.json"),
 			)
 
 			expectedCollFile := timeseriesCollName(serverVersion, colName)
-			bsonFile := util.ToUniversalPath(
+			bsonFile := filepath.FromSlash(
 				filepath.Join(dumpDBDir, expectedCollFile+".bson"),
 			)
 			assert.True(t, fileDirExists(dumpDir))
@@ -1990,7 +1990,7 @@ func TestTimeseriesCollections(t *testing.T) {
 			path, err := os.Getwd()
 			require.NoError(t, err)
 
-			archiveFilePath := util.ToUniversalPath(filepath.Join(path, "dump.archive"))
+			archiveFilePath := filepath.FromSlash(filepath.Join(path, "dump.archive"))
 
 			archiveFile, err := os.Open(archiveFilePath)
 			require.NoError(t, err)
@@ -2033,7 +2033,7 @@ func TestTimeseriesCollections(t *testing.T) {
 			path, err := os.Getwd()
 			require.NoError(t, err)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
 			assert.False(t, fileDirExists(dumpDir))
 
 			require.NoError(t, os.RemoveAll(dumpDir))
@@ -2078,12 +2078,12 @@ func TestTimeseriesCollections(t *testing.T) {
 			path, err := os.Getwd()
 			require.NoError(t, err)
 
-			dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-			dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, dbName))
-			metadataFile := util.ToUniversalPath(
+			dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+			dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, dbName))
+			metadataFile := filepath.FromSlash(
 				filepath.Join(dumpDBDir, colName+".metadata.json"),
 			)
-			bsonFile := util.ToUniversalPath(
+			bsonFile := filepath.FromSlash(
 				filepath.Join(dumpDBDir, timeseriesCollName(serverVersion, colName)+".bson"),
 			)
 			assert.True(t, fileDirExists(dumpDir))
@@ -2213,7 +2213,7 @@ func TestDumpTimeseriesCollectionsWithMixedSchema(t *testing.T) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	archiveFilePath := util.ToUniversalPath(filepath.Join(path, "dump.archive"))
+	archiveFilePath := filepath.FromSlash(filepath.Join(path, "dump.archive"))
 
 	archiveFile, err := os.Open(archiveFilePath)
 	require.NoError(t, err)
@@ -2499,8 +2499,8 @@ func dumpAndCheckPipelineOrder(t *testing.T, collName string, pipeline bson.A) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, "dump"))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
+	dumpDir := filepath.FromSlash(filepath.Join(path, "dump"))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
 	require.True(t, fileDirExists(dumpDir))
 	require.True(t, fileDirExists(dumpDBDir))
 
@@ -2508,7 +2508,7 @@ func dumpAndCheckPipelineOrder(t *testing.T, collName string, pipeline bson.A) {
 	require.NoError(t, err)
 	require.Equal(t, len(metaFiles), 1)
 
-	metaFile, err := os.Open(util.ToUniversalPath(filepath.Join(dumpDBDir, metaFiles[0])))
+	metaFile, err := os.Open(filepath.FromSlash(filepath.Join(dumpDBDir, metaFiles[0])))
 
 	require.NoError(t, err)
 	contents, err := io.ReadAll(metaFile)

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,9 +92,9 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, "vectored_inserts"))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
-	oplogFilePath := util.ToUniversalPath(filepath.Join(dumpDir, "oplog.bson"))
+	dumpDir := filepath.FromSlash(filepath.Join(path, "vectored_inserts"))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
+	oplogFilePath := filepath.FromSlash(filepath.Join(dumpDir, "oplog.bson"))
 	require.True(t, fileDirExists(dumpDir))
 	require.True(t, fileDirExists(dumpDBDir))
 	require.True(t, fileDirExists(oplogFilePath))
@@ -214,9 +213,9 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, "collMod_indexUniqueness"))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
-	oplogFilePath := util.ToUniversalPath(filepath.Join(dumpDir, "oplog.bson"))
+	dumpDir := filepath.FromSlash(filepath.Join(path, "collMod_indexUniqueness"))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
+	oplogFilePath := filepath.FromSlash(filepath.Join(dumpDir, "oplog.bson"))
 	require.True(t, fileDirExists(dumpDir))
 	require.True(t, fileDirExists(dumpDBDir))
 	require.True(t, fileDirExists(oplogFilePath))
@@ -378,9 +377,9 @@ func TestOplogDumpBypassDocumentValidation(t *testing.T) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, "oplog_bypassDocumentValidation"))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
-	oplogFilePath := util.ToUniversalPath(filepath.Join(dumpDir, "oplog.bson"))
+	dumpDir := filepath.FromSlash(filepath.Join(path, "oplog_bypassDocumentValidation"))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
+	oplogFilePath := filepath.FromSlash(filepath.Join(dumpDir, "oplog.bson"))
 	require.True(t, fileDirExists(dumpDir))
 	require.True(t, fileDirExists(dumpDBDir))
 	require.True(t, fileDirExists(oplogFilePath))
@@ -534,9 +533,9 @@ func TestOplogDumpCollModTTL(t *testing.T) {
 	path, err := os.Getwd()
 	require.NoError(t, err)
 
-	dumpDir := util.ToUniversalPath(filepath.Join(path, md.OutputOptions.Out))
-	dumpDBDir := util.ToUniversalPath(filepath.Join(dumpDir, testDB))
-	oplogFilePath := util.ToUniversalPath(filepath.Join(dumpDir, "oplog.bson"))
+	dumpDir := filepath.FromSlash(filepath.Join(path, md.OutputOptions.Out))
+	dumpDBDir := filepath.FromSlash(filepath.Join(dumpDir, testDB))
+	oplogFilePath := filepath.FromSlash(filepath.Join(dumpDir, "oplog.bson"))
 	require.True(t, fileDirExists(dumpDir))
 	require.True(t, fileDirExists(dumpDBDir))
 	require.True(t, fileDirExists(oplogFilePath))

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -206,7 +207,7 @@ func (dump *MongoDump) outputPath(dbName, colName string) string {
 	// than 255 bytes long. This includes the longest possible file extension: .metadata.json.gz
 	// The new format is <truncated-url-encoded-collection-name>%24<collection-name-hash-base64>
 	// where %24 represents a $ symbol delimiter (e.g. aVeryVery...VeryLongName%24oPpXMQ...).
-	escapedColName := util.EscapeCollectionName(colName)
+	escapedColName := url.QueryEscape(colName)
 	if len(escapedColName) > 238 {
 		colNameTruncated := escapedColName[:208]
 		// #nosec G401 -- we do not use this digest algorithm in a security-sensitive way.

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -239,7 +239,7 @@ func (exp *MongoExport) GetOutputWriter() (io.WriteCloser, error) {
 			return nil, err
 		}
 
-		file, err := os.Create(util.ToUniversalPath(exp.OutputOpts.OutputFile))
+		file, err := os.Create(filepath.FromSlash(exp.OutputOpts.OutputFile))
 		if err != nil {
 			return nil, err
 		}

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -1005,9 +1004,9 @@ func TestMongoFilesCommands(t *testing.T) {
 
 		Convey("Testing the 'put' command with multiple lorem ipsum files bytes should", func() {
 			localTestFiles := []string{
-				util.ToUniversalPath("testdata/lorem_ipsum_multi_args_0.txt"),
-				util.ToUniversalPath("testdata/lorem_ipsum_multi_args_1.txt"),
-				util.ToUniversalPath("testdata/lorem_ipsum_multi_args_2.txt"),
+				filepath.FromSlash("testdata/lorem_ipsum_multi_args_0.txt"),
+				filepath.FromSlash("testdata/lorem_ipsum_multi_args_1.txt"),
+				filepath.FromSlash("testdata/lorem_ipsum_multi_args_2.txt"),
 			}
 
 			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("put", localTestFiles...)
@@ -1213,7 +1212,7 @@ func runPutIDTestCase(idToTest string, t *testing.T) {
 
 	So(err, ShouldBeNil)
 	So(mongoFilesInstance, ShouldNotBeNil)
-	mongoFilesInstance.StorageOptions.LocalFileName = util.ToUniversalPath(
+	mongoFilesInstance.StorageOptions.LocalFileName = filepath.FromSlash(
 		"testdata/lorem_ipsum_287613_bytes.txt",
 	)
 
@@ -1242,7 +1241,7 @@ func runPutIDTestCase(idToTest string, t *testing.T) {
 	So(str, ShouldEqual, "")
 	So(buff.Len(), ShouldNotEqual, 0)
 
-	loremIpsumOrig, err := os.Open(util.ToUniversalPath("testdata/lorem_ipsum_287613_bytes.txt"))
+	loremIpsumOrig, err := os.Open(filepath.FromSlash("testdata/lorem_ipsum_287613_bytes.txt"))
 	So(err, ShouldBeNil)
 
 	loremIpsumCopy, err := os.Open("lorem_ipsum_copy.txt")

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -284,7 +284,7 @@ func (imp *MongoImport) validateSettings() error {
 // reader supports it.
 func (imp *MongoImport) getSourceReader() (io.ReadCloser, int64, error) {
 	if imp.InputOptions.File != "" {
-		file, err := os.Open(util.ToUniversalPath(imp.InputOptions.File))
+		file, err := os.Open(filepath.FromSlash(imp.InputOptions.File))
 		if err != nil {
 			return nil, -1, err
 		}

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -1372,10 +1371,10 @@ func nestedFieldsTestHelper(
 	expectedErr error,
 ) func() {
 	return func() {
-		err := os.WriteFile(util.ToUniversalPath("./temp_test_data.csv"), []byte(data), 0644)
+		err := os.WriteFile(filepath.FromSlash("./temp_test_data.csv"), []byte(data), 0644)
 		So(err, ShouldBeNil)
 		defer func() {
-			err = os.Remove(util.ToUniversalPath("./temp_test_data.csv"))
+			err = os.Remove(filepath.FromSlash("./temp_test_data.csv"))
 			So(err, ShouldBeNil)
 		}()
 

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -10,6 +10,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -259,7 +260,7 @@ func (restore *MongoRestore) getInfoFromFile(filename string) (string, FileType,
 	}
 
 	// Unescape the finalized collection name and return it.
-	unescapedCollName, err = util.UnescapeCollectionName(collName)
+	unescapedCollName, err = url.QueryUnescape(collName)
 	if err != nil {
 		return "", UnknownFileType, fmt.Errorf(
 			"error parsing collection name from filename %#q: %v",

--- a/mongorestore/filepath_test.go
+++ b/mongorestore/filepath_test.go
@@ -8,6 +8,7 @@ package mongorestore
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	commonOpts "github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
-	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/mongorestore/ns"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -375,7 +375,7 @@ func TestCreateIntentsForCollection(t *testing.T) {
 		log.SetWriter(&buff)
 
 		Convey("running CreateIntentForCollection on a file without metadata", func() {
-			ddl, err := newActualPath(util.ToUniversalPath("testdata/testdirs/db1/c2.bson"))
+			ddl, err := newActualPath(filepath.FromSlash("testdata/testdirs/db1/c2.bson"))
 			So(err, ShouldBeNil)
 			err = mr.CreateIntentForCollection("myDB", "myC", ddl)
 			So(err, ShouldBeNil)
@@ -386,7 +386,7 @@ func TestCreateIntentsForCollection(t *testing.T) {
 				So(i0, ShouldNotBeNil)
 				So(i0.DB, ShouldEqual, "myDB")
 				So(i0.C, ShouldEqual, "myC")
-				ddl, err := newActualPath(util.ToUniversalPath("testdata/testdirs/db1/c2.bson"))
+				ddl, err := newActualPath(filepath.FromSlash("testdata/testdirs/db1/c2.bson"))
 				So(err, ShouldBeNil)
 				So(i0.Location, ShouldEqual, ddl.Path())
 				i1 := mr.manager.Pop()
@@ -401,7 +401,7 @@ func TestCreateIntentsForCollection(t *testing.T) {
 		})
 
 		Convey("running CreateIntentForCollection on a file *with* metadata", func() {
-			ddl, err := newActualPath(util.ToUniversalPath("testdata/testdirs/db1/c1.bson"))
+			ddl, err := newActualPath(filepath.FromSlash("testdata/testdirs/db1/c1.bson"))
 			So(err, ShouldBeNil)
 			err = mr.CreateIntentForCollection("myDB", "myC", ddl)
 			So(err, ShouldBeNil)
@@ -412,7 +412,7 @@ func TestCreateIntentsForCollection(t *testing.T) {
 				So(i0, ShouldNotBeNil)
 				So(i0.DB, ShouldEqual, "myDB")
 				So(i0.C, ShouldEqual, "myC")
-				So(i0.Location, ShouldEqual, util.ToUniversalPath("testdata/testdirs/db1/c1.bson"))
+				So(i0.Location, ShouldEqual, filepath.FromSlash("testdata/testdirs/db1/c1.bson"))
 				i1 := mr.manager.Pop()
 				So(i1, ShouldBeNil)
 
@@ -420,7 +420,7 @@ func TestCreateIntentsForCollection(t *testing.T) {
 					So(
 						i0.MetadataLocation,
 						ShouldEqual,
-						util.ToUniversalPath("testdata/testdirs/db1/c1.metadata.json"),
+						filepath.FromSlash("testdata/testdirs/db1/c1.metadata.json"),
 					)
 					logs := buff.String()
 					So(strings.Contains(logs, "found metadata"), ShouldEqual, true)
@@ -478,7 +478,7 @@ func TestCreateIntentForCollectionTimeSeries(t *testing.T) {
 			"running CreateIntentForCollection on a system.buckets file *with* metadata",
 			func() {
 				ddl, err := newActualPath(
-					util.ToUniversalPath(
+					filepath.FromSlash(
 						"testdata/timeseries_tests/ts_dump/timeseries_test/system.buckets.foo_ts.bson",
 					),
 				)
@@ -503,7 +503,7 @@ func TestCreateIntentForCollectionTimeSeries(t *testing.T) {
 					So(i0, ShouldNotBeNil)
 					So(i0.DB, ShouldEqual, mr.ToolOptions.DB)
 					So(i0.C, ShouldEqual, "foo_ts")
-					So(i0.Location, ShouldEqual, util.ToUniversalPath(ddl.Path()))
+					So(i0.Location, ShouldEqual, filepath.FromSlash(ddl.Path()))
 					i1 := mr.manager.Pop()
 					So(i1, ShouldBeNil)
 
@@ -511,7 +511,7 @@ func TestCreateIntentForCollectionTimeSeries(t *testing.T) {
 						So(
 							i0.MetadataLocation,
 							ShouldEqual,
-							util.ToUniversalPath(
+							filepath.FromSlash(
 								"testdata/timeseries_tests/ts_dump/timeseries_test/foo_ts.metadata.json",
 							),
 						)
@@ -538,7 +538,7 @@ func TestCreateIntentForCollectionTimeSeries(t *testing.T) {
 							So(
 								i0.MetadataLocation,
 								ShouldEqual,
-								util.ToUniversalPath(
+								filepath.FromSlash(
 									"testdata/timeseries_tests/ts_dump/timeseries_test/foo_ts.metadata.json",
 								),
 							)
@@ -574,7 +574,7 @@ func TestCreateIntentsForLongCollectionName(t *testing.T) {
 			"running CreateIntentForCollection on a truncated bson file without metadata",
 			func() {
 				ddl, err := newActualPath(
-					util.ToUniversalPath("testdata/longcollectionname/" + longInvalidBson),
+					filepath.FromSlash("testdata/longcollectionname/" + longInvalidBson),
 				)
 				So(err, ShouldBeNil)
 				err = mr.CreateIntentForCollection("myDB", "myC", ddl)
@@ -589,7 +589,7 @@ func TestCreateIntentsForLongCollectionName(t *testing.T) {
 			"running CreateIntentForCollection on a truncated bson file *with* metadata",
 			func() {
 				ddl, err := newActualPath(
-					util.ToUniversalPath("testdata/longcollectionname/db1/" + longBsonName),
+					filepath.FromSlash("testdata/longcollectionname/db1/" + longBsonName),
 				)
 				So(err, ShouldBeNil)
 				err = mr.CreateIntentForCollection("myDB", "myC", ddl)
@@ -604,7 +604,7 @@ func TestCreateIntentsForLongCollectionName(t *testing.T) {
 					So(
 						i0.Location,
 						ShouldEqual,
-						util.ToUniversalPath("testdata/longcollectionname/db1/"+longBsonName),
+						filepath.FromSlash("testdata/longcollectionname/db1/"+longBsonName),
 					)
 					i1 := mr.manager.Pop()
 					So(i1, ShouldBeNil)
@@ -613,7 +613,7 @@ func TestCreateIntentsForLongCollectionName(t *testing.T) {
 						So(
 							i0.MetadataLocation,
 							ShouldEqual,
-							util.ToUniversalPath(
+							filepath.FromSlash(
 								"testdata/longcollectionname/db1/"+longMetadataName,
 							),
 						)

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -8,11 +8,11 @@ package mongorestore
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/util"
 )
 
 // Usage describes basic usage of mongorestore.
@@ -175,7 +175,7 @@ func ParseOptions(rawArgs []string, versionStr, gitCommit string) (Options, erro
 	if err != nil {
 		return Options{}, fmt.Errorf("error parsing positional arguments: %v", err)
 	}
-	targetDir = util.ToUniversalPath(targetDir)
+	targetDir = filepath.FromSlash(targetDir)
 
 	wc, err := db.NewMongoWriteConcern(outputOpts.WriteConcern, opts.ParsedConnString())
 	if err != nil {


### PR DESCRIPTION
These wrappers are one line wrappers for existing stdlib funcs. This removes them and just calls the stdlib directly.