### PR TITLE
TOOLS-4313 Hint $natural on unfiltered, unsorted mongoexport queries

### DIFF
--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -365,6 +365,15 @@ func (exp *MongoExport) getCursor() (*mongo.Cursor, error) {
 		findOpts.SetProjection(makeFieldSelector(exp.OutputOpts.Fields))
 	}
 
+	// An export with neither a query nor a sort is a deliberate full collection scan. Saying so
+	// with a $natural hint exempts it from the server's maxEstimatedScanBytes rejection
+	// (SERVER-127688) without changing the plan the server would have chosen anyway. We must not
+	// do this when there is a query or a sort, either of which could be served by an index.
+	sorted := exp.InputOpts != nil && exp.InputOpts.Sort != ""
+	if len(query) == 0 && !sorted {
+		findOpts.SetHint(bson.D{{"$natural", 1}})
+	}
+
 	return coll.Find(context.TODO(), query, findOpts)
 }
 

--- a/mongoexport/mongoexport_test.go
+++ b/mongoexport/mongoexport_test.go
@@ -709,3 +709,72 @@ func rowsContainValue(rows []map[string]string, col, val string) bool {
 	}
 	return false
 }
+
+// TestMongoExportMaxEstimatedScanBytes verifies that mongoexport can export a collection larger
+// than the server's maxEstimatedScanBytes threshold (SERVER-127688, added in 9.0). An export with
+// neither a query nor a sort plans an unbounded COLLSCAN, which the server rejects with
+// NoQueryExecutionPlans unless the query carries a $natural hint.
+func TestMongoExportMaxEstimatedScanBytes(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	log.SetWriter(io.Discard)
+
+	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	require.NoError(t, err, "no cluster available")
+	defer sessionProvider.Close()
+
+	serverVersion, err := sessionProvider.ServerVersionArray()
+	require.NoError(t, err, "get server version")
+	if serverVersion.LT(db.Version{9, 0, 0}) {
+		t.Skipf("maxEstimatedScanBytes was added in 9.0; testing with %s", serverVersion.String())
+	}
+
+	// setParameter on a mongos does not reach the shards, so the knob would never be applied to
+	// the nodes that actually plan the query.
+	isMongos, err := sessionProvider.IsMongos()
+	require.NoError(t, err, "check for mongos")
+	if isMongos {
+		t.Skip("setParameter does not propagate from mongos to shards")
+	}
+
+	session, err := sessionProvider.GetSession()
+	require.NoError(t, err, "get session")
+
+	const collName = "max_estimated_scan_bytes"
+	const numDocs = 100
+
+	coll := session.Database(testDB).Collection(collName)
+	require.NoError(t, coll.Drop(context.Background()), "drop existing collection")
+
+	docs := make([]any, numDocs)
+	for i := range docs {
+		docs[i] = bson.D{{"_id", i}, {"pad", strings.Repeat("x", 1024)}}
+	}
+	_, err = coll.InsertMany(context.Background(), docs)
+	require.NoError(t, err, "insert test documents")
+
+	// The collection is ~100KB, so any threshold well below that triggers the rejection.
+	setKnob := func(value any) {
+		var res bson.M
+		err := sessionProvider.Run(
+			bson.D{{"setParameter", 1}, {"maxEstimatedScanBytes", value}},
+			&res,
+			"admin",
+		)
+		require.NoError(t, err, "set maxEstimatedScanBytes to %v", value)
+	}
+	setKnob(int64(1024))
+	defer setKnob(int64(-1))
+
+	opts, err := simpleMongoExportOpts()
+	require.NoError(t, err)
+	opts.Collection = collName
+
+	me, err := New(opts)
+	require.NoError(t, err)
+	defer me.Close()
+
+	out := &bytes.Buffer{}
+	exported, err := me.Export(out)
+	require.NoError(t, err, "export a collection larger than maxEstimatedScanBytes")
+	assert.EqualValues(t, numDocs, exported, "all documents were exported")
+}


### PR DESCRIPTION
SERVER-127688 (9.0) adds a maxEstimatedScanBytes server parameter that rejects queries at plan time when the plan requires an unbounded COLLSCAN on a collection larger than the configured threshold. An export with neither a query nor a sort is exactly that shape, so with the knob enabled mongoexport cannot export any collection over the threshold.

mongoexport builds its own find options rather than going through common/db.DeferredQuery, so the equivalent mongodump fix in TOOLS-4312 does not cover it. There is no count path to fix here: getCount only ever uses EstimatedDocumentCount, which reads metadata rather than planning a scan.

We must not send the hint when there is a query or a sort, either of which could be served by an index. That leaves a sort on an unindexed field still rejected, which is deliberate: that plan is a collection scan plus a blocking sort, which is the workload the guardrail exists to catch.