### PR TITLE
TOOLS-4296 Annotate HTTP and S3 errors when downloading a server package

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -10,6 +10,8 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/json"
+	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1498,6 +1500,58 @@ func downloadMongodAndShell(v string) {
 	}
 }
 
+// s3ErrorResponse is the XML document S3 serves in place of the requested object when a
+// request fails. Presigned URLs from Evergreen artifacts are served by S3, so this is what
+// comes back when, say, the credentials they were signed with have been rotated away.
+type s3ErrorResponse struct {
+	Code      string `xml:"Code"`
+	Message   string `xml:"Message"`
+	RequestID string `xml:"RequestId"`
+}
+
+// s3CredentialErrorCodes are the S3 error codes that mean the request was not accepted,
+// as opposed to the object being missing or the service being unhappy.
+var s3CredentialErrorCodes = mapset.NewSet(
+	"AccessDenied",
+	"ExpiredToken",
+	"InvalidAccessKeyId",
+	"InvalidToken",
+	"RequestTimeTooSkewed",
+	"SignatureDoesNotMatch",
+	"TokenRefreshRequired",
+)
+
+// checkDownloadResponse returns an error describing why a download did not return the
+// artifact, or nil if it did.
+func checkDownloadResponse(res *http.Response) error {
+	if res.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	// An error body is a short XML or HTML document. Anything longer is not something we
+	// want in a log line, and we already have the status to report.
+	body, err := io.ReadAll(io.LimitReader(res.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("got %s and could not read the response body: %w", res.Status, err)
+	}
+
+	var s3Err s3ErrorResponse
+	if xml.Unmarshal(body, &s3Err) != nil || s3Err.Code == "" {
+		return fmt.Errorf("got %s: %s", res.Status, strings.TrimSpace(string(body)))
+	}
+
+	msg := fmt.Sprintf("got %s from S3: %s: %s", res.Status, s3Err.Code, s3Err.Message)
+	if s3Err.RequestID != "" {
+		msg += fmt.Sprintf(" (request ID %s)", s3Err.RequestID)
+	}
+	if s3CredentialErrorCodes.Contains(s3Err.Code) {
+		msg += ". The AWS credentials the URL was signed with are not valid, which is a" +
+			" problem with the credentials rather than with this build"
+	}
+
+	return errors.New(msg)
+}
+
 func downloadBinaries(url string) {
 	tempDir, err := os.MkdirTemp("bin", "")
 	check(err, "create temp dir")
@@ -1511,6 +1565,11 @@ func downloadBinaries(url string) {
 
 	res, err := http.Get(url)
 	check(err, "get the server package")
+	defer res.Body.Close()
+
+	// Without this, an error response gets written to disk and then fails much later as a
+	// corrupt archive, which says nothing about why the download did not work.
+	check(checkDownloadResponse(res), "download %s", filename)
 
 	_, err = io.Copy(packageFile, res.Body)
 	check(err, "write server package file")

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -1,13 +1,76 @@
 package main
 
 import (
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func TestCheckDownloadResponse(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	newResponse := func(status int, body string) *http.Response {
+		return &http.Response{
+			StatusCode: status,
+			Status:     http.StatusText(status),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
+
+	t.Run("a successful response is not an error", func(t *testing.T) {
+		require.NoError(t, checkDownloadResponse(newResponse(http.StatusOK, "")))
+	})
+
+	t.Run("an S3 credential error explains that the credentials are at fault", func(t *testing.T) {
+		err := checkDownloadResponse(
+			newResponse(http.StatusForbidden, `<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>InvalidAccessKeyId</Code><Message>The AWS Access Key Id you provided does not exist in our records.</Message><RequestId>YPJR6F724JWN7314</RequestId></Error>`),
+		)
+
+		require.ErrorContains(t, err, "InvalidAccessKeyId", "reports the S3 error code")
+		require.ErrorContains(
+			t,
+			err,
+			"The AWS Access Key Id you provided does not exist in our records.",
+			"reports the S3 error message",
+		)
+		require.ErrorContains(t, err, "YPJR6F724JWN7314", "reports the S3 request ID")
+		require.ErrorContains(
+			t,
+			err,
+			"problem with the credentials rather than with this build",
+			"says that the credentials are at fault",
+		)
+	})
+
+	t.Run("a non-credential S3 error does not blame the credentials", func(t *testing.T) {
+		err := checkDownloadResponse(
+			newResponse(http.StatusNotFound, `<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>`),
+		)
+
+		require.ErrorContains(t, err, "NoSuchKey", "reports the S3 error code")
+		require.NotContains(
+			t,
+			err.Error(),
+			"problem with the credentials",
+			"does not say that the credentials are at fault",
+		)
+	})
+
+	t.Run("a response that is not S3 XML reports the status and body", func(t *testing.T) {
+		err := checkDownloadResponse(newResponse(http.StatusBadGateway, "upstream is down"))
+
+		require.ErrorContains(t, err, "Bad Gateway", "reports the HTTP status")
+		require.ErrorContains(t, err, "upstream is down", "reports the response body")
+	})
+}
 
 func TestRepoConfig(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)


### PR DESCRIPTION
downloadBinaries did not check the response status, so an S3 error document was written to disk as if it were the server archive. The failure only surfaced much later, when extracting the "archive" failed, and said nothing about why the download had not worked.

This change checks the status up front and report what came back. S3 serves a small XML document describing the error, so parse that and include its code, message and request ID. When the code is one that means the request itself was rejected, say that the credentials the presigned URL was signed with are at fault rather than the build, which is what an Evergreen artifact URL looks like after an AWS credential rotation.