### PR TITLE
TOOLS-4279 Update 9.0 version to 9.0.0-rc0

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1765,7 +1765,7 @@ tasks:
       - func: "install mise and go"
       - func: "download mongod and shell"
         vars:
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "start mongod"
         vars:
           USE_TLS: "true"
@@ -1792,7 +1792,7 @@ tasks:
       - func: "install mise and go"
       - func: "download mongod and shell"
         vars:
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "start mongod"
         vars:
           USE_TLS: "true"
@@ -1817,7 +1817,7 @@ tasks:
       - func: "install mise and go"
       - func: "download mongod and shell"
         vars:
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "create repl_set"
         vars:
           USE_TLS: "true"
@@ -1838,7 +1838,7 @@ tasks:
       - func: "download mongod and shell"
         vars:
           edition: "enterprise"
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "start mongod"
         vars:
           AWS_AUTH: "true"
@@ -2291,7 +2291,7 @@ tasks:
       - func: "install mise and go"
       - func: "download mongod and shell"
         vars:
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "run make target"
         vars:
           target: build
@@ -2479,7 +2479,7 @@ tasks:
       - func: "install mise and go"
       - func: "download mongod and shell"
         vars:
-          mongo_version: "9.0.0-alpha2"
+          mongo_version: "9.0.0-rc0"
       - func: "run make target"
         vars:
           target: build

--- a/test/shell_common/libs/parallelTester-9.0.js
+++ b/test/shell_common/libs/parallelTester-9.0.js
@@ -1,5 +1,4 @@
-// parallelTester.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1 (the closest
-// published 9.0 source tag; the 9.0.0-alpha2 server binary we test against has no source tag).
+// parallelTester.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1.
 export var Thread;
 
 if (typeof _threadInject != "undefined") {

--- a/test/shell_common/libs/replsettest-9.0.js
+++ b/test/shell_common/libs/replsettest-9.0.js
@@ -1,6 +1,4 @@
-/* Changes to replsettest.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1 (the
- * closest published 9.0 source tag; the 9.0.0-alpha2 server binary we test against has no
- * source tag).
+/* Changes to replsettest.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1.
  * 1. Change the `Thread` import path to the vendored parallelTester-9.0.js.
  * 2. Replace the top-level (load-time) imports that reference server jstest libraries not
  *    vendored into mongo-tools (fail_point_util.js, hook_appname.js, replicated_truncates_utils.js)

--- a/test/shell_common/libs/shardingtest-9.0.js
+++ b/test/shell_common/libs/shardingtest-9.0.js
@@ -1,6 +1,4 @@
-/* Changes to shardingtest.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1 (the
- * closest published 9.0 source tag; the 9.0.0-alpha2 server binary we test against has no
- * source tag).
+/* Changes to shardingtest.js copied over from mongodb/mongo repo at tag r9.0.0-alpha1.
  * 1. Replace the top-level imports of server jstest libraries not vendored into mongo-tools
  *    (viewless_timeseries_util.js -> getTimeseriesCollForDDLOps, feature_flag_util.js ->
  *    FeatureFlagUtil) with minimal local implementations. These are only referenced on code


### PR DESCRIPTION
The version we were using was being downloaded from a previous Evergreen build which has now been purged.