### PR TITLE
evergreen: restore missing AWS env vars for release

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -512,6 +512,8 @@ functions:
         args:
           - "./scripts/upload-release.sh"
         env:
+          AWS_ACCESS_KEY_ID: ${cdn_aws_access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${cdn_aws_secret}
           EVG_BUILD_ID: ${build_id}
           EVG_IS_PATCH: ${is_patch}
           EVG_KEY: ${evg_key}
@@ -533,6 +535,8 @@ functions:
         args:
           - "./scripts/upload-release-json.sh"
         env:
+          AWS_ACCESS_KEY_ID: ${cdn_aws_access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${cdn_aws_secret}
           EVG_BUILD_ID: ${build_id}
           EVG_IS_PATCH: ${is_patch}
           EVG_KEY: ${evg_key}


### PR DESCRIPTION
These got lost in the shuffle in 96909627 (TOOLS-4238 Move more inline shell code from the Evergreen config to scripts), 2026-07-16) and 926381b0 (TOOLS-4238 Finish moving inline shell that uses `_set_shell_env` to scripts), 2026-07-16), and we need them for the push task to work correctly on release.