### PR TITLE
TOOLS-4263 Drop the mopt alias for the driver's options package

### DIFF
--- a/integration/dumprestore/dump_behaviors_test.go
+++ b/integration/dumprestore/dump_behaviors_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
-	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type extendedJSONQueryCase struct {
@@ -202,7 +202,7 @@ func (s *DumpRestoreSuite) TestDumpStorageEngineOptions() {
 	s.createCollection(
 		testDB,
 		collName,
-		mopt.CreateCollection().SetStorageEngine(storageEngine),
+		options.CreateCollection().SetStorageEngine(storageEngine),
 	)
 
 	storageEngineBefore := s.collectionOption(testDB, collName, "storageEngine")

--- a/integration/dumprestore/oplog_replset_test.go
+++ b/integration/dumprestore/oplog_replset_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // TestDumpOplogSnapshotDuringWrites checks the point-in-time guarantee --oplog
@@ -210,7 +210,7 @@ func (s *DumpRestoreSuite) latestOplogTimestamp() bson.Timestamp {
 		FindOne(
 			s.Context(),
 			bson.D{},
-			mopt.FindOne().SetSort(bson.D{{"$natural", -1}}),
+			options.FindOne().SetSort(bson.D{{"$natural", -1}}),
 		).
 		Decode(&entry)
 	s.Require().NoError(err, "reading the newest oplog entry")

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -366,7 +366,7 @@ func (s *DumpRestoreSuite) TestRestoreZeroTimestamp() {
 				}},
 			}}},
 		},
-		mopt.UpdateOne().SetUpsert(true),
+		options.UpdateOne().SetUpsert(true),
 	)
 	s.Require().NoError(err, "should insert (via update/upsert)")
 
@@ -425,7 +425,7 @@ func (s *DumpRestoreSuite) TestRestoreZeroTimestamp_NonClobber() {
 				}},
 			}}},
 		},
-		mopt.UpdateOne().SetUpsert(true),
+		options.UpdateOne().SetUpsert(true),
 	)
 	s.Require().NoError(err, "should insert (via update/upsert)")
 
@@ -489,15 +489,15 @@ func (s *DumpRestoreSuite) TestRestoreMultipleIDIndexes() {
 				{Keys: bson.D{{"_id", "hashed"}}},
 				{
 					Keys: bson.D{{"_id", "hashed"}},
-					Options: mopt.Index().
+					Options: options.Index().
 						SetName("_id_hashed_de").
-						SetCollation(&mopt.Collation{Locale: "de"}),
+						SetCollation(&options.Collation{Locale: "de"}),
 				},
 				{
 					Keys: bson.D{{"_id", "hashed"}},
-					Options: mopt.Index().
+					Options: options.Index().
 						SetName("_id_hashed_ar").
-						SetCollation(&mopt.Collation{Locale: "ar"}),
+						SetCollation(&options.Collation{Locale: "ar"}),
 				},
 				{Keys: bson.D{{"_id", "2dsphere"}}},
 			},


### PR DESCRIPTION
The driver's `mongo/options` package was imported as `mopt` in two files that
predate the JS-to-Go test migration. Nothing in either file shadows the name,
and the rest of `integration/dumprestore` now imports it unaliased, so the alias
only made the call sites harder to read.

* `integration/dumprestore/roundtrip_test.go` - `mopt.` -> `options.`
* `integration/dumprestore/oplog_replset_test.go` - `mopt.` -> `options.`

No behavior change. `go test ./integration/dumprestore/ -count=1` passes.