### PR TITLE
TOOLS-4295 Call go via $GO_EXEC_PREFIX in build-mongodump-and-mongorestore.sh

### DIFF
--- a/scripts/build-mongodump-and-mongorestore.sh
+++ b/scripts/build-mongodump-and-mongorestore.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(dirname "$0")
 # shellcheck source=scripts/ci-env.sh
 . "$SCRIPT_DIR/ci-env.sh"
 
-go run build.go -v build
+$GO_EXEC_PREFIX go run build.go -v build
 # Copy mongodump and mongorestore to mongosync/dist
 mkdir -p "$EVG_WORKDIR/src/mongosync/dist"
 cp -p bin/mongodump bin/mongorestore "$EVG_WORKDIR/src/mongosync/dist"


### PR DESCRIPTION
scripts/ci-env.sh does not put go on PATH on architectures where mise manages the toolchain; it exports GO_EXEC_PREFIX="mise exec go --" and expects callers to use it, as scripts/run-make-target.sh does. So the bare "go run build.go" here failed with "go: command not found", breaking compile_coverage on the mongodump_passthru_v variant. That variant only runs on ad hoc and patch requesters, so the waterfall never caught it.

$GO_EXEC_PREFIX is unquoted so that it word-splits, and is empty on ppc64le/s390x, where we manage the Go toolchain ourselves and go is on PATH.