### PR TITLE
TOOLS-4294 linuxRelease: fix push task for weird architectures

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1312,9 +1312,17 @@ func linuxRelease(v version.Version) {
 	tasks, err := evergreen.GetTasksForBuild(buildID)
 	check(err, "get evergreen tasks")
 
+	var distTaskName string
+	switch pf.Arch {
+	case platform.ArchS390x, platform.ArchPpc64le:
+		distTaskName = "dist-without-mise"
+	default:
+		distTaskName = "dist"
+	}
+
 	distTasks := []evergreen.Task{}
 	for _, task := range tasks {
-		if task.IsPatch() || task.DisplayName != "dist" {
+		if task.IsPatch() || task.DisplayName != distTaskName {
 			continue
 		}
 


### PR DESCRIPTION
This was broken by 9d47eccb (TOOLS-4102 Use `mise` to execute `go` as well as other dev tools, 2026-07-07); on ppc64le and s390x architectures, we don't use `mise`, and so the "dist" task name on those platforms is actually "dist-without-mise". The code in the `push` task was looking for the hard-coded "dist" name, and so was failing with the new name.