### PR TITLE
TOOLS-4293 Restart mongod in oplog_replay_local_rs.js so the fake oplog is visible

### DIFF
--- a/test/qa-tests/jstests/restore/oplog_replay_local_rs.js
+++ b/test/qa-tests/jstests/restore/oplog_replay_local_rs.js
@@ -36,6 +36,26 @@
     assert.eq(1, r.nInserted, "insert failed");
   }
 
+  // The server sets the timestamp up to which the oplog is visible when it starts up,
+  // and inserting into local.oplog.rs directly never advances it. As of MongoDB 9.0, a
+  // forward scan of the oplog stops at that timestamp, so the entries we just wrote are
+  // invisible to mongodump until the server restarts and sets the timestamp from the
+  // last entry in the oplog. Restarting keeps the same port and dbpath, so the fake
+  // oplog is still there afterwards.
+  //
+  // The suites that run this test get ToolTest from the mongo shell, not from
+  // jstests/libs/servers_misc.js, so this cannot be moved into a ToolTest method there.
+  // ToolTest.stop() is the way to stop the mongod here: toolTest.m is a connection, which
+  // MongoRunner.stopMongod rejects because it has no 'port' property. stop() clears
+  // toolTest.m/db, so startDB() can reuse the same port and dbpath. It also prints
+  // "completed successfully", which is premature but harmless.
+  toolTest.stop();
+  toolTest.startDB();
+
+  // Connections made before the restart are no longer usable.
+  testRestoreDB = toolTest.db.getSiblingDB('test');
+  testRestoreColl = testRestoreDB.op;
+
   // Dump the fake oplog.
   var ret = toolTest.runTool.apply(toolTest, ['dump',
     '--db', 'local',


### PR DESCRIPTION
This test fakes a replica set oplog by inserting directly into local.oplog.rs on a standalone mongod. The server sets the timestamp up to which the oplog is visible at startup, and those direct inserts never advance it. As of MongoDB 9.0 a forward scan of the oplog stops at that timestamp, so mongodump saw an empty oplog and the test failed.

Restarting the mongod makes the server set the visibility timestamp from the last entry in the oplog. The restart reuses the same port and dbpath, so the fake oplog survives it, and the connections the test opened beforehand are re-established afterwards.

The restart goes through ToolTest.stop() and startDB(): the suites that run this test get ToolTest from the mongo shell rather than from jstests/libs/servers_misc.js, and MongoRunner.stopMongod cannot be used because toolTest.m is a connection with no 'port' property.