### PR TITLE
TOOLS-4310 drop ident oplog

### DIFF
--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mongodb/mongo-tools/common"
 	"github.com/mongodb/mongo-tools/common/archive"
@@ -2561,4 +2562,229 @@ func TestBrokenPipe(t *testing.T) {
 	)
 	args = append(args, "--db", dbName, "--archive=-")
 	testutil.AssertBrokenPipeHandled(t, exec.Command("go", args...))
+}
+
+// TestTimeseriesDumpConcurrentWithSetFCV exercises the open item from the TOOLS-4182
+// investigation: a long-running mongodump that overlaps a setFCV, which on 9.0+ converts
+// timeseries collections between their viewless and viewful forms (SERVER-114505). The
+// server does not currently expect the collection format to change mid-operation, so the
+// point of this test is to pin down that the dump either completes with every measurement
+// or fails outright — it must never silently produce a truncated dump.
+func TestTimeseriesDumpConcurrentWithSetFCV(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	ctx := t.Context()
+
+	session, err := testutil.GetBareSession()
+	require.NoError(t, err, "get session")
+
+	sp, _, err := testutil.GetBareSessionProvider()
+	require.NoError(t, err, "get session provider")
+
+	serverVersion, err := sp.ServerVersionArray()
+	require.NoError(t, err, "get server version")
+	if serverVersion.LT(db.Version{9, 0, 0}) {
+		t.Skipf(
+			"the viewless timeseries conversion requires a 9.0 server; found %v",
+			serverVersion,
+		)
+	}
+
+	fcv := testutil.GetFCV(session)
+	if cmp, err := testutil.CompareFCV(fcv, "9.0"); err != nil || cmp < 0 {
+		t.Skipf("Requires FCV 9.0 so that setFCV downgrades to a viewful format; found %v", fcv)
+	}
+
+	const dbName = "ts_setfcv_test_DB"
+	const collName = "timeseriesColl"
+	// Enough distinct meta values to produce more buckets than fit in one cursor batch, so
+	// the dump must issue a getMore that we can block on.
+	const numBuckets = 500
+
+	require.NoError(t, session.Database(dbName).Drop(ctx))
+	t.Cleanup(func() { _ = session.Database(dbName).Drop(context.Background()) })
+
+	setUpBucketedTimeseries(t, session, dbName, collName, numBuckets)
+
+	// The failpoint targets this app name only, so the test's own commands — including the
+	// setFCV below — are not blocked.
+	const dumpAppName = "mongodump_setfcv_test"
+
+	md, err := simpleMongoDumpInstance()
+	require.NoError(t, err)
+	md.ToolOptions.DB = dbName
+	md.ToolOptions.AppName = dumpAppName
+	md.OutputOptions.Out = t.TempDir()
+
+	require.NoError(t, md.Init())
+
+	blockGetMoreForAppName(t, session, dumpAppName)
+
+	dumpErr := make(chan error, 1)
+	go func() { dumpErr <- md.Dump() }()
+
+	waitForBlockedGetMore(t, session, dumpAppName)
+
+	// This is the conversion under test: downgrading from 9.0 turns the viewless timeseries
+	// collection back into a view plus a system.buckets collection, underneath the dump.
+	var fcvResult bson.D
+	setFCVErr := session.Database("admin").RunCommand(ctx, bson.D{
+		{"setFeatureCompatibilityVersion", "8.0"},
+		{"confirm", true},
+	}).Decode(&fcvResult)
+	t.Cleanup(func() {
+		_ = session.Database("admin").RunCommand(context.Background(), bson.D{
+			{"setFeatureCompatibilityVersion", "9.0"},
+			{"confirm", true},
+		}).Err()
+	})
+
+	err = <-dumpErr
+
+	// A failed setFCV means the conversion never happened, so there is nothing to assert.
+	require.NoError(t, setFCVErr, "setFCV should succeed while a dump is running")
+
+	if err != nil {
+		// The server interrupts reads whose collection is converted underneath them, and
+		// mongodump surfaces that as a dump failure. Losing the race is the expected outcome;
+		// what matters is that it is reported rather than silently truncating the dump.
+		require.ErrorContains(
+			t,
+			err,
+			"InterruptedDueToTimeseriesUpgradeDowngrade",
+			"a dump interrupted by the conversion should fail with the server's specific error",
+		)
+		return
+	}
+
+	dumped := countDumpedMeasurements(t, filepath.Join(md.OutputOptions.Out, dbName))
+	assert.EqualValues(
+		t,
+		numBuckets,
+		dumped,
+		"a dump that reports success must contain every measurement, even though the "+
+			"collection format changed underneath it",
+	)
+}
+
+// setUpBucketedTimeseries creates a timeseries collection holding one measurement per distinct
+// meta value, so that the collection contains numBuckets buckets.
+func setUpBucketedTimeseries(
+	t *testing.T,
+	session *mongo.Client,
+	dbName, collName string,
+	numBuckets int,
+) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	require.NoError(t, session.Database(dbName).RunCommand(ctx, bson.D{
+		{"create", collName},
+		{"timeseries", bson.D{{"timeField", "ts"}, {"metaField", "my_meta"}}},
+	}).Err(), "create timeseries collection")
+
+	docs := make([]any, 0, numBuckets)
+	for i := range numBuckets {
+		docs = append(docs, bson.D{
+			{"ts", bson.NewDateTimeFromTime(time.Now())},
+			{"my_meta", bson.D{{"device", i}}},
+			{"measurement", i},
+		})
+	}
+
+	_, err := session.Database(dbName).Collection(collName).InsertMany(ctx, docs)
+	require.NoError(t, err, "insert measurements")
+}
+
+// blockGetMoreForAppName makes every getMore from the given app name hang, so that a dump from
+// that app name stays open long enough for a concurrent setFCV to run.
+func blockGetMoreForAppName(t *testing.T, session *mongo.Client, appName string) {
+	t.Helper()
+
+	err := session.Database("admin").RunCommand(t.Context(), bson.D{
+		{"configureFailPoint", "failCommand"},
+		{"mode", "alwaysOn"},
+		{"data", bson.D{
+			{"failCommands", bson.A{"getMore"}},
+			{"appName", appName},
+			{"blockConnection", true},
+			{"blockTimeMS", 10000},
+		}},
+	}).Err()
+
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) && cmdErr.Name == "CommandNotFound" {
+		t.Skip("Requires a server started with enableTestCommands=1")
+	}
+	require.NoError(t, err, "enable the getMore failpoint")
+
+	t.Cleanup(func() {
+		_ = session.Database("admin").RunCommand(context.Background(), bson.D{
+			{"configureFailPoint", "failCommand"},
+			{"mode", "off"},
+		}).Err()
+	})
+}
+
+// waitForBlockedGetMore blocks until the dump's getMore is visible in currentOp, which means
+// the dump is mid-read and it is safe to change the collection format underneath it.
+func waitForBlockedGetMore(t *testing.T, session *mongo.Client, appName string) {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var result struct {
+			Inprog []bson.D `bson:"inprog"`
+		}
+		err := session.Database("admin").RunCommand(t.Context(), bson.D{
+			{"currentOp", 1},
+			{"appName", appName},
+			{"op", "getmore"},
+		}).Decode(&result)
+		require.NoError(t, err, "run currentOp")
+
+		if len(result.Inprog) > 0 {
+			return
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for a blocked getMore from app name %#q", appName)
+}
+
+// countDumpedMeasurements sums the measurement counts of the bucket documents in the timeseries
+// BSON file in the given dump directory.
+func countDumpedMeasurements(t *testing.T, dumpDir string) int {
+	t.Helper()
+
+	entries, err := os.ReadDir(dumpDir)
+	require.NoError(t, err, "read dump directory")
+
+	total := 0
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".bson") {
+			continue
+		}
+
+		file, err := os.Open(filepath.Join(dumpDir, entry.Name()))
+		require.NoError(t, err)
+		defer file.Close()
+
+		bsonSource := db.NewDecodedBSONSource(db.NewBSONSource(file))
+		defer bsonSource.Close()
+
+		var bucket struct {
+			Control struct {
+				Count int `bson:"count"`
+			} `bson:"control"`
+		}
+		for bsonSource.Next(&bucket) {
+			total += bucket.Control.Count
+		}
+		require.NoError(t, bsonSource.Err(), "read dumped buckets")
+	}
+
+	return total
 }

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -57,6 +57,27 @@ var knownCommands = mapset.NewSet(
 
 var errorTimestampBeforeLimit = fmt.Errorf("timestamp before limit")
 
+// upgradeDowngradeViewlessTimeseriesCmd is emitted by setFCV on 9.0+ deployments when a
+// timeseries collection is converted between its viewful and viewless forms. See SERVER-114505.
+const upgradeDowngradeViewlessTimeseriesCmd = "upgradeDowngradeViewlessTimeseries"
+
+// The conversion cannot be replayed: applying it requires the collection UUID, which mongorestore
+// strips unless --preserveUUID is set, and skipping it would leave the target collection in a form
+// that does not match the namespaces used by the oplog entries after the conversion. Rather than
+// silently producing a collection in an inconsistent state, we fail with a specific diagnostic.
+func newViewlessTimeseriesConversionError(op db.Oplog) error {
+	return fmt.Errorf(
+		"oplog entry %#q at %v cannot be replayed: this oplog window crosses a "+
+			"timeseries format conversion caused by an FCV change between 8.x and 9.0. "+
+			"Replaying across such a conversion is not supported. Restore an oplog range "+
+			"that does not span the FCV change, using --oplogLimit to stop before it if "+
+			"needed: %v",
+		upgradeDowngradeViewlessTimeseriesCmd,
+		op.Timestamp,
+		op,
+	)
+}
+
 // shouldIgnoreNamespace returns true if the given namespace should be ignored during applyOps.
 func shouldIgnoreNamespace(ns string) bool {
 	if strings.HasPrefix(ns, util.MongoDBInternalDBPrefix) {
@@ -234,6 +255,10 @@ func (restore *MongoRestore) HandleNonTxnOp(oplogCtx *oplogContext, op db.Oplog)
 			return fmt.Errorf("Empty object value for op: %v", op)
 		}
 		cmdName := op.Object[0].Key
+
+		if cmdName == upgradeDowngradeViewlessTimeseriesCmd {
+			return newViewlessTimeseriesConversionError(op)
+		}
 
 		if !knownCommands.ContainsOne(cmdName) {
 			return fmt.Errorf("unknown oplog command name %v: %v", cmdName, op)

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -191,6 +191,11 @@ var ignoredCEntries = mapset.NewSet(
 	"startIndexBuild",
 	"abortIndexBuild",
 	"setMultikeyMetadata",
+	// The second phase of a replicated table drop (SERVER-118737). Its payload is a storage
+	// engine ident name that only means anything on the node that produced it, so it must be
+	// skipped rather than forwarded to the restore target. The logical drop is already carried
+	// by the first-phase drop/dropIndexes entry, which we do apply.
+	"dropIdent",
 )
 
 func (restore *MongoRestore) HandleOp(oplogCtx *oplogContext, op db.Oplog) error {

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -1045,6 +1045,96 @@ func TestOplogRestoreViewlessTimeseriesConversion(t *testing.T) {
 	}
 }
 
+// TestOplogRestoreDropIdent verifies that a dropIdent entry (the replicated second phase of a
+// table drop, see SERVER-118737) is skipped during oplog replay rather than aborting it or being
+// forwarded to the target, whether it appears on its own or nested inside an applyOps.
+func TestOplogRestoreDropIdent(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	ctx := t.Context()
+
+	session, err := testutil.GetBareSession()
+	require.NoError(t, err, "should be able to get a session")
+	//nolint:errcheck
+	defer session.Disconnect(ctx)
+
+	dropIdentCmd := bson.D{{"dropIdent", "collection-7--4104909142373009110"}}
+
+	testCases := []struct {
+		name  string
+		entry bson.D
+	}{
+		{"standalone", dropIdentCmd},
+		{"nested in applyOps", bson.D{{"applyOps", []bson.D{
+			{
+				{"op", "c"},
+				{"ns", "admin.$cmd"},
+				{"o", dropIdentCmd},
+			},
+		}}}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, session.Database("mongodump_test_db").Drop(ctx))
+			t.Cleanup(func() { _ = session.Database("mongodump_test_db").Drop(t.Context()) })
+			require.NoError(
+				t,
+				session.Database("mongodump_test_db").CreateCollection(ctx, "coll1"),
+			)
+
+			oplogFile := writeOplogFile(t, []db.Oplog{
+				{
+					Timestamp: bson.Timestamp{T: 1, I: 1},
+					Version:   2,
+					Operation: "i",
+					Namespace: "mongodump_test_db.coll1",
+					Object:    bson.D{{"_id", 1}, {"a", 1}},
+				},
+				{
+					Timestamp: bson.Timestamp{T: 1, I: 2},
+					Version:   2,
+					Operation: "c",
+					Namespace: "admin.$cmd",
+					Object:    tc.entry,
+				},
+				{
+					Timestamp: bson.Timestamp{T: 1, I: 3},
+					Version:   2,
+					Operation: "i",
+					Namespace: "mongodump_test_db.coll1",
+					Object:    bson.D{{"_id", 2}, {"a", 2}},
+				},
+			})
+
+			args := []string{
+				DirectoryOption, "testdata/coll_without_index",
+				OplogReplayOption,
+				DropOption,
+				OplogFileOption, oplogFile,
+			}
+
+			restore, err := getRestoreWithArgs(args...)
+			require.NoError(t, err)
+			defer restore.Close()
+
+			result := restore.Restore()
+			require.NoError(t, result.Err, "restore should skip the dropIdent entry")
+
+			count, err := session.Database("mongodump_test_db").
+				Collection("coll1").
+				CountDocuments(ctx, bson.D{{"_id", bson.D{{"$in", []int{1, 2}}}}})
+			require.NoError(t, err)
+			require.EqualValues(
+				t,
+				2,
+				count,
+				"ops on both sides of the dropIdent entry were applied",
+			)
+		})
+	}
+}
+
 // writeOplogFile writes the given oplog entries to a BSON file usable with --oplogFile and
 // returns its path.
 func writeOplogFile(t *testing.T, ops []db.Oplog) string {

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -9,6 +9,7 @@ package mongorestore
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -945,4 +946,121 @@ func TestOplogRestoreCollModTTLIndex(t *testing.T) {
 			require.EqualValues(t, 1000, expireAfterSeconds)
 		}
 	}
+}
+
+// TestOplogRestoreViewlessTimeseriesConversion verifies that an oplog window crossing a
+// viewless timeseries format conversion (emitted by setFCV on 9.0+, see SERVER-114505) fails
+// loudly with a specific diagnostic rather than being silently skipped or rejected with the
+// generic "unknown oplog command name" error.
+func TestOplogRestoreViewlessTimeseriesConversion(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	ctx := t.Context()
+
+	session, err := testutil.GetBareSession()
+	require.NoError(t, err, "should be able to get a session")
+	//nolint:errcheck
+	defer session.Disconnect(ctx)
+
+	for _, isUpgrade := range []bool{true, false} {
+		name := "downgrade to viewful"
+		if isUpgrade {
+			name = "upgrade to viewless"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, session.Database("mongodump_test_db").Drop(ctx))
+			t.Cleanup(func() { _ = session.Database("mongodump_test_db").Drop(t.Context()) })
+			require.NoError(
+				t,
+				session.Database("mongodump_test_db").CreateCollection(ctx, "coll1"),
+			)
+
+			conversion := bson.D{
+				{upgradeDowngradeViewlessTimeseriesCmd, "foo_ts"},
+				{"isUpgrade", isUpgrade},
+			}
+			if !isUpgrade {
+				conversion = append(conversion, bson.E{"skipViewCreation", false})
+			}
+
+			oplogFile := writeOplogFile(t, []db.Oplog{
+				{
+					Timestamp: bson.Timestamp{T: 1, I: 1},
+					Version:   2,
+					Operation: "i",
+					Namespace: "mongodump_test_db.coll1",
+					Object:    bson.D{{"_id", 1}, {"a", 1}},
+				},
+				{
+					Timestamp: bson.Timestamp{T: 1, I: 2},
+					Version:   2,
+					Operation: "c",
+					Namespace: "mongodump_test_db.$cmd",
+					UI: &bson.Binary{
+						Subtype: bson.TypeBinaryUUID,
+						Data:    make([]byte, 16),
+					},
+					Object: conversion,
+				},
+			})
+
+			args := []string{
+				DirectoryOption, "testdata/coll_without_index",
+				OplogReplayOption,
+				DropOption,
+				OplogFileOption, oplogFile,
+			}
+
+			restore, err := getRestoreWithArgs(args...)
+			require.NoError(t, err)
+			defer restore.Close()
+
+			result := restore.Restore()
+			require.Error(t, result.Err, "restore should fail on a timeseries format conversion")
+			require.ErrorContains(
+				t,
+				result.Err,
+				upgradeDowngradeViewlessTimeseriesCmd,
+				"error should name the offending oplog command",
+			)
+			require.ErrorContains(
+				t,
+				result.Err,
+				"crosses a timeseries format conversion",
+				"error should explain why the oplog window cannot be replayed",
+			)
+
+			count, err := session.Database("mongodump_test_db").
+				Collection("coll1").
+				CountDocuments(ctx, bson.D{{"_id", 1}})
+			require.NoError(t, err)
+			require.EqualValues(
+				t,
+				1,
+				count,
+				"ops before the conversion were applied, so the failure is at the conversion itself",
+			)
+		})
+	}
+}
+
+// writeOplogFile writes the given oplog entries to a BSON file usable with --oplogFile and
+// returns its path.
+func writeOplogFile(t *testing.T, ops []db.Oplog) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "oplog.bson")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+
+	for _, op := range ops {
+		raw, err := bson.Marshal(op)
+		require.NoError(t, err)
+		_, err = file.Write(raw)
+		require.NoError(t, err)
+	}
+
+	return path
 }


