### PR TITLE
TOOLS-4276 Mark `vendor` dir as generated and add lint check that vendored code is not modified in a branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Force gpm to always have lf endings even on Windows
 gpm text eol=lf
+vendor/** linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,9 @@ or update tools. But we _also_ manage these in CI via code in `buildscript`, so 
 in sync with the `mise.toml` file.
 
 ```bash
-go run build.go sa:lint      # runs precious (golangci-lint, gosec, goimports, golines)
-go run build.go sa:modtidy   # go mod tidy
+go run build.go sa:lint              # runs precious (golangci-lint, gosec, goimports, golines)
+go run build.go sa:modtidy           # go mod tidy
+go run build.go sa:checkVendoredCode # checks for unexpected changes under vendor/
 ```
 
 ## Code Conventions

--- a/build.go
+++ b/build.go
@@ -51,6 +51,9 @@ func init() {
 	taskRegistry.Declare("sa:modtidy").
 		Description("runs go mod tidy").
 		Do(buildscript.SAModTidy)
+	taskRegistry.Declare("sa:checkVendoredCode").
+		Description("checks that vendored code has no unexpected local changes").
+		Do(buildscript.SACheckVendoredCode)
 
 	// Testing
 	taskRegistry.Declare("test:unit").

--- a/buildscript/sa.go
+++ b/buildscript/sa.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 
 	"github.com/craiggwilson/goke/pkg/sh"
 	"github.com/craiggwilson/goke/task"
@@ -67,4 +68,38 @@ func SAModTidy(ctx *task.Context) error {
 	}
 
 	return nil
+}
+
+var modulesTxtRE = regexp.MustCompile(`(?m)^vendor/modules\.txt$`)
+
+// SACheckVendoredCode checks that vendored code does not have any unexpected changes. An
+// "unexpected" change is one that is not accompanied by a change to `vendor/modules.txt`.
+//
+// The goal of this check is to catch debugging changes made locally to vendored code that get
+// accidentally committed as part of a PR.
+func SACheckVendoredCode(ctx *task.Context) error {
+	base := os.Getenv("EVG_BRANCH_NAME")
+	if base == "" {
+		base = "master"
+	}
+
+	refspec := fmt.Sprintf("%s...HEAD", base)
+
+	out, err := sh.RunOutput(ctx, "git", "diff", "--name-only", refspec, "vendor")
+	if err != nil {
+		return fmt.Errorf("error running `git diff --name-only %s vendor`: %w", refspec, err)
+	}
+
+	if out == "" {
+		return nil
+	}
+
+	if modulesTxtRE.MatchString(out) {
+		return nil
+	}
+
+	return errors.New(
+		"there is a change in vendor/ but not in vendor/modules.txt;" +
+			" does this PR contain some debugging cruft?",
+	)
 }

--- a/common.yml
+++ b/common.yml
@@ -234,6 +234,7 @@ functions:
         args:
           - "./scripts/run-make-target.sh"
         env:
+          EVG_BRANCH_NAME: ${branch_name}
           EVG_BUILD_VARIANT: ${build_variant}
           EVG_PLATFORM: ${_platform}
           EVG_WORKDIR: ${workdir}
@@ -2624,6 +2625,14 @@ tasks:
 
             git diff --exit-code
 
+  - name: check-vendored-code
+    commands:
+      - func: "fetch source"
+      - func: "install mise and go"
+      - func: "run make target"
+        vars:
+          target: sa:checkVendoredCode
+
   - name: check-sbom-lite
     commands:
       - func: "fetch source"
@@ -2651,6 +2660,7 @@ buildvariants:
     tasks:
       - name: lint
       - name: mod-tidy
+      - name: check-vendored-code
       - name: check-third-party-notices
       - name: check-sbom-lite
       - name: check-sarif-report


### PR DESCRIPTION
Marking it as generated means that GitHub will hide diffs in that part of the tree by default. But we also want to make sure that we don't accidentally commit local changes to vendored code.