### PR TITLE
TOOLS-4100 Always connect to the test cluster using the same shared code

### DIFF
--- a/integration/exportimport/suite_test.go
+++ b/integration/exportimport/suite_test.go
@@ -4,12 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	"github.com/mongodb/mongo-tools/integration/sharedsuite"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
@@ -48,25 +46,13 @@ func (s *ExportImportSuite) ExportOptions() mongoexport.Options {
 }
 
 func (s *ExportImportSuite) ImportOptions(dbName, collName string) mongoimport.Options {
-	ssl := testutil.GetSSLOptions()
-	auth := testutil.GetAuthOptions()
+	toolOptions, err := testutil.GetToolOptions()
+	s.Require().NoError(err)
+	toolOptions.Namespace.DB = dbName
+	toolOptions.Namespace.Collection = collName
 
 	return mongoimport.Options{
-		ToolOptions: &options.ToolOptions{
-			General: &options.General{},
-			SSL:     &ssl,
-			Connection: &options.Connection{
-				Host: "localhost",
-				Port: db.DefaultTestPort,
-			},
-			Auth: &auth,
-			URI:  &options.URI{},
-			Namespace: &options.Namespace{
-				DB:         dbName,
-				Collection: collName,
-			},
-			WriteConcern: wcwrapper.Majority(),
-		},
+		ToolOptions: toolOptions,
 		InputOptions: &mongoimport.InputOptions{
 			ParseGrace: "stop",
 		},

--- a/mongoexport/mongoexport_test.go
+++ b/mongoexport/mongoexport_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -614,20 +613,9 @@ func TestExportNestedFieldsCSV(t *testing.T) {
 
 func newExportTestClient(t *testing.T, dbName string) *mongo.Client {
 	t.Helper()
-	ssl := testutil.GetSSLOptions()
-	auth := testutil.GetAuthOptions()
-	sessionProvider, err := db.NewSessionProvider(options.ToolOptions{
-		General: &options.General{},
-		SSL:     &ssl,
-		Connection: &options.Connection{
-			Host: "localhost",
-			Port: db.DefaultTestPort,
-		},
-		Auth:         &auth,
-		URI:          &options.URI{},
-		Namespace:    &options.Namespace{},
-		WriteConcern: wcwrapper.Majority(),
-	})
+	toolOptions, err := testutil.GetToolOptions()
+	require.NoError(t, err, "should get tool options")
+	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	require.NoError(t, err, "should create session provider")
 	client, err := sessionProvider.GetSession()
 	require.NoError(t, err, "should get session")

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,31 +30,26 @@ import (
 )
 
 var (
-	testDB     = "mongofiles_test_db"
-	testServer = "localhost"
-	testPort   = db.DefaultTestPort
+	testDB = "mongofiles_test_db"
 
-	ssl        = testutil.GetSSLOptions()
-	auth       = testutil.GetAuthOptions()
-	connection = &options.Connection{
-		Host: testServer,
-		Port: testPort,
-	}
-	toolOptions = &options.ToolOptions{
-		SSL:          &ssl,
-		Connection:   connection,
-		Auth:         &auth,
-		Verbosity:    &options.Verbosity{},
-		URI:          &options.URI{},
-		WriteConcern: wcwrapper.Majority(),
-	}
-	testFiles = map[string]bson.ObjectID{
+	ssl         = testutil.GetSSLOptions()
+	toolOptions = mustGetToolOptions()
+	testFiles   = map[string]bson.ObjectID{
 		"testfile1": bson.NewObjectID(),
 		"testfile2": bson.NewObjectID(),
 		"testfile3": bson.NewObjectID(),
 		"testfile4": bson.NewObjectID(),
 	}
 )
+
+func mustGetToolOptions() *options.ToolOptions {
+	toolOptions, err := testutil.GetToolOptions()
+	if err != nil {
+		panic(fmt.Sprintf("could not get tool options: %v", err))
+	}
+
+	return toolOptions
+}
 
 // put in some test data into GridFS.
 func setUpGridFSTestData() (map[string]int, error) {

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
-	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,27 +107,14 @@ func countDocuments(t *testing.T, sessionProvider *db.SessionProvider) (int, err
 // getBasicToolOptions returns a test helper to instantiate the session provider
 // for calls to StreamDocument.
 func getBasicToolOptions() *options.ToolOptions {
-	general := &options.General{}
-	ssl := testutil.GetSSLOptions()
-	auth := testutil.GetAuthOptions()
-	namespace := &options.Namespace{
-		DB:         testDb,
-		Collection: testCollection,
+	toolOptions, err := testutil.GetToolOptions()
+	if err != nil {
+		panic(fmt.Sprintf("could not get tool options: %v", err))
 	}
-	connection := &options.Connection{
-		Host: "localhost",
-		Port: db.DefaultTestPort,
-	}
+	toolOptions.Namespace.DB = testDb
+	toolOptions.Namespace.Collection = testCollection
 
-	return &options.ToolOptions{
-		General:      general,
-		SSL:          &ssl,
-		Namespace:    namespace,
-		Connection:   connection,
-		Auth:         &auth,
-		URI:          &options.URI{},
-		WriteConcern: wcwrapper.Majority(),
-	}
+	return toolOptions
 }
 
 func newOptions() Options {
@@ -1908,20 +1894,9 @@ func TestImportModeByID(t *testing.T) {
 
 func newImportTestClient(t *testing.T, dbName string) *mongo.Client {
 	t.Helper()
-	ssl := testutil.GetSSLOptions()
-	auth := testutil.GetAuthOptions()
-	sessionProvider, err := db.NewSessionProvider(options.ToolOptions{
-		General: &options.General{},
-		SSL:     &ssl,
-		Connection: &options.Connection{
-			Host: "localhost",
-			Port: db.DefaultTestPort,
-		},
-		Auth:         &auth,
-		URI:          &options.URI{},
-		Namespace:    &options.Namespace{},
-		WriteConcern: wcwrapper.Majority(),
-	})
+	toolOptions, err := testutil.GetToolOptions()
+	require.NoError(t, err, "should get tool options")
+	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	require.NoError(t, err, "should create session provider")
 	client, err := sessionProvider.GetSession()
 	require.NoError(t, err, "should get session")


### PR DESCRIPTION
There were a few spots that hard-coded the connection options instead of checking for `TOOLS_TESTING_MONGOD`.