### PR TITLE
TOOLS-4314 Release 100.18.0

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1263,6 +1263,7 @@ var linuxRepoVersionsStable = []LinuxRepo{
 	{"8.0", "8.0.0"}, // any 8.0 stable release version will send the package to the "8.0" repo
 	{"8.2", "8.2.0"}, // any 8.2 stable release version will send the package to the "8.2" repo
 	{"8.3", "8.3.0"}, // any 8.3 stable release version will send the package to the "8.3" repo
+	{"9.0", "9.0.0"}, // any 9.0 stable release version will send the package to the "9.0" repo
 }
 
 var linuxRepoVersionsUnstable = []LinuxRepo{

--- a/ssdlc/100.18.0.bom.json
+++ b/ssdlc/100.18.0.bom.json
@@ -1,0 +1,911 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.22.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Azure/azure-sdk-for-go"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.22.0"
+        }
+      ],
+      "group": "github.com/Azure/azure-sdk-for-go/sdk",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "azcore",
+      "purl": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.22.0",
+      "type": "library",
+      "version": "v1.22.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.14.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Azure/azure-sdk-for-go"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.14.0"
+        }
+      ],
+      "group": "github.com/Azure/azure-sdk-for-go/sdk",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "azidentity",
+      "purl": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.14.0",
+      "type": "library",
+      "version": "v1.14.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/internal@v1.12.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Azure/azure-sdk-for-go"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/internal@v1.12.0"
+        }
+      ],
+      "group": "github.com/Azure/azure-sdk-for-go/sdk",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "internal",
+      "purl": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/internal@v1.12.0",
+      "type": "library",
+      "version": "v1.12.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/AzureAD/microsoft-authentication-library-for-go@v1.7.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/AzureAD/microsoft-authentication-library-for-go"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/AzureAD/microsoft-authentication-library-for-go@v1.7.2"
+        }
+      ],
+      "group": "github.com/AzureAD",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "microsoft-authentication-library-for-go",
+      "purl": "pkg:golang/github.com/AzureAD/microsoft-authentication-library-for-go@v1.7.2",
+      "type": "library",
+      "version": "v1.7.2"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ccoveille/go-safecast/v2@v2.0.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/ccoveille/go-safecast"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/ccoveille/go-safecast/v2@v2.0.1"
+        }
+      ],
+      "group": "github.com/ccoveille/go-safecast",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "v2",
+      "purl": "pkg:golang/github.com/ccoveille/go-safecast/v2@v2.0.1",
+      "type": "library",
+      "version": "v2.0.1"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/clipperhouse/uax29/v2@v2.7.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/clipperhouse/uax29"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/clipperhouse/uax29/v2@v2.7.0"
+        }
+      ],
+      "group": "github.com/clipperhouse/uax29",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "v2",
+      "purl": "pkg:golang/github.com/clipperhouse/uax29/v2@v2.7.0",
+      "type": "library",
+      "version": "v2.7.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/deckarep/golang-set/v2@v2.9.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/deckarep/golang-set"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/deckarep/golang-set/v2@v2.9.0"
+        }
+      ],
+      "group": "github.com/deckarep/golang-set",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "v2",
+      "purl": "pkg:golang/github.com/deckarep/golang-set/v2@v2.9.0",
+      "type": "library",
+      "version": "v2.9.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang-jwt/jwt/v5@v5.3.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/golang-jwt/jwt"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/golang-jwt/jwt/v5@v5.3.1"
+        }
+      ],
+      "group": "github.com/golang-jwt/jwt",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "v5",
+      "purl": "pkg:golang/github.com/golang-jwt/jwt/v5@v5.3.1",
+      "type": "library",
+      "version": "v5.3.1"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/google/uuid"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/google/uuid@v1.6.0"
+        }
+      ],
+      "group": "github.com/google",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "type": "library",
+      "version": "v1.6.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.6.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/jessevdk/go-flags"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/jessevdk/go-flags@v1.6.1"
+        }
+      ],
+      "group": "github.com/jessevdk",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "go-flags",
+      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.6.1",
+      "type": "library",
+      "version": "v1.6.1"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/klauspost/compress@v1.18.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/klauspost/compress"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/klauspost/compress@v1.18.6"
+        }
+      ],
+      "group": "github.com/klauspost",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "compress",
+      "purl": "pkg:golang/github.com/klauspost/compress@v1.18.6",
+      "type": "library",
+      "version": "v1.18.6"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kylelemons/godebug@v1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/kylelemons/godebug"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/kylelemons/godebug@v1.1.0"
+        }
+      ],
+      "group": "github.com/kylelemons",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "godebug",
+      "purl": "pkg:golang/github.com/kylelemons/godebug@v1.1.0",
+      "type": "library",
+      "version": "v1.1.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.24",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/mattn/go-runewidth"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/mattn/go-runewidth@v0.0.24"
+        }
+      ],
+      "group": "github.com/mattn",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.24",
+      "type": "library",
+      "version": "v0.0.24"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nsf/termbox-go@v1.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/nsf/termbox-go"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/nsf/termbox-go@v1.1.1"
+        }
+      ],
+      "group": "github.com/nsf",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "termbox-go",
+      "purl": "pkg:golang/github.com/nsf/termbox-go@v1.1.1",
+      "type": "library",
+      "version": "v1.1.1"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pkg/browser"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c"
+        }
+      ],
+      "group": "github.com/pkg",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "browser",
+      "purl": "pkg:golang/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c",
+      "type": "library",
+      "version": "v0.0.0-20240102092130-5ac0b6a4141c"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pkg/errors"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/pkg/errors@v0.9.1"
+        }
+      ],
+      "group": "github.com/pkg",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "version": "v0.9.1"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/samber/lo@v1.53.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/samber/lo"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/samber/lo@v1.53.0"
+        }
+      ],
+      "group": "github.com/samber",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "lo",
+      "purl": "pkg:golang/github.com/samber/lo@v1.53.0",
+      "type": "library",
+      "version": "v1.53.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xdg-go/scram@v1.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/xdg-go/scram"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/xdg-go/scram@v1.2.0"
+        }
+      ],
+      "group": "github.com/xdg-go",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "scram",
+      "purl": "pkg:golang/github.com/xdg-go/scram@v1.2.0",
+      "type": "library",
+      "version": "v1.2.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xdg-go/stringprep@v1.0.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/xdg-go/stringprep"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/xdg-go/stringprep@v1.0.4"
+        }
+      ],
+      "group": "github.com/xdg-go",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "stringprep",
+      "purl": "pkg:golang/github.com/xdg-go/stringprep@v1.0.4",
+      "type": "library",
+      "version": "v1.0.4"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/youmark/pkcs8"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78"
+        }
+      ],
+      "group": "github.com/youmark",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "pkcs8",
+      "purl": "pkg:golang/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78",
+      "type": "library",
+      "version": "v0.0.0-20240726163527-a2c0da244d78"
+    },
+    {
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.17.9",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/mongodb/mongo-go-driver.git"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.17.9"
+        }
+      ],
+      "group": "go.mongodb.org",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.17.9",
+      "type": "library",
+      "version": "v1.17.9"
+    },
+    {
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver/v2@v2.7.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/mongodb/mongo-go-driver.git"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/go.mongodb.org/mongo-driver/v2@v2.7.0"
+        }
+      ],
+      "group": "go.mongodb.org/mongo-driver",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "v2",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver/v2@v2.7.0",
+      "type": "library",
+      "version": "v2.7.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.54.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/crypto"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/crypto@v0.54.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.54.0",
+      "type": "library",
+      "version": "v0.54.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20260611194520-c48552f49976",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/exp"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/exp@v0.0.0-20260611194520-c48552f49976"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "exp",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20260611194520-c48552f49976",
+      "type": "library",
+      "version": "v0.0.0-20260611194520-c48552f49976"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.56.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/net"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/net@v0.56.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "net",
+      "purl": "pkg:golang/golang.org/x/net@v0.56.0",
+      "type": "library",
+      "version": "v0.56.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.22.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/sync"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/sync@v0.22.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.22.0",
+      "type": "library",
+      "version": "v0.22.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.47.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/sys"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/sys@v0.47.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.47.0",
+      "type": "library",
+      "version": "v0.47.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.45.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/term"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/term@v0.45.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "term",
+      "purl": "pkg:golang/golang.org/x/term@v0.45.0",
+      "type": "library",
+      "version": "v0.45.0"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.40.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://go.googlesource.com/text"
+        },
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/golang.org/x/text@v0.40.0"
+        }
+      ],
+      "group": "golang.org/x",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "text",
+      "purl": "pkg:golang/golang.org/x/text@v0.40.0",
+      "type": "library",
+      "version": "v0.40.0"
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/gopkg.in/yaml.v2@v2.4.0"
+        }
+      ],
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "version": "v2.4.0"
+    },
+    {
+      "bom-ref": "pkg:golang/std@go1.26.5",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://pkg.go.dev/None/std@go1.26.5"
+        }
+      ],
+      "name": "std",
+      "purl": "pkg:golang/std@go1.26.5",
+      "type": "library",
+      "version": "go1.26.5"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.22.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.14.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/internal@v1.12.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/AzureAD/microsoft-authentication-library-for-go@v1.7.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/ccoveille/go-safecast/v2@v2.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/clipperhouse/uax29/v2@v2.7.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/deckarep/golang-set/v2@v2.9.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/golang-jwt/jwt/v5@v5.3.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.6.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.6.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/compress@v1.18.6"
+    },
+    {
+      "ref": "pkg:golang/github.com/kylelemons/godebug@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.24"
+    },
+    {
+      "ref": "pkg:golang/github.com/nsf/termbox-go@v1.1.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c"
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/samber/lo@v1.53.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/xdg-go/scram@v1.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/xdg-go/stringprep@v1.0.4"
+    },
+    {
+      "ref": "pkg:golang/github.com/youmark/pkcs8@v0.0.0-20240726163527-a2c0da244d78"
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver/v2@v2.7.0"
+    },
+    {
+      "ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.17.9"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.54.0"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20260611194520-c48552f49976"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.56.0"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.22.0"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.47.0"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.45.0"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.40.0"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+    },
+    {
+      "ref": "pkg:golang/std@go1.26.5"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2026-07-27T17:16:05.055785+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:ecf433fd-8f8f-476e-bb32-15507acd4361",
+  "version": 48,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "vulnerabilities": []
+}

--- a/ssdlc/100.18.0.sarif.json
+++ b/ssdlc/100.18.0.sarif.json
@@ -1,0 +1,159 @@
+{
+	"runs": [
+		{
+			"results": [
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "bindata.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 41,
+									"snippet": {
+										"text": "arg0 := byte(args[0].Uint())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 41
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint64 -\u003e byte"
+					},
+					"ruleId": "G115",
+					"suppressions": [
+						{
+							"justification": "args[0] was constructed with reflect type byteType, so\nits Kind is always Uint8 and Uint() can only return a byte-range value.",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "bsondump.go"
+								},
+								"region": {
+									"endColumn": 64,
+									"endLine": 245,
+									"snippet": {
+										"text": "fmt.Fprintf(out, \"%v\\t\\t\\ttype: %4d size: %v\\n\", indent, int8(value.Type), len(rawElem))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 64,
+									"startLine": 245
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion byte -\u003e int8"
+					},
+					"ruleId": "G115",
+					"suppressions": [
+						{
+							"justification": "the bson.Type type always fits in an int8",
+							"kind": "inSource"
+						}
+					]
+				}
+			],
+			"taxonomies": [
+				{
+					"downloadUri": "https://cwe.mitre.org/data/xml/cwec_v4.4.xml.zip",
+					"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+					"informationUri": "https://cwe.mitre.org/data/published/cwe_v4.4.pdf/",
+					"isComprehensive": true,
+					"language": "en",
+					"minimumRequiredLocalizedDataSemanticVersion": "4.4",
+					"name": "CWE",
+					"organization": "MITRE",
+					"releaseDateUtc": "2021-03-15",
+					"shortDescription": {
+						"text": "The MITRE Common Weakness Enumeration"
+					},
+					"taxa": [
+						{
+							"fullDescription": {
+								"text": "The software performs a calculation that can produce an integer overflow or wraparound, when the logic assumes that the resulting value will always be larger than the original value. This can introduce other weaknesses when the calculation is used for resource management or execution control."
+							},
+							"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+							"helpUri": "https://cwe.mitre.org/data/definitions/190.html",
+							"id": "190",
+							"shortDescription": {
+								"text": "Integer Overflow or Wraparound"
+							}
+						}
+					],
+					"version": "4.4"
+				}
+			],
+			"tool": {
+				"driver": {
+					"guid": "8b518d5f-906d-39f9-894b-d327b1a421c5",
+					"informationUri": "https://github.com/securego/gosec/",
+					"name": "gosec",
+					"rules": [
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "integer overflow conversion uint64 -\u003e byte"
+							},
+							"help": {
+								"text": "integer overflow conversion uint64 -\u003e byte\nSeverity: HIGH\nConfidence: MEDIUM\n"
+							},
+							"id": "G115",
+							"name": "Integer Overflow or Wraparound",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+										"id": "190",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "integer overflow conversion uint64 -\u003e byte"
+							}
+						}
+					],
+					"semanticVersion": "2.27.1",
+					"supportedTaxonomies": [
+						{
+							"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+							"name": "CWE"
+						}
+					],
+					"version": "2.27.1"
+				}
+			}
+		}
+	],
+	"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+	"version": "2.1.0"
+}


### PR DESCRIPTION
Changes release.go to trigger publication to the server 9.0 linux repo.

Includes sarif.json and newly generated SBOM as per the release process documentation.