### PR TITLE
DEVPROD-34208: use DevProd Platforms ECR for Silkbomb and signing images

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -449,6 +449,10 @@ functions:
         bucket: mciuploads
 
   "sign artifacts":
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to pull from DevProd Platforms ECR
+      params:
+        role_arn: ${devprod_platforms_ecr_readonly_role_arn}
     - command: subprocess.exec
       params:
         # binary must be bash (with the script passed via args), not the script
@@ -457,9 +461,8 @@ functions:
         working_dir: src/github.com/mongodb/mongo-tools
         args:
           - "./scripts/sign_artifacts.sh"
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
         env:
-          ARTIFACTORY_PASSWORD: ${artifactory_password}
-          ARTIFACTORY_USERNAME: ${artifactory_username}
           AUTHENTICODE_KEY_NAME: ${authenticode_key_name}
           EVG_TASK_ID: ${task_id}
           EVG_TRIGGERED_BY_TAG: ${triggered_by_git_tag}
@@ -739,6 +742,7 @@ functions:
         args:
           - "./scripts/regenerate-and-diff-sbom-lite.sh"
         env:
+          EVG_TASK_ID: ${task_id}
           EVG_WORKDIR: ${workdir}
 
   "check sarif report":
@@ -792,6 +796,24 @@ functions:
       params:
         file: kondukto_token.yml
         redact_file_expansions: true
+
+  "login to devprod platforms ecr":
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to pull from DevProd Platforms ECR
+      params:
+        role_arn: ${devprod_platforms_ecr_readonly_role_arn}
+    - command: shell.exec
+      display_name: Log in to DevProd Platforms ECR
+      params:
+        shell: bash
+        silent: true
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
+        script: |
+          set -o errexit
+          set -o pipefail
+
+          aws ecr get-login-password --region us-east-1 |
+              podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
 pre:
   - command: shell.exec
@@ -956,6 +978,7 @@ tasks:
       - func: "fetch source"
       - command: expansions.update
       - func: "set silkbomb credentials"
+      - func: "login to devprod platforms ecr"
       - func: "install mise and go"
       - command: subprocess.exec
         params:
@@ -967,6 +990,7 @@ tasks:
             - "./scripts/regenerate-and-diff-augmented-sbom.sh"
           include_expansions_in_env: [KONDUKTO_TOKEN]
           env:
+            EVG_TASK_ID: ${task_id}
             EVG_TRIGGERED_BY_TAG: ${triggered_by_git_tag}
 
   - name: release-json
@@ -2627,6 +2651,7 @@ tasks:
   - name: check-sbom-lite
     commands:
       - func: "fetch source"
+      - func: "login to devprod platforms ecr"
       - func: "install mise and go"
       - func: "check sbom lite"
 

--- a/scripts/regenerate-augmented-sbom.sh
+++ b/scripts/regenerate-augmented-sbom.sh
@@ -4,6 +4,15 @@ set -e
 set -x
 set -o pipefail
 
+# In CI, authentication with the DevProd Platforms ECR registry happens once
+# at the Evergreen task level before this script runs. Locally, we log in
+# here using a named AWS SSO profile.
+if [ -z "${EVG_TASK_ID:-}" ]; then
+    profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+    aws ecr get-login-password --region us-east-1 --profile "$profile" |
+        podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+fi
+
 TAG="$EVG_TRIGGERED_BY_TAG"
 if [ -z "$TAG" ]; then
     echo "Cannot regenerate the Augmented SBOM file without a tag"
@@ -30,7 +39,7 @@ podman run \
     --platform linux/amd64 \
     -v "${PWD}":/pwd \
     --env-file silkbomb.env \
-    artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
+    901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
     augment \
     --sbom-in /pwd/cyclonedx.sbom.json \
     --repo mongodb/mongo-tools \

--- a/scripts/regenerate-sbom-lite.sh
+++ b/scripts/regenerate-sbom-lite.sh
@@ -4,6 +4,15 @@ set -e
 set -o pipefail
 set -x
 
+# In CI, authentication with the DevProd Platforms ECR registry happens once
+# at the Evergreen task level before this script runs. Locally, we log in
+# here using a named AWS SSO profile.
+if [ -z "${EVG_TASK_ID:-}" ]; then
+    profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+    aws ecr get-login-password --region us-east-1 --profile "$profile" |
+        podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+fi
+
 rm -f purls.txt
 
 BINARY_DIRS="$(mise exec go -- go run release/release.go print-binary-paths)"
@@ -44,7 +53,7 @@ podman run \
     --rm \
     --platform linux/amd64 \
     -v "${PWD}":/pwd \
-    artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
+    901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
     update \
     --sbom-in /pwd/cyclonedx.sbom.json \
     --purls /pwd/purls.txt \

--- a/scripts/sign_artifacts.sh
+++ b/scripts/sign_artifacts.sh
@@ -11,7 +11,7 @@ pgp_sign() {
         --rm \
         --volume "$PWD:$PWD" \
         --workdir "$PWD" \
-        artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-gpg \
+        901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-gpg \
         /bin/bash -c "gpgloader && gpg --yes -v --armor -o ${signature_name} --detach-sign ${file_name}"
 }
 
@@ -23,14 +23,14 @@ authenticode_sign() {
         --rm \
         --volume "$PWD:$PWD" \
         --workdir "$PWD" \
-        artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
+        901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-jsign \
         /bin/bash -c "jsign -a ${AUTHENTICODE_KEY_NAME} --replace --tsaurl http://timestamp.digicert.com -d SHA-256 ${file_name}"
 }
 
 setup_garasign_authentication() {
     set +x
 
-    echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+    aws ecr get-login-password --region us-east-1 | podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
     echo "GRS_CONFIG_USER1_USERNAME=${GARASIGN_USERNAME}" >>"signing-envfile"
     echo "GRS_CONFIG_USER1_PASSWORD=${GARASIGN_PASSWORD}" >>"signing-envfile"


### PR DESCRIPTION
MongoDB Artifactory will be deprecated soon, so the Silkbomb and signing images must be pulled from ECR instead.