### PR TITLE
release: fix server 8.2 skip

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -1261,7 +1261,6 @@ var linuxRepoVersionsStable = []LinuxRepo{
 	{"6.0", "6.0.0"}, // any 6.0 stable release version will send the package to the "6.0" repo
 	{"7.0", "7.0.0"}, // any 7.0 stable release version will send the package to the "7.0" repo
 	{"8.0", "8.0.0"}, // any 8.0 stable release version will send the package to the "8.0" repo
-	{"8.2", "8.2.0"}, // any 8.2 stable release version will send the package to the "8.2" repo
 	{"8.3", "8.3.0"}, // any 8.3 stable release version will send the package to the "8.3" repo
 	{"9.0", "9.0.0"}, // any 9.0 stable release version will send the package to the "9.0" repo
 }
@@ -1371,11 +1370,6 @@ func linuxRelease(v version.Version) {
 					}
 					if pf.MaxLinuxServerVersion != nil &&
 						mongoVer.GreaterThan(*pf.MaxLinuxServerVersion) {
-						log.Printf("skip to push a linux release to server version %s", mongoVer)
-						continue
-					}
-
-					if mongoVer.Major == 8 && mongoVer.Minor <= 2 {
 						log.Printf("skip to push a linux release to server version %s", mongoVer)
 						continue
 					}


### PR DESCRIPTION
This was clearly wrong the first time because it would also skip 8.0; oops! The right fix here is to remove 8.2 from linuxRepoVersionsStable.