### PR TITLE
TOOLS-4080 Add a merge-queue variant so we can have GitHub block on this

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,16 +88,26 @@ locally.
 All merges go through the GitHub merge queue. The queue re-runs CI on the result of merging your
 branch into `master`, which can catch breakage that isn't seen just by running CI on the PR.
 
-The queue runs the same set of tasks as pull request testing, minus `push`. Both sets are generated
-from the same list in `evergreen/evergreen.go` and written into `common.yml` as `github_pr_aliases`
-and `commit_queue_aliases`. To regenerate these blocks run:
+This repo's branch protection rules require exactly one status check, `evergreen/merge-queue`, which
+is the `merge-queue` build variant in `common.yml`. The only task in that variant is a no-op that
+`depends_on` the tasks that gate a merge. It turns green as soon as those pass, so a PR can enter
+the queue without waiting for every task the PR runs.
+
+To change what gates a merge, edit that variant's `depends_on`. Many test tasks include the
+`required-for-merge-queue` tag, so **a new test task must carry the tag** if we want it to block
+merges. A unit test in `evergreen` fails if a dependency of the `merge-queue` variant is not also
+run for PRs, since the required check could then never pass. Note that the opposite is not required.
+PRs can run tasks that are not required by the merge queue.
+
+The `github_pr_aliases` config is generated because part of it is derived from each variant's task
+list rather than written out by hand:
 
 ```bash
 go run evergreen/generator/main.go
 ```
 
-That prints both blocks to stdout. Replace the corresponding blocks in `common.yml` with its output.
-A unit test in `evergreen` fails if the two ever drift apart.
+That prints the block to stdout. Replace the `github_pr_aliases` block in `common.yml` with its
+output. A unit test in `evergreen` fails if the two ever drift apart.
 
 ## JIRA Tickets
 

--- a/common.yml
+++ b/common.yml
@@ -911,6 +911,16 @@ timeout:
   - func: "wait for resmoke to shutdown"
 
 tasks:
+  # A no-op whose dependencies are the tasks that gate a merge. It is the single required GitHub
+  # status check. See the merge-queue buildvariant.
+  - name: merge-queue-workaround
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            echo "This task is a no-op. It exists so that the merge queue has a single required status check."
+
   - name: dist
     tags: ["git_tag"]
     commands:
@@ -1029,7 +1039,7 @@ tasks:
       - func: "generate full JSON feed"
 
   - name: integration-4.2
