### PR TITLE
Upgrade to Go 1.26.5

### DIFF
--- a/cyclonedx.sbom.json
+++ b/cyclonedx.sbom.json
@@ -750,17 +750,17 @@
       "version": "v2.4.0"
     },
     {
-      "bom-ref": "pkg:golang/std@go1.26.4",
+      "bom-ref": "pkg:golang/std@go1.26.5",
       "externalReferences": [
         {
           "type": "website",
-          "url": "https://pkg.go.dev/None/std@go1.26.4"
+          "url": "https://pkg.go.dev/None/std@go1.26.5"
         }
       ],
       "name": "std",
-      "purl": "pkg:golang/std@go1.26.4",
+      "purl": "pkg:golang/std@go1.26.5",
       "type": "library",
-      "version": "go1.26.4"
+      "version": "go1.26.5"
     }
   ],
   "dependencies": [
@@ -855,11 +855,11 @@
       "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
     },
     {
-      "ref": "pkg:golang/std@go1.26.4"
+      "ref": "pkg:golang/std@go1.26.5"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-29T18:44:32.731971+00:00",
+    "timestamp": "2026-07-27T17:14:08.541243+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -903,7 +903,7 @@
     ]
   },
   "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
-  "version": 46,
+  "version": 47,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongo-tools
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@
 
 [tools]
 # Go and Go tools
-go = "1.26.4"
+go = "1.26.5"
 "go:golang.org/x/tools/cmd/goimports" = "0.29.0"
 "go:golang.org/x/tools/gopls" = "0.21.1"
 "github:golangci/golangci-lint" = "2.12.2"


### PR DESCRIPTION
This Go release includes a fix for CVE-2026-42505.