### PR TITLE
TOOLS-4100 Fix a panic that can happen when `TOOLS_TESTING_MONGOD` is set

### DIFF
--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -88,6 +88,10 @@ func GetToolOptions() (*options.ToolOptions, error) {
 				err,
 			)
 		}
+
+		// ParseArgs does not set this, but tools like mongoimport and mongorestore
+		// dereference it without a nil check.
+		toolOptions.WriteConcern = wcwrapper.Majority()
 	} else {
 		ssl := GetSSLOptions()
 		auth := GetAuthOptions()


### PR DESCRIPTION
We need to set `toolOptions.WriteConcern`, because code in the tools themselves will dereference this without checking if it's set. This works fine in normal tool usage, but not in the tests, which bypass the tools' option parsing.