### PR TITLE
TOOLS-4278 Convert mongofiles write concern tests to testify

### DIFF
--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -1178,23 +1178,25 @@ func TestDefaultWriteConcern(t *testing.T) {
 		t.Skip("Skipping non-SSL test with SSL configuration")
 	}
 
-	Convey("with a URI that doesn't specify write concern", t, func() {
+	t.Run("with a URI that doesn't specify write concern", func(t *testing.T) {
 		mf, err := getMongofilesWithArgs("get", "filename", "--uri", "mongodb://localhost:33333")
-		So(err, ShouldBeNil)
-		So(
-			mf.ToolOptions.WriteConcern,
-			ShouldResemble,
+		require.NoError(t, err, "should build mongofiles from a URI")
+		assert.Equal(
+			t,
 			writeconcern.Majority(),
+			mf.ToolOptions.WriteConcern,
+			"should default to majority write concern",
 		)
 	})
 
-	Convey("with no URI and no write concern option", t, func() {
+	t.Run("with no URI and no write concern option", func(t *testing.T) {
 		mf, err := getMongofilesWithArgs("get", "filename", "--port", "33333")
-		So(err, ShouldBeNil)
-		So(
-			mf.ToolOptions.WriteConcern,
-			ShouldResemble,
+		require.NoError(t, err, "should build mongofiles from a port")
+		assert.Equal(
+			t,
 			writeconcern.Majority(),
+			mf.ToolOptions.WriteConcern,
+			"should default to majority write concern",
 		)
 	})
 }


### PR DESCRIPTION
Converts TestDefaultWriteConcern's two Convey blocks to subtests.
TestValidArguments above it was already testify, and
TestMongoFilesCommands below it stays on GoConvey for now, so the
dot-import remains.

runPutIDTestCase sits just after this function in the file but is called
only from TestMongoFilesCommands, so it is left for that conversion
rather than taken by line position.

This test already fails, before and after: it compares
mf.ToolOptions.WriteConcern, a *wcwrapper.WriteConcern, against
writeconcern.Majority(), which returns a *writeconcern.WriteConcern. The
two can never be deeply equal regardless of the values inside. The
failure is preserved exactly and recorded for follow-up.

4 assertions before and after. No behavior change.