-    tags: ["4.2"]
+    tags: ["4.2", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1051,7 +1061,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-4.2-auth
-    tags: ["4.2", "auth"]
+    tags: ["4.2", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1081,7 +1091,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-4.4
-    tags: ["4.4"]
+    tags: ["4.4", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1103,7 +1113,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-4.4-auth
-    tags: ["4.4", "auth"]
+    tags: ["4.4", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1133,7 +1143,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-4.4-cluster
-    tags: ["4.4", "cluster"]
+    tags: ["4.4", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1152,7 +1162,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: integration-5.0
-    tags: ["5.0"]
+    tags: ["5.0", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1174,7 +1184,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-5.0-auth
-    tags: ["5.0", "auth"]
+    tags: ["5.0", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1204,7 +1214,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-5.0-cluster
-    tags: ["5.0", "cluster"]
+    tags: ["5.0", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1223,7 +1233,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-5.0
-    tags: ["5.0", "aws-auth"]
+    tags: ["5.0", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1244,7 +1254,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-6.0
-    tags: ["6.0"]
+    tags: ["6.0", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1266,7 +1276,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-6.0-auth
-    tags: ["6.0", "auth"]
+    tags: ["6.0", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1296,7 +1306,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-6.0-cluster
-    tags: ["6.0", "cluster"]
+    tags: ["6.0", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1315,7 +1325,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-6.0
-    tags: ["6.0", "aws-auth"]
+    tags: ["6.0", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1336,7 +1346,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-7.0
-    tags: ["7.0"]
+    tags: ["7.0", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1358,7 +1368,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-7.0-auth
-    tags: ["7.0", "auth"]
+    tags: ["7.0", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1388,7 +1398,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-7.0-cluster
-    tags: ["7.0", "cluster"]
+    tags: ["7.0", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1407,7 +1417,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-7.0
-    tags: ["7.0", "aws-auth"]
+    tags: ["7.0", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1428,7 +1438,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-8.0
-    tags: ["8.0"]
+    tags: ["8.0", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1450,7 +1460,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-8.0-auth
-    tags: ["8.0", "auth"]
+    tags: ["8.0", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1480,7 +1490,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-8.0-cluster
-    tags: ["8.0", "cluster"]
+    tags: ["8.0", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1499,7 +1509,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-8.0
-    tags: ["8.0", "aws-auth"]
+    tags: ["8.0", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1520,7 +1530,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-8.2
-    tags: ["8.2"]
+    tags: ["8.2", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1542,7 +1552,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-8.2-auth
-    tags: ["8.2", "auth"]
+    tags: ["8.2", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1572,7 +1582,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-8.2-cluster
-    tags: ["8.2", "cluster"]
+    tags: ["8.2", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1592,7 +1602,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-8.2
-    tags: ["8.2", "aws-auth"]
+    tags: ["8.2", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1613,7 +1623,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-8.3
-    tags: ["8.3"]
+    tags: ["8.3", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1635,7 +1645,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-8.3-auth
-    tags: ["8.3", "auth"]
+    tags: ["8.3", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1665,7 +1675,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-8.3-cluster
-    tags: ["8.3", "cluster"]
+    tags: ["8.3", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1685,7 +1695,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-8.3
-    tags: ["8.3", "aws-auth"]
+    tags: ["8.3", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1706,7 +1716,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-9.0
-    tags: ["9.0"]
+    tags: ["9.0", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1728,7 +1738,7 @@ tasks:
           target: test:integration -ssl=true ${testArgs}
 
   - name: integration-9.0-auth
-    tags: ["9.0", "auth"]
+    tags: ["9.0", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1758,7 +1768,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-9.0-cluster
-    tags: ["9.0", "cluster"]
+    tags: ["9.0", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1778,7 +1788,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: aws-auth-9.0
-    tags: ["9.0", "aws-auth"]
+    tags: ["9.0", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1800,7 +1810,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: integration-latest
-    tags: ["latest"]
+    tags: ["latest", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1826,7 +1836,7 @@ tasks:
   # exercises the no-TLS path. It is deliberately not tagged with a server
   # version, so that it runs only on the variants that ask for ".no-ssl".
   - name: integration-latest-no-ssl
-    tags: ["no-ssl"]
+    tags: ["no-ssl", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Variants that run integration tasks set mongod_args/mongo_args to their
@@ -1858,7 +1868,7 @@ tasks:
           target: test:integration ${testArgs}
 
   - name: integration-latest-auth
-    tags: ["latest", "auth"]
+    tags: ["latest", "auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Concat auth args
@@ -1888,7 +1898,7 @@ tasks:
           target: test:integration -ssl=true -auth=true ${testArgs}
 
   - name: integration-latest-cluster
-    tags: ["latest", "cluster"]
+    tags: ["latest", "cluster", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1908,7 +1918,7 @@ tasks:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
   - name: integration-4.4-sharded
-    tags: ["4.4", "sharded"]
+    tags: ["4.4", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1925,7 +1935,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-5.0-sharded
-    tags: ["5.0", "sharded"]
+    tags: ["5.0", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1942,7 +1952,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-6.0-sharded
-    tags: ["6.0", "sharded"]
+    tags: ["6.0", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1959,7 +1969,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-7.0-sharded
-    tags: ["7.0", "sharded"]
+    tags: ["7.0", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1976,7 +1986,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-8.0-sharded
-    tags: ["8.0", "sharded"]
+    tags: ["8.0", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -1993,7 +2003,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-8.2-sharded
-    tags: ["8.2", "sharded"]
+    tags: ["8.2", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -2012,7 +2022,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: integration-latest-sharded
-    tags: ["latest", "sharded"]
+    tags: ["latest", "sharded", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -2031,7 +2041,7 @@ tasks:
           target: test:sharded-integration ${testArgs}
 
   - name: aws-auth-latest
-    tags: ["latest", "aws-auth"]
+    tags: ["latest", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -2052,7 +2062,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: aws-auth-4.4
-    tags: ["4.4", "aws-auth"]
+    tags: ["4.4", "aws-auth", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - command: expansions.update
@@ -2073,7 +2083,7 @@ tasks:
           target: test:awsauth ${testArgs}
 
   - name: kerberos
-    tags: ["kerberos"]
+    tags: ["kerberos", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       # Explicitly run ONLY Kerberos tests
@@ -2092,7 +2102,7 @@ tasks:
           target: test:kerberos ${testArgs}
 
   - name: legacy-jstests-4.2 # The server jstests from the tools removal from server in 4.2
-    tags: ["4.2", "no-race"]
+    tags: ["4.2", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2109,7 +2119,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-4.4 # The server jstests from the tools removal from server in 4.2
-    tags: ["4.4", "no-race"]
+    tags: ["4.4", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2126,7 +2136,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-5.0 # The server jstests from the tools removal from server in 4.2
-    tags: ["5.0", "no-race"]
+    tags: ["5.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2143,7 +2153,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-6.0 # The server jstests from the tools removal from server in 4.2
-    tags: ["6.0", "no-race"]
+    tags: ["6.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2160,7 +2170,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-7.0 # The server jstests from the tools removal from server in 4.2
-    tags: ["7.0", "no-race"]
+    tags: ["7.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2177,7 +2187,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-8.0 # The server jstests from the tools removal from server in 4.2
-    tags: ["8.0", "no-race"]
+    tags: ["8.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2194,7 +2204,7 @@ tasks:
           test_path: "test/legacy42"
 
   - name: legacy-jstests-8.2 # The server jstests from the tools removal from server in 4.2
-    tags: ["8.2", "no-race"]
+    tags: ["8.2", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2212,7 +2222,7 @@ tasks:
           load_libs_version: "8.2"
 
   - name: legacy-jstests-8.3 # The server jstests from the tools removal from server in 4.2
-    tags: ["8.3", "no-race"]
+    tags: ["8.3", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2230,7 +2240,7 @@ tasks:
           load_libs_version: "8.3"
 
   - name: legacy-jstests-9.0 # The server jstests from the tools removal from server in 4.2
-    tags: ["9.0", "no-race"]
+    tags: ["9.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2248,7 +2258,7 @@ tasks:
           load_libs_version: "9.0"
 
   - name: legacy-jstests-latest # The server jstests from the tools removal from server in 4.2
-    tags: ["latest", "no-race"]
+    tags: ["latest", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2292,7 +2302,7 @@ tasks:
             EVG_WORKDIR: ${workdir}
 
   - name: qa-tests-5.0
-    tags: ["5.0", "no-race"]
+    tags: ["5.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2310,7 +2320,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-6.0
-    tags: ["6.0", "no-race"]
+    tags: ["6.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2328,7 +2338,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-7.0
-    tags: ["7.0", "no-race"]
+    tags: ["7.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2346,7 +2356,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-8.0
-    tags: ["8.0", "no-race"]
+    tags: ["8.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2364,7 +2374,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-8.2
-    tags: ["8.2", "no-race"]
+    tags: ["8.2", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2382,7 +2392,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-8.3
-    tags: ["8.3", "no-race"]
+    tags: ["8.3", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2400,7 +2410,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-9.0
-    tags: ["9.0", "no-race"]
+    tags: ["9.0", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2418,7 +2428,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-latest
-    tags: ["latest", "no-race"]
+    tags: ["latest", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2436,7 +2446,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-4.4
-    tags: ["4.4", "no-race"]
+    tags: ["4.4", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2454,7 +2464,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-tests-4.2
-    tags: ["4.2", "no-race"]
+    tags: ["4.2", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2472,7 +2482,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: native-cert-ssl-4.4
-    tags: ["4.4", "no-race"]
+    tags: ["4.4", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2487,7 +2497,7 @@ tasks:
       - func: "run native-cert-ssl"
 
   - name: qa-dump-restore-with-archiving-4.4
-    tags: ["4.4", "no-race"]
+    tags: ["4.4", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2505,7 +2515,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: qa-dump-restore-with-gzip-4.4
-    tags: ["4.4", "no-race"]
+    tags: ["4.4", "no-race", "required-for-merge-queue"]
     commands:
       - func: "fetch source"
       - func: "get buildnumber"
@@ -2523,6 +2533,7 @@ tasks:
           excludes: "requires_unstable,${excludes}"
 
   - name: unit
+    tags: ["required-for-merge-queue"]
     commands:
       - command: expansions.update
       - func: "fetch source"
@@ -2593,6 +2604,47 @@ buildvariants:
       - name: check-third-party-notices
       - name: check-sbom-lite
       - name: check-sarif-report
+
+  #######################################
+  #      Merge Queue Buildvariant       #
+  #######################################
+
+  # The one variant GitHub branch protection requires, so that a PR can enter the merge queue as
+  # soon as the tasks below pass rather than waiting for every task the PR runs. The dependencies
+  # are what actually gate a merge.  See CONTRIBUTING.md.
+  - name: merge-queue
+    display_name: "! Required for Merge"
+    # This variant exists only to gate a merge, and it must not run on the waterfall. Evergreen
+    # activates a task's dependencies, and the dependencies below include the rhel88 variant, which
+    # is deliberately nightly-only (`cron`). Without this restriction every mainline commit would
+    # pull that whole nightly set in.
+    allowed_requesters: ["github_pr", "github_merge_queue", "patch"]
+    run_on:
+      - rhel80-small
+    tasks:
+      - name: merge-queue-workaround
+    depends_on:
+      - name: "*"
+        variant: static
+      - name: "*"
+        variant: rhel88-race
+      # Every task on this variant that runs tests, which is all of them except dist, push, and
+      # sign.
+      - name: .required-for-merge-queue
+        variant: rhel88
+      # These carry the required-for-merge-queue tag too, but they have to be named individually:
+      # the windows variant runs every server version, while pull request testing only runs the
+      # latest on it. Selecting by tag here would gate on tasks a pull request never ran.
+      - name: unit
+        variant: windows
+      - name: integration-latest
+        variant: windows
+      - name: integration-latest-auth
+        variant: windows
+      - name: integration-latest-cluster
+        variant: windows
+      - name: integration-latest-sharded
+        variant: windows
 
   #######################################
   #     Release Manager Buildvariant    #
@@ -3261,6 +3313,11 @@ github_pr_aliases:
   # Run push and record this PR run in Papertrail.
   - variant: ".*"
     task: "^push$"
+  # Report the merge queue gate on the PR too. Without this the required
+  # status check is never reported on the PR ref and GitHub waits for it
+  # forever.
+  - variant: "^merge-queue$"
+    task: ".*"
   # Run golang tests with the race detector enabled.
   - variant: "^rhel88-race$"
     task: "^(aws-auth|integration|kerberos|unit)"
@@ -3273,24 +3330,10 @@ github_pr_aliases:
   - variant: "^(rhel88|windows)$"
     task: "integration-latest"
 
-# This set of aliases is generated by the code in the `evergreen` directory.
-# Do not edit this by hand!
-# It can be regenerated by running `go run evergreen/generator/main.go`.
+# Unlike github_pr_aliases above, this block is not generated. The merge queue runs the no-op gate
+# task and nothing else, because Evergreen schedules that task's whole dependency closure, and those
+# dependencies are what gate a merge.  Change what gates a merge by editing the merge-queue
+# buildvariant's depends_on, not this block.
 commit_queue_aliases:
-  # Run all static analysis tasks.
-  - variant: "^static$"
+  - variant: "^merge-queue$"
     task: ".*"
-  # Run unit for every platform.
-  - variant: ".*"
-    task: "^unit$"
-  # Run golang tests with the race detector enabled.
-  - variant: "^rhel88-race$"
-    task: "^(aws-auth|integration|kerberos|unit)"
-  # Run all integration tests on one variant. We pick RHEL 8.8 because it's
-  # a relatively recent platform that supports a wide range of servers.
-  - variant: "^rhel88$"
-    task: "^(aws-auth|integration|kerberos|legacy|native-cert-ssl|qa-dump-restore|qa-tests)"
-  # Run a subset of integration tests against the latest version of MongoDB
-  # Server on all variants where that is the most recent supported version.
-  - variant: "^(rhel88|windows)$"
-    task: "integration-latest"

--- a/etc/evergreen-validate-wrapper.sh
+++ b/etc/evergreen-validate-wrapper.sh
@@ -27,9 +27,6 @@ fi
 if grep --quiet "is valid with warnings" "$TEMP_FILE"; then
     while IFS= read -r line; do
         case "$line" in
-        "WARNING: task 'commit-queue-workaround' defined but not used by any variants; consider using or disabling")
-            continue
-            ;;
         "WARNING: task 't_resmoke_setup' defined but not used by any variants; consider using or disabling")
             continue
             ;;

--- a/evergreen/evergreen.go
+++ b/evergreen/evergreen.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -15,6 +16,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Config is the part of the Evergreen project configuration this package reads. It is deliberately
+// incomplete: generating the alias blocks only needs variant and task names.
+//
+// The DependsOn field is only used by this package's tests, which check that every required for the
+// merge queue is also run for PRs.
 type Config struct {
 	Variants []Variant `yaml:"buildvariants"`
 }
@@ -27,11 +33,33 @@ type Variant struct {
 
 type Task struct {
 	Name string `yaml:"name"`
+
+	// Evergreen pushes a variant's depends_on down onto each of its tasks when it evaluates a
+	// configuration, so this is where the merge queue gate's dependencies show up.
+	DependsOn []Dependency `yaml:"depends_on"`
 }
 
-func Load() (*Config, error) {
+// Dependency is one entry in a task's depends_on list. Name may be the literal `*`, meaning every
+// task on the named variant; Evergreen leaves that unexpanded.
+type Dependency struct {
+	Name    string `yaml:"name"`
+	Variant string `yaml:"variant"`
+}
+
+func repoRoot() string {
 	_, pkgPath, _, _ := runtime.Caller(0)
-	common, err := os.ReadFile(filepath.Join(filepath.Dir(pkgPath), "..", "common.yml"))
+
+	return filepath.Join(filepath.Dir(pkgPath), "..")
+}
+
+func commonYAMLPath() string {
+	return filepath.Join(repoRoot(), "common.yml")
+}
+
+// Load parses common.yml as written, with task selectors like `.latest` left alone. The alias
+// generator needs them that way, because it reads the version tags in each variant's task list.
+func Load() (*Config, error) {
+	common, err := os.ReadFile(commonYAMLPath())
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +68,38 @@ func Load() (*Config, error) {
 	err = yaml.Unmarshal(common, &config)
 	if err != nil {
 		return nil, err
+	}
+
+	return &config, nil
+}
+
+// LoadEvaluated returns the configuration as Evergreen itself resolves it: tag selectors expanded
+// to concrete task names, and the files in common.yml's `include:` list merged in.
+//
+// Only this package's tests use it. Shelling out to the evergreen CLI is the point: reimplementing
+// tag and selector semantics in Go would be a second, subtly different copy of Evergreen's own
+// rules, and a test built on a wrong copy would pass while checking the wrong thing. The command is
+// local -- it makes no network calls and needs no credentials -- but it does require the evergreen
+// CLI on PATH.
+func LoadEvaluated() (*Config, error) {
+	cmd := exec.Command("evergreen", "evaluate", "--variants", "--file", "common.yml")
+
+	// The paths in common.yml's `include:` list are relative to the project root,
+	// and evergreen resolves them against its working directory, which is the
+	// package directory when this runs under `go test`.
+	cmd.Dir = repoRoot()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("running `%s`: %w: %s", cmd, err, stderr.String())
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(stdout.Bytes(), &config); err != nil {
+		return nil, fmt.Errorf("parsing the output of `%s`: %w", cmd, err)
 	}
 
 	return &config, nil
@@ -94,11 +154,13 @@ type alias struct {
 	comment string
 	variant string
 	tasks   string
-	// Aliases that only make sense for a PR run. The merge queue re-tests the
-	// merge result, so anything with side effects outside Evergreen belongs
-	// here rather than in the queue.
-	prOnly bool
 }
+
+// The variant whose only task is a no-op depending on everything that must pass before a merge. It
+// is the single required GitHub status check, so the queue needs to select nothing else: Evergreen
+// pulls in the dependency closure.  That makes commit_queue_aliases a constant, so it is written
+// out by hand in common.yml rather than generated here.
+const mergeQueueVariant = "merge-queue"
 
 func (c *Config) GitHubPRAliasesYAML() (string, error) {
 	aliases, err := c.aliases()
@@ -107,23 +169,6 @@ func (c *Config) GitHubPRAliasesYAML() (string, error) {
 	}
 
 	return aliasesYAML("github_pr_aliases", aliases)
-}
-
-func (c *Config) MergeQueueAliasesYAML() (string, error) {
-	all, err := c.aliases()
-	if err != nil {
-		return "", err
-	}
-
-	var aliases []alias
-	for _, a := range all {
-		if a.prOnly {
-			continue
-		}
-		aliases = append(aliases, a)
-	}
-
-	return aliasesYAML("commit_queue_aliases", aliases)
 }
 
 func (c *Config) aliases() ([]alias, error) {
@@ -142,7 +187,13 @@ func (c *Config) aliases() ([]alias, error) {
 			comment: "Run push and record this PR run in Papertrail.",
 			variant: `.*`,
 			tasks:   `^push$`,
-			prOnly:  true,
+		},
+		{
+			comment: "Report the merge queue gate on the PR too. Without this the" +
+				" required status check is never reported on the PR ref and" +
+				" GitHub waits for it forever.",
+			variant: "^" + mergeQueueVariant + "$",
+			tasks:   `.*`,
 		},
 		{
 			comment: "Run golang tests with the race detector enabled.",
@@ -158,10 +209,9 @@ func (c *Config) aliases() ([]alias, error) {
 		},
 	}
 
-	// This finds the most recent version of the server supported by each
-	// variant. Based on that it constructs a set of aliases to run
-	// "integration-<version>" for that latest version of each supported
-	// variant.
+	// This finds the most recent version of the server supported by each variant. Based on that it
+	// constructs a set of aliases to run "integration-<version>" for that latest version of each
+	// supported variant.
 	intTests, err := c.integrationTestAliases()
 	if err != nil {
 		return nil, err
@@ -171,11 +221,10 @@ func (c *Config) aliases() ([]alias, error) {
 	return aliases, nil
 }
 
-// The comments are the reason this builds a yaml.Node tree rather than
-// marshaling a plain struct. The encoder emits a node's HeadComment for us,
-// including the `#` prefix and the indentation, but it does not wrap, so each
-// comment arrives here already wrapped to a width that leaves room for the
-// prefix the encoder adds.
+// The comments are the reason this builds a yaml.Node tree rather than marshaling a plain
+// struct. The encoder emits a node's HeadComment for us, including the `#` prefix and the
+// indentation, but it does not wrap, so each comment arrives here already wrapped to a width that
+// leaves room for the prefix the encoder adds.
 func aliasesYAML(key string, aliases []alias) (string, error) {
 	header := "This set of aliases is generated by the code in the `evergreen` directory.\n" +
 		"Do not edit this by hand!\n" +
@@ -207,8 +256,8 @@ func aliasesYAML(key string, aliases []alias) (string, error) {
 	return buf.String(), nil
 }
 
-// A width that leaves room for the `  # ` prefix the encoder adds, so that no
-// comment line exceeds the line length the linter enforces.
+// A width that leaves room for the ` # ` prefix the encoder adds, so that no comment line exceeds
+// the line length the linter enforces.
 const aliasCommentWidth = 72
 
 func aliasNode(a alias) *yaml.Node {

--- a/evergreen/evergreen_test.go
+++ b/evergreen/evergreen_test.go
@@ -2,11 +2,12 @@ package evergreen
 
 import (
 	"os"
-	"path/filepath"
-	"runtime"
+	"os/exec"
+	"regexp"
 	"slices"
 	"testing"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,127 +19,196 @@ type aliasEntry struct {
 	Task    string `yaml:"task"`
 }
 
+// Every task that the merge-queue variant depends on must run for PRs, otherwise PRs will not be
+// mergeable at all, because the GitHub branch protection ruleset for this repo requires that
+// `evergreen/merge-queue` has passed.
+//
+// This is a subset check, not equality. PRs can run things that the merge queue does not depend on.
+func TestPRTasksAreRequiredForMerge(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	c, err := Load()
+	require.NoError(t, err, "loading common.yml")
+
+	prYAML, err := c.GitHubPRAliasesYAML()
+	require.NoError(t, err, "generating PR aliases")
+
+	// Expanding the tag selectors in common.yml means running the evergreen CLI,
+	// which the project never installs -- it relies on Evergreen hosts having it.
+	// Rather than fail the unit suite on every variant that lacks it, skip.
+	if _, err := exec.LookPath("evergreen"); err != nil {
+		t.Skip("this test needs the evergreen CLI on PATH to expand task tags")
+	}
+
+	evaluated, err := LoadEvaluated()
+	require.NoError(t, err, "evaluating common.yml")
+
+	prTasks := evaluated.tasksMatchingAliases(t, parseAliases(t, prYAML, "github_pr_aliases"))
+	missingFromPRs := evaluated.mergeQueueDependencies(t).Difference(prTasks)
+
+	assert.Empty(
+		t,
+		sortedNames(missingFromPRs),
+		"every task the %q variant depends on is selected by github_pr_aliases,"+
+			" so add an alias covering it (or drop the dependency)",
+		mergeQueueVariant,
+	)
+}
+
+// parseAliases pulls one alias sequence out of a YAML document. It decodes only the requested key,
+// so that it works on all of common.yml and not just on a generated block.
 func parseAliases(t *testing.T, doc, key string) []aliasEntry {
 	t.Helper()
 
-	var parsed map[string][]aliasEntry
-	require.NoError(t, yaml.Unmarshal([]byte(doc), &parsed), "generated %s YAML parses", key)
+	var parsed map[string]yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &parsed), "the %s YAML parses", key)
 
-	entries, ok := parsed[key]
-	require.True(t, ok, "generated YAML contains the %s key", key)
+	node, ok := parsed[key]
+	require.True(t, ok, "the YAML contains the %s key", key)
+
+	var entries []aliasEntry
+	require.NoError(t, node.Decode(&entries), "the %s value is a list of aliases", key)
 
 	return entries
 }
 
-// A merge queue run must never gate on a task that PR testing did not already
-// run. Otherwise a PR can pass every check, get enqueued, and then fail in the
-// queue for a reason no reviewer could have seen.
-func TestMergeQueueAliasesAreSubsetOfPRAliases(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+// The no-op task the merge queue gate variant runs.
+const mergeQueueWorkaroundTaskName = "merge-queue-workaround"
 
-	c, err := Load()
-	require.NoError(t, err, "loading common.yml")
-
-	prYAML, err := c.GitHubPRAliasesYAML()
-	require.NoError(t, err, "generating PR aliases")
-
-	mqYAML, err := c.MergeQueueAliasesYAML()
-	require.NoError(t, err, "generating merge queue aliases")
-
-	prAliases := parseAliases(t, prYAML, "github_pr_aliases")
-	mqAliases := parseAliases(t, mqYAML, "commit_queue_aliases")
-
-	require.NotEmpty(t, mqAliases, "merge queue selects at least one alias")
-
-	for _, a := range mqAliases {
-		assert.Contains(
-			t,
-			prAliases,
-			a,
-			"merge queue alias (variant %q, task %q) is also a PR alias",
-			a.Variant,
-			a.Task,
-		)
-	}
+// variantTask is one scheduled unit of work: a task on a specific variant.
+type variantTask struct {
+	variant string
+	task    string
 }
 
-// Tasks with effects outside Evergreen must not run in the queue, which tests
-// a commit that has not landed yet. `push` uploads release artifacts to S3 and
-// the linux repos, so it is the one alias PR testing runs that the queue skips.
-func TestPushIsTheOnlyAliasExcludedFromMergeQueue(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+// tasksMatchingAliases is every task the given aliases select. The receiver must come from
+// LoadEvaluated, so that each variant's task list is concrete names rather than tag selectors.
+func (c *Config) tasksMatchingAliases(
+	t *testing.T,
+	aliases []aliasEntry,
+) mapset.Set[variantTask] {
+	t.Helper()
 
-	c, err := Load()
-	require.NoError(t, err, "loading common.yml")
+	matched := mapset.NewSet[variantTask]()
+	for _, a := range aliases {
+		variantRE, err := regexp.Compile(a.Variant)
+		require.NoError(t, err, "compiling the variant regex %q", a.Variant)
 
-	prYAML, err := c.GitHubPRAliasesYAML()
-	require.NoError(t, err, "generating PR aliases")
+		taskRE, err := regexp.Compile(a.Task)
+		require.NoError(t, err, "compiling the task regex %q", a.Task)
 
-	mqYAML, err := c.MergeQueueAliasesYAML()
-	require.NoError(t, err, "generating merge queue aliases")
+		for _, v := range c.Variants {
+			if !variantRE.MatchString(v.Name) {
+				continue
+			}
 
-	mqAliases := parseAliases(t, mqYAML, "commit_queue_aliases")
-
-	var excluded []aliasEntry
-	for _, a := range parseAliases(t, prYAML, "github_pr_aliases") {
-		if !slices.Contains(mqAliases, a) {
-			excluded = append(excluded, a)
+			for _, task := range v.Tasks {
+				if taskRE.MatchString(task.Name) {
+					matched.Add(variantTask{v.Name, task.Name})
+				}
+			}
 		}
 	}
 
-	assert.Equal(
-		t,
-		[]aliasEntry{{Variant: ".*", Task: "^push$"}},
-		excluded,
-		"push is the only PR alias the merge queue excludes",
-	)
+	return matched
 }
 
-// The alias blocks in common.yml are generated. This catches both a hand-edit
-// and a change to the generator that nobody copied into common.yml.
+// mergeQueueDependencies is every task the gate task depends on. It does not follow those tasks'
+// own dependencies, which is the conservative direction for the caller: a transitively required
+// task shows up as one to check rather than being silently passed over.
+func (c *Config) mergeQueueDependencies(t *testing.T) mapset.Set[variantTask] {
+	t.Helper()
+
+	deps := mapset.NewSet[variantTask]()
+	for _, task := range c.variantTasks(t, mergeQueueVariant) {
+		if task.Name != mergeQueueWorkaroundTaskName {
+			continue
+		}
+
+		require.NotEmpty(
+			t,
+			task.DependsOn,
+			"the %q task declares dependencies",
+			mergeQueueWorkaroundTaskName,
+		)
+
+		for _, dep := range task.DependsOn {
+			require.NotEqual(
+				t,
+				"*",
+				dep.Variant,
+				`the dependency on %q names a specific variant, because a wildcard`+
+					` would silently pull in new variants`,
+				dep.Name,
+			)
+
+			// Evergreen expands tag selectors but leaves `*` alone.
+			if dep.Name == "*" {
+				for _, task := range c.variantTasks(t, dep.Variant) {
+					deps.Add(variantTask{dep.Variant, task.Name})
+				}
+				continue
+			}
+
+			deps.Add(variantTask{dep.Variant, dep.Name})
+		}
+	}
+
+	require.NotZero(t, deps.Cardinality(), "the %q variant gates some tasks", mergeQueueVariant)
+
+	return deps
+}
+
+func (c *Config) variantTasks(t *testing.T, variant string) []Task {
+	t.Helper()
+
+	for _, v := range c.Variants {
+		if v.Name == variant {
+			return v.Tasks
+		}
+	}
+
+	require.FailNowf(t, "unknown variant", "common.yml defines a %q variant", variant)
+
+	return nil
+}
+
+// sortedNames renders a set of scheduled tasks as sorted "variant/task" strings,
+// so that a failure names the offending tasks in a stable order.
+func sortedNames(tasks mapset.Set[variantTask]) []string {
+	names := make([]string, 0, tasks.Cardinality())
+	for _, vt := range tasks.ToSlice() {
+		names = append(names, vt.variant+"/"+vt.task)
+	}
+	slices.Sort(names)
+
+	return names
+}
+
+// The github_pr_aliases block in common.yml is generated. This catches both a
+// hand-edit and a change to the generator that nobody copied into common.yml.
 //
 // Comparing the parsed alias sequences rather than searching for the generated
 // text matters: a substring search would not notice a hand-written alias
 // appended after the generated block.
-func TestCommonYAMLAliasBlocksAreUpToDate(t *testing.T) {
+func TestGitHubPRAliasBlockIsUpToDate(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	c, err := Load()
 	require.NoError(t, err, "loading common.yml")
 
-	_, pkgPath, _, _ := runtime.Caller(0)
-	commonPath := filepath.Join(filepath.Dir(pkgPath), "..", "common.yml")
-	common, err := os.ReadFile(commonPath)
+	block, err := c.GitHubPRAliasesYAML()
+	require.NoError(t, err, "generating the github_pr_aliases block")
+
+	common, err := os.ReadFile(commonYAMLPath())
 	require.NoError(t, err, "reading common.yml")
 
-	var blocks struct {
-		PR    []aliasEntry `yaml:"github_pr_aliases"`
-		Queue []aliasEntry `yaml:"commit_queue_aliases"`
-	}
-	require.NoError(t, yaml.Unmarshal(common, &blocks), "parsing common.yml")
-
-	onDisk := map[string][]aliasEntry{
-		"github_pr_aliases":    blocks.PR,
-		"commit_queue_aliases": blocks.Queue,
-	}
-
-	for key, gen := range map[string]func() (string, error){
-		"github_pr_aliases":    c.GitHubPRAliasesYAML,
-		"commit_queue_aliases": c.MergeQueueAliasesYAML,
-	} {
-		t.Run(key, func(t *testing.T) {
-			block, err := gen()
-			require.NoError(t, err, "generating the %s block", key)
-
-			assert.Equal(
-				t,
-				parseAliases(t, block, key),
-				onDisk[key],
-				"the %s block in common.yml matches the generator output"+
-					" (run `go run evergreen/generator/main.go` and replace the"+
-					" block in common.yml with its output)",
-				key,
-			)
-		})
-	}
+	assert.Equal(
+		t,
+		parseAliases(t, block, "github_pr_aliases"),
+		parseAliases(t, string(common), "github_pr_aliases"),
+		"the github_pr_aliases block in common.yml matches the generator output"+
+			" (run `go run evergreen/generator/main.go` and replace the block in"+
+			" common.yml with its output)",
+	)
 }

--- a/evergreen/generator/main.go
+++ b/evergreen/generator/main.go
@@ -17,11 +17,5 @@ func main() {
 		panic(err)
 	}
 
-	mq, err := c.MergeQueueAliasesYAML()
-	if err != nil {
-		panic(err)
-	}
-
 	fmt.Println(pr)
-	fmt.Println(mq)
 }

--- a/mongodump_passthrough/tasks.yml
+++ b/mongodump_passthrough/tasks.yml
@@ -15,13 +15,6 @@ variables:
   _src_dir: &src_dir src/mongosync
 
 tasks:
-  - name: commit-queue-workaround
-    commands:
-      - command: shell.exec
-        params:
-          script: |
-            echo "This task is a no-op to work around evergreen's commit queue behavior"
-
   # For mongodump passthrough, this builds and uploads the mongodump and mongorestore
   # binaries (but without coverage), and uploads them.  The name "compile_coverage"
   # is misleading, but that task name is used in the generated tasks from mongodump-task-gen

--- a/release/platform/platform_test.go
+++ b/release/platform/platform_test.go
@@ -43,7 +43,7 @@ func TestPlatformsMatchCI(t *testing.T) {
 		// Variant "mongodump_passthru_v" has been added to support mongodump
 		// passthrough testing.
 		if v.Name == "release" || v.Name == "static" || v.Name == "rhel88-race" ||
-			v.Name == "mongodump_passthru_v" {
+			v.Name == "mongodump_passthru_v" || v.Name == "merge-queue" {
 			continue
 		}
 


### PR DESCRIPTION
The previous attempt at adding merge queue support wasn't complete. We need a single name we can have GitHub block on, rather than having it block on an ever-changing list of tasks.

This is the same thing we do for Mongosync.

It also includes a test to make sure that the merge queue variant never depends on tasks that are _not_ run for a PR. If we were to let that happen, then the PR would never be mergeable.