### PR TITLE
TOOLS-4100 Run integration tests against 9.1 DSC cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ test/qa-tests/[0-9]*
 test/qa-tests/install_compass
 test/qa-tests/mongo*
 test/qa-tests/venv
+dsc-cluster/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,30 @@ case.
 All programmatic tool invocations should use `mise exec <tool>`. This will work in CI as well as
 locally.
 
+## Running DSC Clusters Locally
+
+In order to run these locally, you need access to the private `10gen/mongo-downloader` repo. This is
+only available for MongoDB employees.
+
+First, you must authenticate with aws using a profile that has access to the SLS image repo. You
+also need to authenticate with a profile that can access the S3 bucket containing Server binaries
+used by `mongodb-downloader. This can be two different profiles or just one.
+
+In order to start a DSC cluster, run this command:
+
+```
+MISE_ENV=dsc SLS_AWS_ECR_PROFILE=... ./scripts/start-dsc-cluster.sh
+```
+
+The `SLS_AWS_ECR_PROFILE` value should be the name of the authenticated profile which has access to
+the ECR repo.
+
+You can stop the cluster with:
+
+```
+MISE_ENV=dsc mise exec -- ./scripts/start-dsc-cluster.sh
+```
+
 ## Getting Started
 
 1. Create a [MongoDB JIRA account](https://jira.mongodb.org/secure/Signup!default.jspa).

--- a/common.yml
+++ b/common.yml
@@ -82,6 +82,7 @@ functions:
           - ${mise_and_go_cache_version}
         key_files:
           - src/github.com/mongodb/mongo-tools/mise.toml
+          - src/github.com/mongodb/mongo-tools/mise.dsc.toml
           - src/github.com/mongodb/mongo-tools/scripts/mise-version.txt
           - src/github.com/mongodb/mongo-tools/scripts/install-mise-and-go.sh
         name: mise-and-go
@@ -109,6 +110,7 @@ functions:
           - ${mise_and_go_cache_version}
         key_files:
           - src/github.com/mongodb/mongo-tools/mise.toml
+          - src/github.com/mongodb/mongo-tools/mise.dsc.toml
           - src/github.com/mongodb/mongo-tools/scripts/mise-version.txt
           - src/github.com/mongodb/mongo-tools/scripts/install-mise-and-go.sh
         name: mise-and-go
@@ -148,6 +150,7 @@ functions:
           - ${mise_all_tools_cache_version}
         key_files:
           - src/github.com/mongodb/mongo-tools/mise.toml
+          - src/github.com/mongodb/mongo-tools/mise.dsc.toml
           - src/github.com/mongodb/mongo-tools/scripts/mise-version.txt
           - src/github.com/mongodb/mongo-tools/scripts/install-mise-managed-tools.sh
           - src/github.com/mongodb/mongo-tools/scripts/recreate-npm-bin-symlinks.py
@@ -177,6 +180,7 @@ functions:
           - ${mise_all_tools_cache_version}
         key_files:
           - src/github.com/mongodb/mongo-tools/mise.toml
+          - src/github.com/mongodb/mongo-tools/mise.dsc.toml
           - src/github.com/mongodb/mongo-tools/scripts/mise-version.txt
           - src/github.com/mongodb/mongo-tools/scripts/install-mise-managed-tools.sh
           - src/github.com/mongodb/mongo-tools/scripts/recreate-npm-bin-symlinks.py
@@ -243,7 +247,96 @@ functions:
           TARGET: ${target}
           TOOLS_TESTING_AUTH_PASSWORD: ${auth_password}
           TOOLS_TESTING_AUTH_USERNAME: ${auth_username}
+          TOOLS_TESTING_MONGOD: ${TOOLS_TESTING_MONGOD}
           TOOLS_TESTING_PKCS8_PASSWORD: ${pkcs8_password}
+
+  #######################################
+  #  Disaggregated Storage (DSC) setup  #
+  #######################################
+  # A DSC cluster needs mongodb-downloader, which is in a private repo and so needs a generated
+  # token. It also needs credentials for two different AWS accounts.
+
+  "start dsc cluster":
+    # The order of these commands is important. ec2.assume_role overwrites existing AWS_*
+    # expansions, so each role has to be used before the next one is assumed. Two roles are needed
+    # because the SLS container images and the Server build live in different accounts. The GitHub
+    # token is generated first because assume_role does not touch it.
+    - command: github.generate_token
+      params:
+        owner: 10gen
+        repo: mongodb-downloader
+        expansion_name: generated_token_mongodb_downloader
+        permissions:
+          attestations: read
+          contents: read
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to pull SLS images from ECR
+      params:
+        role_arn: arn:aws:iam::664315256653:role/disagg-storage-tf-project-ro
+    - command: subprocess.exec
+      params:
+        # binary must be bash (with the script passed via args), not the script
+        # directly: Windows can't execute a shebang script as a native binary.
+        binary: bash
+        working_dir: src/github.com/mongodb/mongo-tools
+        args:
+          - "./scripts/authenticate-sls-ecr.sh"
+        env:
+          AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+          AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+          AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to read Server builds from S3
+      params:
+        role_arn: arn:aws:iam::557821124784:role/evergreen.aws-c2c-sync
+    - command: subprocess.exec
+      params:
+        # binary must be bash (with the script passed via args), not the script
+        # directly: Windows can't execute a shebang script as a native binary.
+        binary: bash
+        working_dir: src/github.com/mongodb/mongo-tools
+        args:
+          - "./scripts/start-dsc-cluster.sh"
+        env:
+          AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+          AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+          AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+          EVG_WORKDIR: ${workdir}
+          # mise installs mongodb-downloader from a private repo, so it needs a token.
+          GITHUB_TOKEN: ${generated_token_mongodb_downloader}
+    # The cluster's connection string is only known at runtime, and each command runs in its own
+    # shell, so the script passes this setting through a file rather than an exported variable. This
+    # lets the "run make target" function see TOOLS_TESTING_MONGOD.
+    - command: expansions.update
+      params:
+        file: src/github.com/mongodb/mongo-tools/dsc-cluster/expansions.yml
+
+  # These two tasks run in the project-wide "post" block, so they have to be safe for every
+  # task. Both are no-ops when the task never started a DSC cluster.
+  "stop dsc cluster":
+    - command: subprocess.exec
+      params:
+        # binary must be bash (with the script passed via args), not the script
+        # directly: Windows can't execute a shebang script as a native binary.
+        binary: bash
+        working_dir: src/github.com/mongodb/mongo-tools
+        args:
+          - "./scripts/stop-dsc-cluster.sh"
+        env:
+          EVG_WORKDIR: ${workdir}
+
+  "upload dsc cluster logs":
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/github.com/mongodb/mongo-tools/dsc-cluster/logs.tgz
+        remote_file: mongo-tools/dsc-logs/${build_id}/${task_name}/logs.tgz
+        content_type: application/x-gzip
+        bucket: mciuploads
+        permissions: public-read
+        display_name: "DSC cluster logs"
+        optional: true
 
   "download mongod and shell":
     - command: github.generate_token
@@ -891,6 +984,8 @@ post:
 
         rm -rf /data/db/*
         exit 0
+  - func: "stop dsc cluster"
+  - func: "upload dsc cluster logs"
   # Extra post steps needed for mongodump passthrough.
   - func: f_resmoke_report_attach
   - func: "attach artifacts"
@@ -1811,6 +1906,23 @@ tasks:
         vars:
           target: test:awsauth ${testArgs}
 
+  - name: integration-9.1-dsc
+    commands:
+      - func: "fetch source"
+      - func: "install mise and go"
+      - func: "install mise-managed tools"
+      # Starting the SLS services is slow, so we want to build the tools before starting the
+      # cluster.
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "start dsc cluster"
+      # No -ssl: mongodb-runner starts the replica set without TLS. The connection string reaches
+      # the suite through the TOOLS_TESTING_MONGOD expansion that "start dsc cluster" sets.
+      - func: "run make target"
+        vars:
+          target: test:integration -topology=replSet ${testArgs}
+
   - name: integration-latest
     tags: ["latest", "required-for-merge-queue"]
     commands:
@@ -2613,7 +2725,7 @@ buildvariants:
 
   # The one variant GitHub branch protection requires, so that a PR can enter the merge queue as
   # soon as the tasks below pass rather than waiting for every task the PR runs. The dependencies
-  # are what actually gate a merge.  See CONTRIBUTING.md.
+  # are what actually gate a merge. See CONTRIBUTING.md.
   - name: merge-queue
     display_name: "! Required for Merge"
     # This variant exists only to gate a merge, and it must not run on the waterfall. Evergreen
@@ -2634,6 +2746,8 @@ buildvariants:
       # sign.
       - name: .required-for-merge-queue
         variant: rhel88
+      - name: integration-9.1-dsc
+        variant: ubuntu2204-arm64-dsc
       # These carry the required-for-merge-queue tag too, but they have to be named individually:
       # the windows variant runs every server version, while pull request testing only runs the
       # latest on it. Selecting by tag here would gate on tasks a pull request never ran.
@@ -3134,6 +3248,27 @@ buildvariants:
       - name: "push"
         run_on: rhel80-small
 
+  # Disaggregated storage, which the tools have to keep working against. This runs on every PR, via
+  # its own entry in github_pr_aliases, and nightly on the mainline. It needs that explicit alias
+  # because `integrationTestAliases` only matches tasks named like a tag selector (".9.0"), and this
+  # variant lists one literal task name.
+  #
+  # We're using Ubuntu 22.04 arm64 because it has docker-compose v2. The m7g.2xlarge is big enough
+  # to run the many containers for SLS.
+  #
+  # _platform is set because this variant's own name is not in release/platform's table, and
+  # ci-env.sh needs a name that is, or build.go drops the per-platform build tags - including
+  # "failpoints", which several integration tests need.
+  - name: ubuntu2204-arm64-dsc
+    display_name: "# Ubuntu 22.04 ARM Disaggregated Storage"
+    cron: 0 3 * * *
+    run_on:
+      - ubuntu2204-arm64-latest-large
+    expansions:
+      _platform: ubuntu2204-arm64
+    tasks:
+      - name: "integration-9.1-dsc"
+
   - name: amazon2023-aarch64
     display_name: Amazon Linux 2023 ARM
     run_on:
@@ -3302,6 +3437,14 @@ buildvariants:
       - name: "push"
         run_on: rhel80-small
 
+# Unlike github_pr_aliases, this block is not generated. The merge queue runs the no-op gate task
+# and nothing else, because Evergreen schedules that task's whole dependency closure, and those
+# dependencies are what gate a merge.  Change what gates a merge by editing the merge-queue
+# buildvariant's depends_on, not this block.
+commit_queue_aliases:
+  - variant: "^merge-queue$"
+    task: ".*"
+
 # This set of aliases is generated by the code in the `evergreen` directory.
 # Do not edit this by hand!
 # It can be regenerated by running `go run evergreen/generator/main.go`.
@@ -3327,15 +3470,10 @@ github_pr_aliases:
   # a relatively recent platform that supports a wide range of servers.
   - variant: "^rhel88$"
     task: "^(aws-auth|integration|kerberos|legacy|native-cert-ssl|qa-dump-restore|qa-tests)"
+  # Run the integration tests against a disaggregated-storage cluster.
+  - variant: "^ubuntu2204-arm64-dsc$"
+    task: ".*"
   # Run a subset of integration tests against the latest version of MongoDB
   # Server on all variants where that is the most recent supported version.
   - variant: "^(rhel88|windows)$"
     task: "integration-latest"
-
-# Unlike github_pr_aliases above, this block is not generated. The merge queue runs the no-op gate
-# task and nothing else, because Evergreen schedules that task's whole dependency closure, and those
-# dependencies are what gate a merge.  Change what gates a merge by editing the merge-queue
-# buildvariant's depends_on, not this block.
-commit_queue_aliases:
-  - variant: "^merge-queue$"
-    task: ".*"

--- a/etc/mongodb-downloader-config.yaml
+++ b/etc/mongodb-downloader-config.yaml
@@ -1,0 +1,16 @@
+s3:
+  bucket: c2c-testing-server-artifacts
+  region: us-east-1
+  serverBinariesPrefix: server-binaries
+  resmokePrefix: resmoke
+
+serverVersions:
+  - version: "9.1-dsc"
+    commit: 8161735c839119f6f21ccd4861df07e922f39335
+    disagg: true
+    resmoke: false
+    platforms:
+      - os: ubuntu2204
+        arch: arm64
+      - os: ubuntu2204
+        arch: x86_64

--- a/etc/mongodb-downloader-s3-artifacts.json
+++ b/etc/mongodb-downloader-s3-artifacts.json
@@ -1,0 +1,17 @@
+{
+    "serverBinaries": {
+        "ubuntu2204-arm64": {
+            "9.1-dsc": {
+                "tarball": "ubuntu2204-arm64-9.1-dsc-8161735c839119f6f21ccd4861df07e922f39335.tar.xz",
+                "commit": "8161735c839119f6f21ccd4861df07e922f39335"
+            }
+        },
+        "ubuntu2204-x86_64": {
+            "9.1-dsc": {
+                "tarball": "ubuntu2204-x86_64-9.1-dsc-8161735c839119f6f21ccd4861df07e922f39335.tar.xz",
+                "commit": "8161735c839119f6f21ccd4861df07e922f39335"
+            }
+        }
+    },
+    "resmoke": null
+}

--- a/evergreen/evergreen.go
+++ b/evergreen/evergreen.go
@@ -171,6 +171,11 @@ func (c *Config) aliases() ([]alias, error) {
 			variant: `^rhel88$`,
 			tasks:   `^(aws-auth|integration|kerberos|legacy|native-cert-ssl|qa-dump-restore|qa-tests)`,
 		},
+		{
+			comment: "Run the integration tests against a disaggregated-storage cluster.",
+			variant: `^ubuntu2204-arm64-dsc$`,
+			tasks:   `.*`,
+		},
 	}
 
 	// This finds the most recent version of the server supported by each variant. Based on that it

--- a/integration/dumprestore/oplog_replset_test.go
+++ b/integration/dumprestore/oplog_replset_test.go
@@ -19,6 +19,10 @@ func (s *DumpRestoreSuite) TestOplogReplayFromLocalOplogRS() {
 	// local.oplog.rs only exists on a replica set. The suite as a whole gates on
 	// the integration test type, so this case needs a gate of its own.
 	testtype.SkipUnlessTestType(s.T(), testtype.ReplSetTestType)
+	testutil.SkipForDisaggregatedStorage(
+		s.T(),
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	const collName = "coll"
 

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -824,6 +824,11 @@ func (s *DumpRestoreSuite) TestIgnoreMongoDBInternal() {
 		s.T().Skip("replica set required")
 	}
 
+	testutil.SkipForDisaggregatedStorage(
+		s.T(),
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
+
 	ctx := s.Context()
 
 	testName := s.DBName()

--- a/mise.dsc.toml
+++ b/mise.dsc.toml
@@ -1,0 +1,20 @@
+# mongodb-downloader lives here rather than in mise.toml because 10gen/mongodb-downloader is a
+# private repo. Running `mise install` would fail with a 404 for anyone without a token that can
+# read that repo. This would break lint and every other task that installs mise-managed tools. mise
+# has no way to make a tool conditional on the user having access, so instead this config
+# environment keeps it out of sight of everything except the code that actually wants it.
+#
+# When `MISE_ENV=dsc` is set, then this config file is included when `mise install` is run. This is
+# set by `scripts/start-dsc-cluster.sh`.
+
+[tools]
+# This opts out of mise.toml's minimum_release_age because these releases are ours and are cut as
+# they are needed.
+"github:10gen/mongodb-downloader" = { version = "0.0.4", minimum_release_age = "0d" }
+
+[settings]
+# Evergreen passes GITHUB_TOKEN, which takes precedence over this, so if the Evergreen hosts don't
+# have the `gh` command installed, this is not an issue. Locally, this saves everyone from having to
+# export a token by hand: mise does not pick up gh's token on its own for private release assets,
+# even though github.gh_cli_tokens defaults to true.
+github.credential_command = "gh auth token"

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,9 @@ go = "1.26.7"
 node = "22.22.0"
 "npm:eslint" = "8.57.0"
 "npm:github-codeowners" = "0.2.1"
+# This opts out of the minimum_release_age below because this release is ours and is cut as it is
+# needed.
+"npm:@mongodb-js/mongodb-runner" = { version = "6.12.0", minimum_release_age = "0d" }
 "npm:oxfmt" = "0.52.0"
 
 [settings]

--- a/mongorestore/mongorestore_archive_test.go
+++ b/mongorestore/mongorestore_archive_test.go
@@ -101,6 +101,10 @@ func TestMongorestoreShortArchive(t *testing.T) {
 
 func TestMongorestoreArchiveWithOplog(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -509,6 +509,10 @@ func TestMongorestoreLongCollectionName(t *testing.T) {
 
 func TestMongorestorePreserveUUID(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it restores with --preserveUUID, which mongorestore implements via applyOps, and DSC does not support that command",
+	)
 	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
@@ -1499,6 +1503,10 @@ func TestAutoIndexIdNonLocalDB(t *testing.T) {
 // related tables aren't applied via applyops when replaying the oplog.
 func TestSkipSystemCollections(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	ctx := t.Context()
 
 	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
@@ -1647,6 +1655,10 @@ func TestSkipStartAndAbortIndexBuild(t *testing.T) {
 // TestcommitIndexBuild asserts that all "commitIndexBuild" are converted to creatIndexes commands.
 func TestCommitIndexBuild(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	ctx := t.Context()
 	testDB := "commit_index"
 
@@ -1737,6 +1749,10 @@ func TestCommitIndexBuild(t *testing.T) {
 // CreateIndexes oplog will be applied directly for versions < 4.4 and converted to createIndex cmd > 4.4.
 func TestCreateIndexes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	ctx := t.Context()
 	testDB := "create_indexes"
 
@@ -2403,6 +2419,10 @@ func TestRestoreClusteredIndex(t *testing.T) {
 	require := require.New(t)
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -38,6 +38,10 @@ type txnTestDataCase struct {
 
 func TestMongorestoreTxns(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")

--- a/mongorestore/oplog_edges_test.go
+++ b/mongorestore/oplog_edges_test.go
@@ -59,6 +59,10 @@ func TestOplogReplayPriorityOplog(t *testing.T) {
 	// permitted on a standalone: a replica set rejects direct oplog writes, and
 	// mongos rejects writes to the local database.
 	testutil.SkipUnlessStandalone(t)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
@@ -111,6 +115,10 @@ func TestOplogReplayPriorityOplog(t *testing.T) {
 // are skipped while the inserts around them are still applied.
 func TestOplogReplayNoop(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
@@ -149,6 +157,10 @@ func TestOplogReplayNoop(t *testing.T) {
 // chance.
 func TestOplogReplayPreservesComplexIDOrder(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
@@ -252,6 +264,10 @@ func writeOplogUpdate(t *testing.T, path, ns string, id bson.D) {
 // within the server's message size limit (TOOLS-939).
 func TestOplogReplaySizeSafety(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -134,6 +134,10 @@ func TestValidOplogLimitChecking(t *testing.T) {
 
 func TestOplogRestore(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	session, err := testutil.GetBareSession(t)
 	if err != nil {
@@ -180,6 +184,10 @@ func TestOplogRestore(t *testing.T) {
 
 func TestOplogRestoreWithDuplicateIndexKeys(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	session, err := testutil.GetBareSession(t)
 	if err != nil {
@@ -216,6 +224,10 @@ func TestOplogRestoreWithDuplicateIndexKeys(t *testing.T) {
 
 func TestOplogRestoreUpdatesIndexCatalog(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	session, err := testutil.GetBareSession(t)
 	if err != nil {
@@ -495,6 +507,10 @@ func TestOplogRestoreUpdatesIndexCatalog(t *testing.T) {
 
 func TestOplogRestoreMaxDocumentSize(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	session, err := testutil.GetBareSession(t)
 	if err != nil {
@@ -604,6 +620,10 @@ func generateOplogWith16MiBDocument() ([]byte, error) {
 
 func TestOplogRestoreTools2002(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
@@ -703,6 +723,10 @@ func TestOplogRestoreVectoredInsert(t *testing.T) {
 
 func testOplogRestoreVectoredInsert(t *testing.T, linked bool) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	ctx := t.Context()
 
@@ -783,6 +807,10 @@ func testOplogRestoreVectoredInsert(t *testing.T, linked bool) {
 
 func TestOplogRestoreCollModIndexUniqueness(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	ctx := t.Context()
 
@@ -847,6 +875,10 @@ func TestOplogRestoreCollModIndexUniqueness(t *testing.T) {
 
 func TestOplogRestoreBypassDocumentValidation(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	ctx := t.Context()
 
@@ -897,6 +929,10 @@ func TestOplogRestoreBypassDocumentValidation(t *testing.T) {
 
 func TestOplogRestoreCollModTTLIndex(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	testutil.SkipIfFCVLessThan(t, "6.0", "collMod TTL is not supported")
 
 	ctx := t.Context()
@@ -954,6 +990,10 @@ func TestOplogRestoreCollModTTLIndex(t *testing.T) {
 // generic "unknown oplog command name" error.
 func TestOplogRestoreViewlessTimeseriesConversion(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	ctx := t.Context()
 
@@ -1050,6 +1090,10 @@ func TestOplogRestoreViewlessTimeseriesConversion(t *testing.T) {
 // forwarded to the target, whether it appears on its own or nested inside an applyOps.
 func TestOplogRestoreDropIdent(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	ctx := t.Context()
 

--- a/release/platform/platform_test.go
+++ b/release/platform/platform_test.go
@@ -42,8 +42,12 @@ func TestPlatformsMatchCI(t *testing.T) {
 	for _, v := range config.Variants {
 		// Variant "mongodump_passthru_v" has been added to support mongodump
 		// passthrough testing.
+		//
+		// Variant "ubuntu2204-arm64-dsc" only runs the integration suite against a
+		// disaggregated-storage cluster. It never builds anything we release.
 		if v.Name == "release" || v.Name == "static" || v.Name == "rhel88-race" ||
-			v.Name == "mongodump_passthru_v" || v.Name == "merge-queue" {
+			v.Name == "mongodump_passthru_v" || v.Name == "merge-queue" ||
+			v.Name == "ubuntu2204-arm64-dsc" {
 			continue
 		}
 

--- a/scripts/authenticate-sls-ecr.sh
+++ b/scripts/authenticate-sls-ecr.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Authenticates docker to the ECR registry hosting the SLS container images.
+#
+# This runs both locally and in Evergreen.
+#
+# The credentials that can pull SLS images are not the same ones that can read the Server binary
+# tarballs from S3, so this takes its profile from `SLS_ECR_AWS_PROFILE` rather than sharing
+# `AWS_PROFILE` with the rest of the toolchain. If we tried to use one profile for both, then either
+# the Docker or S3 interactions would fail. `SLS_ECR_AWS_PROFILE` falls back to `AWS_PROFILE` when
+# unset, so running this script on its own still works.
+#
+# Evergreen does not set any profile env vars. The `ec2.assume_role` command sets
+# `AWS_ACCESS_KEY_ID` and related env vars, which the aws CLI picks up on its own.
+#
+# Note that a successful login here does not prove you can pull: minting a token only needs
+# `ecr:GetAuthorizationToken` in your own account, while pulling needs `ecr:BatchGetImage` granted
+# by a resource-based policy on the repositories in account 664315256653. Login succeeds with a
+# profile that cannot pull, so verify with `docker manifest inspect` if a pull later fails.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REGISTRY_ID="664315256653"
+ECR="${REGISTRY_ID}.dkr.ecr.us-east-1.amazonaws.com"
+REGION="us-east-1"
+
+if [ -n "${SLS_ECR_AWS_PROFILE:-}" ]; then
+    export AWS_PROFILE="${SLS_ECR_AWS_PROFILE:?}"
+fi
+
+# This must be get-authorization-token with --registry-ids, not the more familiar
+# get-login-password. get-login-password issues a token scoped to the caller's _own_
+# registry. Locally that is the wrong account - a developer's profile lives outside 664315256653 -
+# so docker login rejects the token with "status: 400 Bad Request".
+#
+# In Evergreen the assumed role is inside `664315256653`, so get-login-password would work there,
+# but it's simpler to use the same command for both cases.
+set -o xtrace
+aws ecr get-authorization-token \
+    --region "${REGION}" \
+    --registry-ids "${REGISTRY_ID}" \
+    --query 'authorizationData[0].authorizationToken' \
+    --output text |
+    base64 -d | cut -d: -f2- |
+    docker login --username AWS --password-stdin "${ECR}"

--- a/scripts/install-mise-managed-tools.sh
+++ b/scripts/install-mise-managed-tools.sh
@@ -33,12 +33,14 @@ recreate_npm_bin_symlinks() {
     for install_dir in "${mise_data_dir}/installs"/npm-*/*/; do
         local lib_modules="${install_dir}lib/node_modules"
         [ -d "${lib_modules}" ] || continue
-        for pkg_dir in "${lib_modules}"/*/; do
-            [ -f "${pkg_dir}package.json" ] || continue
+        # A plain glob over node_modules/* misses scoped packages, which live one level deeper at
+        # node_modules/@scope/pkg, so find the package.json files instead.
+        while IFS= read -r pkg_json; do
             local pkg_name
-            pkg_name=$(basename "${pkg_dir}")
-            python3 "$SCRIPT_DIR/recreate-npm-bin-symlinks.py" "${install_dir%/}" "${pkg_name}" "${pkg_dir}package.json"
-        done
+            pkg_name="${pkg_json#"${lib_modules}"/}"
+            pkg_name="${pkg_name%/package.json}"
+            python3 "$SCRIPT_DIR/recreate-npm-bin-symlinks.py" "${install_dir%/}" "${pkg_name}" "${pkg_json}"
+        done < <(find "${lib_modules}" -mindepth 2 -maxdepth 3 -name package.json -type f)
     done
 }
 

--- a/scripts/start-dsc-cluster.sh
+++ b/scripts/start-dsc-cluster.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# Starts a 2-node disaggregated-storage (DSC) replica set for running the tools integration suite
+# against, and prints the connection string to export as TOOLS_TESTING_MONGOD.
+#
+# Everything except mongodb-runner itself comes out of one tarball: the DSC-capable binaries, the
+# SLS compose file, and the pinned SLS image tag. The compose file and the image tag are read from
+# the tarball rather than from a mongo repo checkout so they can never drift from the Server
+# binaries they were built alongside.
+#
+# This script starts a cluster and then exits, leaving it running. Cluster startup requires starting
+# a docker compose project and, on a first run, several minutes of SLS image pulls.
+#
+# Prerequisites: docker compose v2, `mise install` for mongodb-runner, and read access to the
+# private 10gen/mongodb-downloader repo, either through gh or through GITHUB_TOKEN.
+#
+# Use scripts/stop-dsc-cluster.sh to stop the cluster.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+# shellcheck source=scripts/functions.sh
+source "${SCRIPT_DIR}/functions.sh"
+
+# In Evergreen, mise itself is under ${workdir}, which is what ci-env.sh puts on PATH.
+if [ -n "${EVG_WORKDIR:-}" ]; then
+    # shellcheck source=scripts/ci-env.sh
+    source "${SCRIPT_DIR:?}/ci-env.sh"
+fi
+
+RUNNER=(mise exec node npm:@mongodb-js/mongodb-runner -- mongodb-runner)
+
+# mise.dsc.toml, which adds mongodb-downloader, is only visible under this MISE_ENV. See the
+# comments in that file for more details on why it exists.
+export MISE_ENV=dsc
+DOWNLOADER=(mise exec github:10gen/mongodb-downloader -- mongodb-downloader)
+
+VERSION_LABEL="9.1-dsc"
+# Absolute, not relative: mongodb-runner spawns mongod from its own working directory rather than
+# ours, so a relative --binDir fails with "spawn dsc-cluster/server/bin/mongod ENOENT" even though
+# the binary is there. Deriving from $0 also lets this run from any working directory.
+REPO_ROOT="$(cd "${SCRIPT_DIR:?}/.." && pwd)"
+CLUSTER_DIR="${REPO_ROOT:?}/dsc-cluster"
+INSTALL_DIR="${CLUSTER_DIR:?}/server"
+LOG_DIR="${CLUSTER_DIR:?}/logs"
+CLUSTER_ID="tools-dsc"
+ATLAS_DIR="${INSTALL_DIR:?}/buildscripts/modules/atlas"
+
+if ! docker compose version >/dev/null 2>&1; then
+    echo "docker compose v2 is required; see the DSC prerequisites in mongodb-runner's docs" >&2
+    exit 1
+fi
+
+# We use Python to read the SLS image tag from the `manifest.json` file in the Server tarball.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to read pinned_sls_commit from the manifest JSON file in the Server tarball" >&2
+    exit 1
+fi
+
+# We want to actually run the tool rather than just resolving its path: a restored tool cache can
+# leave bin/mongodb-runner in place but unable to load its own package (see the comment on
+# recreate_npm_bin_symlinks in scripts/install-mise-managed-tools.sh).
+if ! "${RUNNER[@]}" --help >/dev/null 2>&1; then
+    echo 'mongodb-runner is not installed or cannot load; run "mise install"' >&2
+    exit 1
+fi
+
+# Installed here rather than in a separate step because it comes from a private repo: it cannot be
+# part of the plain "mise install" that everything else in mise.toml goes through. The token comes
+# from GITHUB_TOKEN in Evergreen and from "gh auth token" locally (see mise.dsc.toml). We only retry
+# twice because the likely failure is a token that cannot read the repo, which is not transient.
+RETRY_FAILURES_BEFORE_BACKOFF=0 RETRY_FAILURES_BEFORE_HARD_FAIL=1 \
+    retry mise install github:10gen/mongodb-downloader
+
+mkdir -p "${CLUSTER_DIR:?}" "${LOG_DIR:?}"
+
+# The SLS images live in a private registry, so we log in before compose tries to pull them. The
+# login runs under SLS_ECR_AWS_PROFILE, which authenticate-sls-ecr.sh reads directly, so the
+# download below still uses whatever AWS_PROFILE the caller set.
+#
+# Evergreen does its own login, in a step before it assumes the role that reads Server builds from
+# S3, because only one set of AWS_* variables can be in the environment at a time. Repeating it here
+# would run under the S3 role, which cannot mint an ECR token. The docker login from that earlier
+# step is still in effect, since it is recorded in ~/.docker/config.json.
+if [ -z "${EVG_WORKDIR:-}" ]; then
+    "${SCRIPT_DIR:?}/authenticate-sls-ecr.sh"
+fi
+
+"${DOWNLOADER[@]}" download \
+    --config "${REPO_ROOT:?}/etc/mongodb-downloader-config.yaml" \
+    --output-dir "${REPO_ROOT:?}/etc/" \
+    --server-version "${VERSION_LABEL:?}" \
+    --to "${INSTALL_DIR:?}"
+
+COMPOSE_FILE="${ATLAS_DIR:?}/sls-multicell-docker-compose.yml"
+MANIFEST="${ATLAS_DIR:?}/manifest.json"
+
+for f in "${COMPOSE_FILE:?}" "${MANIFEST:?}" "${ATLAS_DIR:?}/slsbackup.proto" "${ATLAS_DIR:?}/flags-state.json"; do
+    if [ ! -f "$f" ]; then
+        echo "missing ${f}: the downloaded tarball is not a disagg build" >&2
+        exit 1
+    fi
+done
+
+# We read the SLS image tag from the manifest bundled with the Server binaries. This ensures that we
+# test using the same Server binary/SLS tag combo that the Server tests with.
+SLS_IMAGE_TAG="$(python3 -c "import json; print(json.load(open('${MANIFEST:?}'))['pinned_sls_commit'])")"
+
+echo "Starting a DSC replica set (SLS image tag ${SLS_IMAGE_TAG:?}). The first run pulls all SLS images and can take several minutes." >&2
+
+cleanup_started_cluster() {
+    echo "start failed after the cluster came up; tearing it down" >&2
+    "${SCRIPT_DIR:?}/stop-dsc-cluster.sh" || echo "teardown also failed; run scripts/stop-dsc-cluster.sh by hand" >&2
+}
+
+# stop-dsc-cluster.sh checks for the marker file before it tears anything down. We create it and
+# install the cleanup trap before starting the cluster so that a failed `mongodb-runner start`
+# (which errexit/pipefail would otherwise let end the script) still tears the cluster down.
+touch "${CLUSTER_DIR:?}/connection-string"
+trap cleanup_started_cluster EXIT
+
+# Without --debug a DSC startup failure is very hard to diagnose: details are in the compose output
+# and the per-mongod logs. The runner writes its diagnostics to stderr and only the connection
+# string to stdout, so capturing stdout keeps it parseable; the tee is there to keep those
+# diagnostics visible on the terminal as they happen.
+OUTPUT="$("${RUNNER[@]}" start \
+    --topology=replset \
+    --slsCompose="${COMPOSE_FILE:?}" \
+    --slsImageTag="${SLS_IMAGE_TAG:?}" \
+    --binDir="${INSTALL_DIR:?}/bin" \
+    --logDir="${LOG_DIR:?}" \
+    --id="${CLUSTER_ID:?}" \
+    --debug | tee /dev/stderr)"
+
+# The runner prints the cluster URI last, after the per-node startup output. The grep can legitimately
+# fail when the cluster comes up but the URI is missing from the output, so the `if !` here is what
+# keeps errexit from swallowing the diagnostic below.
+if ! CONNECTION_STRING="$(echo "${OUTPUT:?}" | grep -oE 'mongodb://[^ ]+' | tail -1)"; then
+    echo "the cluster started but printed no mongodb:// connection string; check ${LOG_DIR}" >&2
+    exit 1
+fi
+
+echo "${CONNECTION_STRING:?}" >"${CLUSTER_DIR:?}/connection-string"
+
+# Evergreen's expansions.update reads a YAML file. This is written unconditionally so that a local
+# run produces the same artifacts as a CI run.
+echo "TOOLS_TESTING_MONGOD: '${CONNECTION_STRING:?}'" >"${CLUSTER_DIR:?}/expansions.yml"
+
+# Now that the cluster is running properly, we don't want to stop it when the script exits.
+trap - EXIT
+
+echo
+echo "export TOOLS_TESTING_MONGOD='${CONNECTION_STRING:?}'"

--- a/scripts/stop-dsc-cluster.sh
+++ b/scripts/stop-dsc-cluster.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Tears down a DSC cluster started by scripts/start-dsc-cluster.sh, including the docker compose
+# project providing the SLS storage backend.
+#
+# This is a no-op when the cluster was not started, because we run this in the Evergreen `post`
+# block for every task in the project.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CLUSTER_ID="tools-dsc"
+REPO_ROOT="$(cd "${SCRIPT_DIR:?}/.." && pwd)"
+CLUSTER_DIR="${REPO_ROOT:?}/dsc-cluster"
+
+# We continue even if there's just a log directory, because a start that fails partway through leaves logs but no
+# connection string.
+if [ ! -f "${CLUSTER_DIR:?}/connection-string" ] && [ ! -d "${CLUSTER_DIR:?}/logs" ]; then
+    echo "no ${CLUSTER_DIR}/connection-string and no ${CLUSTER_DIR}/logs, so there is no DSC cluster to stop" >&2
+    exit 0
+fi
+
+if [ -n "${EVG_WORKDIR:-}" ]; then
+    # shellcheck source=scripts/ci-env.sh
+    source "${SCRIPT_DIR:?}/ci-env.sh"
+fi
+
+RUNNER=(mise exec node npm:@mongodb-js/mongodb-runner -- mongodb-runner)
+
+# Archiving happens after the teardown, so that anything the runner writes into logDir during
+# teardown is included.
+#
+# The teardown's exit status is held rather than allowed to end the script, so that a failed teardown
+# still produces an archive.
+#
+# The teardown is skipped when there is no connection string, because the runner tears its own
+# compose project down when start fails.
+STOP_STATUS=0
+if [ -f "${CLUSTER_DIR:?}/connection-string" ]; then
+    "${RUNNER[@]}" stop --id="${CLUSTER_ID:?}" || STOP_STATUS=$?
+fi
+
+# Archived here rather than with an `s3.put` because this runs in Evergreen's project-wide post
+# block. A filter that matches nothing would require `s3.put` to allow `optional` for multi-file
+# puts, which it does not.
+if [ -d "${CLUSTER_DIR:?}/logs" ]; then
+    tar -czf "${CLUSTER_DIR:?}/logs.tgz" -C "${CLUSTER_DIR:?}" logs ||
+        echo "could not archive the cluster logs" >&2
+fi
+
+rm -f "${CLUSTER_DIR:?}/connection-string" "${CLUSTER_DIR:?}/expansions.yml"
+
+exit "${STOP_STATUS}"


### PR DESCRIPTION
This uses `mongodb-downloader` to manage the Server binaries for this task. It uses `mongodb-runner` to actually start the cluster.

The `mongodb-downloader` repo is private, so this adds a new, separate mise config file for just that project. It's only used when `MISE_ENV=dsc` is set in the environment. For example, running `mise install` will not install it unless that env var is set. The same goes for running `mise exec`.

This adds scripts for authenticating against the SLS ECR repo as well as start and stopping a cluster. All of this can be run both locally on dev machines and in CI.

The S3 bucket with the Server tarballs and the ECR registry are accessed via differerent AWS profiles, so the Evergreen config has to order these things in a specific way. We have to complete all the tasks needed for one role before the next `ec2.assume_role` call, because each call resets the AWS env vars visible to the task.

This PR also adds skips for any test that runs `applyOps`, since DSC clusters do not support this command.