### PR TITLE
TOOLS-4263 Add multi-node replica set test infrastructure

### DIFF
--- a/buildscript/build.go
+++ b/buildscript/build.go
@@ -213,6 +213,13 @@ func runTests(ctx *task.Context, pkgs []string, testType string) error {
 		if ctx.Get("topology") == "replSet" {
 			env = append(env, testtype.ReplSetTestType+"=true")
 		}
+		if ctx.Get("topology") == "multiNodeReplSet" {
+			env = append(
+				env,
+				testtype.ReplSetTestType+"=true",
+				testtype.MultiNodeReplSetTestType+"=true",
+			)
+		}
 		if ctx.Get("topology") == "sharded" {
 			env = append(env, testtype.ShardedIntegrationTestType+"=true")
 		}

--- a/common.yml
+++ b/common.yml
@@ -644,6 +644,7 @@ functions:
           MONGOD_PORT: ${mongod_port}
           MONGO_ARGS: ${mongo_args}
           MONGO_ARGS_TLS: ${mongo_args_tls}
+          REPLSET_NODES: ${replset_nodes|1}
           REPLSETTEST_SSL_CONFIG: ${replsettest_ssl_config}
           REPLSETTEST_TLS_CONFIG: ${replsettest_tls_config}
           USE_SSL: ${USE_SSL}
@@ -661,6 +662,7 @@ functions:
           MONGOD_PORT: ${mongod_port}
           MONGO_ARGS: ${mongo_args}
           MONGO_ARGS_TLS: ${mongo_args_tls}
+          REPLSET_NODES: ${replset_nodes|1}
           USE_TLS: ${USE_TLS}
 
   "create sharded cluster":
@@ -1908,6 +1910,29 @@ tasks:
         vars:
           target: test:integration -ssl=true -topology=replSet ${testArgs}
 
+  # Tagged "multinode" rather than "latest" on purpose: a "latest" tag would pull
+  # this into every variant that selects .latest, and only rhel88 runs it.
+  - name: integration-multinode-latest
+    tags: ["multinode"]
+    commands:
+      - func: "fetch source"
+      - command: expansions.update
+      - func: "install mise and go"
+      - func: "download mongod and shell"
+        vars:
+          mongo_version: "latest"
+      - func: "create repl_set"
+        vars:
+          USE_TLS: "true"
+          load_libs_version: *max_server_version
+          replset_nodes: "3"
+      - func: "run make target"
+        vars:
+          target: build
+      - func: "run make target"
+        vars:
+          target: test:integration -ssl=true -topology=multiNodeReplSet ${testArgs}
+
   - name: integration-4.4-sharded
     tags: ["4.4", "sharded", "required-for-merge-queue"]
     commands:
@@ -2795,6 +2820,7 @@ buildvariants:
       - name: ".9.0"
       - name: ".latest"
       - name: ".no-ssl"
+      - name: ".multinode"
       - name: ".kerberos"
       - name: "dist"
       - name: "sign"

--- a/common/testtype/types.go
+++ b/common/testtype/types.go
@@ -46,6 +46,12 @@ const (
 
 	// Testing the tools with a replica set topology.
 	ReplSetTestType = "TOOLS_TESTING_REPLSET"
+
+	// Testing the tools against a replica set with three data-bearing nodes, for
+	// tests that need a secondary to connect to or a write concern greater than
+	// w:1. Anything that sets this also sets ReplSetTestType, since a three-node
+	// set satisfies the single-node replica set tests too.
+	MultiNodeReplSetTestType = "TOOLS_TESTING_MULTINODE_REPLSET"
 )
 
 func HasTestType(testType string) bool {

--- a/scripts/create-repl-set.sh
+++ b/scripts/create-repl-set.sh
@@ -6,6 +6,16 @@ set -o verbose
 : "${LOAD_LIBS_VERSION?}" "${MONGOD_PORT:?}" "${MONGO_ARGS:?}" "${MONGO_ARGS_TLS?}" \
     "${REPLSETTEST_SSL_CONFIG?}" "${REPLSETTEST_TLS_CONFIG?}" "${USE_SSL?}" "${USE_TLS?}"
 
+REPLSET_NODES="${REPLSET_NODES:-1}"
+
+# The tests all connect to MONGOD_PORT, which is the first node of the set, so
+# that node has to be the primary. Give it a higher priority than the rest, which
+# makes it win the election rather than leaving that to chance.
+INITIATE="repl.initiate()"
+if [ "$REPLSET_NODES" -gt 1 ]; then
+    INITIATE="var cfg = repl.getReplSetConfig(); cfg.members[0].priority = 2; repl.initiate(cfg)"
+fi
+
 echo "starting repl set"
 NODE_OPTIONS=""
 mkdir -p /data/db/
@@ -21,4 +31,4 @@ if [ -n "$LOAD_LIBS_VERSION" ]; then
     IMPORT_LOAD_LIBS="await import(\"../shell_common/libs/load_libs-${LOAD_LIBS_VERSION}.js\");"
 fi
 # shellcheck disable=SC2086 # $MONGO_ARGS intentionally word-split
-PATH=./bin:$PATH ./bin/mongo $MONGO_ARGS --nodb --eval "$IMPORT_LOAD_LIBS; TestData = new Object(); TestData.minPort=\"${MONGOD_PORT}\"; var repl = new ReplSetTest({nodes:1, name:'repltester', nodeOptions: {$NODE_OPTIONS}});repl.startSet();repl.initiate();repl.awaitSecondaryNodes();while(true){sleep(1000);}"
+PATH=./bin:$PATH ./bin/mongo $MONGO_ARGS --nodb --eval "$IMPORT_LOAD_LIBS; TestData = new Object(); TestData.minPort=\"${MONGOD_PORT}\"; var repl = new ReplSetTest({nodes:${REPLSET_NODES}, name:'repltester', nodeOptions: {$NODE_OPTIONS}});repl.startSet();${INITIATE};repl.awaitSecondaryNodes();while(true){sleep(1000);}"

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -5,8 +5,17 @@ set -o verbose
 
 : "${MONGOD_PORT:?}" "${MONGO_ARGS?}" "${MONGO_ARGS_TLS?}" "${USE_TLS?}"
 
+REPLSET_NODES="${REPLSET_NODES:-1}"
+
 if [ "$USE_TLS" = "true" ]; then
     MONGO_ARGS="$MONGO_ARGS_TLS"
 fi
 # shellcheck disable=SC2086 # $MONGO_ARGS intentionally word-split
 ./bin/mongo $MONGO_ARGS --nodb --eval "assert.soon(function(x){try{var d = new Mongo(\"localhost:$MONGOD_PORT\"); return true} catch(e){return false}}, \"timed out connection\")"
+
+# Connectability is not enough on a set with more than one node: the tests write
+# through this port, so wait until the node behind it has won the election.
+if [ "$REPLSET_NODES" -gt 1 ]; then
+    # shellcheck disable=SC2086 # $MONGO_ARGS intentionally word-split
+    ./bin/mongo $MONGO_ARGS --nodb --eval "assert.soon(function(x){try{return new Mongo(\"localhost:$MONGOD_PORT\").getDB(\"admin\").isMaster().ismaster} catch(e){return false}}, \"timed out waiting for localhost:$MONGOD_PORT to become primary\")"
+fi


### PR DESCRIPTION
Adds a test type and a CI task for tests that need more than one data-bearing
node: a secondary to connect to, or a write concern greater than w:1. No tests
use it yet; the conversions that do follow in later commits.

- `common/testtype/types.go` - adds `MultiNodeReplSetTestType`
  (`TOOLS_TESTING_MULTINODE_REPLSET`). Additive to `common/`, so no API change,
  but `common/` is used by other projects at MongoDB.

- `buildscript/build.go` - `-topology=multiNodeReplSet` sets both
  `TOOLS_TESTING_REPLSET` and `TOOLS_TESTING_MULTINODE_REPLSET`, since a
  three-node set satisfies the single-node replica set tests too.

- `common.yml` - adds the `integration-multinode-latest` task, modeled on
  `integration-latest-cluster`: the latest server, a three-node set, TLS, and
  `test:integration -ssl=true -topology=multiNodeReplSet`. It is tagged
  `multinode` rather than `latest`, because a `latest` tag would pull it into
  every variant selecting `.latest`, and it runs on `rhel88` only.

- `scripts/create-repl-set.sh` - the node count comes from `REPLSET_NODES`,
  defaulting to 1, so the existing single-node callers are unaffected.

  With more than one node, the set is initiated with `priority = 2` on member 0.
  Everything in CI connects to `localhost:${mongod_port}`, which is the set's
  first node, so that node has to be the primary; without this, an election that
  picks any other node fails every write in the integration suite, not just the
  multi-node tests. Verified locally that a three-node set does elect another
  node when nothing biases the config.

- `scripts/wait-for-cluster.sh` - with more than one node, also waits for the node
  behind `MONGOD_PORT` to report `ismaster`. Waiting only for the port to accept
  connections lets tests start while the election is still in progress.