### PR TITLE
TOOLS-4334 Run the integration suite without SSL in CI

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1821,6 +1821,42 @@ tasks:
         vars:
           target: test:integration -ssl=true ${testArgs}
 
+  # Every other integration task runs with TLS on, which means a test that skips
+  # itself when TLS is enabled never runs anywhere. This task is the one that
+  # exercises the no-TLS path. It is deliberately not tagged with a server
+  # version, so that it runs only on the variants that ask for ".no-ssl".
+  - name: integration-latest-no-ssl
+    tags: ["no-ssl"]
+    commands:
+      - func: "fetch source"
+      # Variants that run integration tasks set mongod_args/mongo_args to their
+      # SSL values, and the startup scripts only look at the _tls variables when
+      # USE_TLS is true. Without these overrides, USE_TLS: "" would still start a
+      # requireSSL mongod and every test would fail to connect.
+      - command: expansions.update
+        params:
+          updates:
+            - key: "mongod_args"
+              value: ""
+            - key: "mongo_args"
+              value: *mongo_default_startup_args_string
+      - func: "install mise and go"
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "latest"
+      - func: "start mongod"
+        vars:
+          USE_TLS: ""
+      - func: "wait for mongod to be ready"
+        vars:
+          USE_TLS: ""
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:integration ${testArgs}
+
   - name: integration-latest-auth
     tags: ["latest", "auth"]
     commands:
@@ -2730,6 +2766,7 @@ buildvariants:
       - name: ".8.3"
       - name: ".9.0"
       - name: ".latest"
+      - name: ".no-ssl"
       - name: ".kerberos"
       - name: "dist"
       - name: "sign"

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
-	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 )
 
 var (
@@ -1184,7 +1183,7 @@ func TestDefaultWriteConcern(t *testing.T) {
 		So(
 			mf.ToolOptions.WriteConcern,
 			ShouldResemble,
-			writeconcern.Majority(),
+			wcwrapper.Majority(),
 		)
 	})
 
@@ -1194,7 +1193,7 @@ func TestDefaultWriteConcern(t *testing.T) {
 		So(
 			mf.ToolOptions.WriteConcern,
 			ShouldResemble,
-			writeconcern.Majority(),
+			wcwrapper.Majority(),
 		)
 	})
 }


### PR DESCRIPTION
Every integration task in `common.yml` passed `-ssl=true`, so any test only runs when SSL is disabled was not being run in CI. `mongofiles.TestDefaultWriteConcern` is guarded that way and had been broken since 3810989b7 (TOOLS-3968, #868) without anyone noticing.

This adds a new `integration-latest-no-ssl` task. It runs with the latest server version, standalone, no TLS, and `test:integration` with no `-ssl` flag.

This PR also fixes `TestDefaultWriteConcern` to compare against `wcwrapper.Majority()`. TOOLS-3968 changed `ToolOptions.WriteConcern` to `*wcwrapper.WriteConcern` but left the expected value as the raw driver `writeconcern.Majority()`, so this would never compare as equal.