### PR DESCRIPTION
SERVER-118737 adds a new command oplog entry, { op: "c", ns: "admin.$cmd", o: { dropIdent: "<ident>" } }. It isn't in mongorestore's knownCommands allowlist, so --oplogReplay aborts on it with unknown oplog command name dropIdent — partway through, with applied entries not rolled back. mongodump --oplog doesn't reject it, so the failure surfaces at restore time on a dump that reported success.

Changes
Add "dropIdent" to ignoredCEntries in mongorestore/oplog.go HandleOp checks that set before the allowlist, so this one line covers standalone entries and entries nested in applyOps or a transaction.

Skipping rather than allowlisting is deliberate. The payload is a storage-engine ident generated by the source cluster; allowlisting would forward it to restore.ApplyOp and ask the target to drop a table by a name it never chose. Nothing is lost by skipping — the logical drop is already carried by the first-phase drop/dropIndexes entry, and the target reaps its own tables on its own schedule.

mongodump's oplogDocumentValidator is intentionally untouched: a concurrent dropIdent doesn't invalidate the dump, and failing it would turn a restorable artifact into none.

Tests
TestOplogRestoreDropIdent replays insert -> dropIdent -> insert and asserts the restore succeeds with both inserts applied. Subtests cover the standalone entry and the entry nested in an applyOps (the HandleOp recursion path). Uses --oplogFile rather than writing to local.oplog.rs, so it runs on the replica-set CI variants.