### PR TITLE
TOOLS-4338 Report the real error when the oplog overflow check fails to read

### DIFF
--- a/common/failpoint/failpoint.go
+++ b/common/failpoint/failpoint.go
@@ -72,10 +72,13 @@ func (p *pauseSignal) signal() {
 
 // Failpoint represents one named failpoint's runtime state — for failpoints
 // that need to pause code until externally resumed, the signaling to
-// coordinate that pause.
+// coordinate that pause, and for failpoints that inject a failure, the error
+// to inject.
 type Failpoint struct {
-	pause    *pauseSignal
-	fireOnce sync.Once
+	pause *pauseSignal
+
+	mu      sync.Mutex
+	errFunc func() error
 }
 
 func newFailpoint() *Failpoint {
@@ -100,13 +103,28 @@ func (fp *Failpoint) Signal() {
 	fp.pause.signal()
 }
 
-// FireOnce returns true the first time it is called and false every time
-// after. Failpoints that inject a transient error use this so that the
-// retry which is supposed to recover from that error is allowed to succeed.
-func (fp *Failpoint) FireOnce() bool {
-	fired := false
-	fp.fireOnce.Do(func() { fired = true })
-	return fired
+// SetErrorFunc sets the function that InjectedError calls. Tests use it to
+// decide both which error this failpoint injects and how often, e.g. by
+// guarding the error with a sync.Once to inject a transient error that a retry
+// is then allowed to recover from.
+func (fp *Failpoint) SetErrorFunc(fn func() error) {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	fp.errFunc = fn
+}
+
+// InjectedError returns the error that this failpoint should inject at the
+// point where it is called, or nil if no error func has been set.
+func (fp *Failpoint) InjectedError() error {
+	fp.mu.Lock()
+	fn := fp.errFunc
+	fp.mu.Unlock()
+
+	if fn == nil {
+		return nil
+	}
+
+	return fn()
 }
 
 // Manager tracks which failpoints are currently enabled.

--- a/common/failpoint/failpoint.go
+++ b/common/failpoint/failpoint.go
@@ -74,7 +74,8 @@ func (p *pauseSignal) signal() {
 // that need to pause code until externally resumed, the signaling to
 // coordinate that pause.
 type Failpoint struct {
-	pause *pauseSignal
+	pause    *pauseSignal
+	fireOnce sync.Once
 }
 
 func newFailpoint() *Failpoint {
@@ -97,6 +98,15 @@ func (fp *Failpoint) Reached(ctx context.Context) error {
 // Signal releases a call blocked in Wait. Safe to call more than once.
 func (fp *Failpoint) Signal() {
 	fp.pause.signal()
+}
+
+// FireOnce returns true the first time it is called and false every time
+// after. Failpoints that inject a transient error use this so that the
+// retry which is supposed to recover from that error is allowed to succeed.
+func (fp *Failpoint) FireOnce() bool {
+	fired := false
+	fp.fireOnce.Do(func() { fired = true })
+	return fired
 }
 
 // Manager tracks which failpoints are currently enabled.

--- a/common/failpoint/failpoints.go
+++ b/common/failpoint/failpoints.go
@@ -31,6 +31,7 @@ var (
 	PauseBeforeDumping = newName("PauseBeforeDumping")
 	SlowBSONDump       = newName("SlowBSONDump")
 	PauseUntilResumed  = newName("PauseUntilResumed")
+	FailOplogCheckRead = newName("FailOplogCheckRead")
 )
 
 // parseNames splits arg, a comma-separated list of failpoint names as

--- a/mongodump/mongodump.go
+++ b/mongodump/mongodump.go
@@ -472,13 +472,13 @@ func (dump *MongoDump) Dump() (err error) {
 		// we started still exist, so we know we haven't lost data)
 		log.Logvf(log.DebugLow, "checking if oplog entry %v still exists", dump.oplogStart)
 		exists, err := dump.checkOplogTimestampExists(dump.oplogStart)
+		if err != nil {
+			return fmt.Errorf("unable to check oplog for overflow: %w", err)
+		}
 		if !exists {
 			return fmt.Errorf(
 				"oplog overflow: mongodump was unable to capture all new oplog entries during execution",
 			)
-		}
-		if err != nil {
-			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
 		log.Logvf(log.DebugHigh, "oplog entry %v still exists", dump.oplogStart)
 
@@ -494,13 +494,13 @@ func (dump *MongoDump) Dump() (err error) {
 		// we copy it.
 		log.Logvf(log.DebugLow, "checking again if oplog entry %v still exists", dump.oplogStart)
 		exists, err = dump.checkOplogTimestampExists(dump.oplogStart)
+		if err != nil {
+			return fmt.Errorf("unable to check oplog for overflow: %w", err)
+		}
 		if !exists {
 			return fmt.Errorf(
 				"oplog overflow: mongodump was unable to capture all new oplog entries during execution",
 			)
-		}
-		if err != nil {
-			return fmt.Errorf("unable to check oplog for overflow: %v", err)
 		}
 		log.Logvf(log.DebugHigh, "oplog entry %v still exists", dump.oplogStart)
 	}

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -8,10 +8,13 @@ package mongodump
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mongodb/mongo-tools/common/db"
+	"github.com/mongodb/mongo-tools/common/failpoint"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -115,22 +118,7 @@ func (dump *MongoDump) getOplogCopyStartTime() (bson.Timestamp, error) {
 // still in the database and making sure it happened at or before the timestamp
 // captured at the start of the dump.
 func (dump *MongoDump) checkOplogTimestampExists(ts bson.Timestamp) (bool, error) {
-	oldestOplogEntry := db.Oplog{}
-	var tempBSON bson.Raw
-
-	err := dump.SessionProvider.FindOne(
-		"local",
-		dump.oplogCollection,
-		0,
-		nil,
-		&bson.M{"$natural": 1},
-		&tempBSON,
-		0,
-	)
-	if err != nil {
-		return false, fmt.Errorf("unable to read entry from oplog: %v", err)
-	}
-	err = bson.Unmarshal(tempBSON, &oldestOplogEntry)
+	oldestOplogEntry, err := dump.findOldestOplogEntry()
 	if err != nil {
 		return false, err
 	}
@@ -142,6 +130,102 @@ func (dump *MongoDump) checkOplogTimestampExists(ts bson.Timestamp) (bool, error
 		return false, nil
 	}
 	return true, nil
+}
+
+// cappedPositionLostErrCode is the server's CappedPositionLost error, returned
+// when a collection scan loses its place because the records it was reading
+// were deleted out from under it.
+const cappedPositionLostErrCode = 136
+
+// oplogReadAttempts bounds how many times findOldestOplogEntry retries a read
+// that lost its position.
+const oplogReadAttempts = 4
+
+// oplogReadRetryDelay is the wait before the first retry, doubled for each
+// retry after that. A single truncation pass has been seen to run for over a
+// second, so the delays have to add up to more than that: otherwise every
+// attempt lands inside the same pass that killed the first read. The delays
+// also can't grow without bound, because each one widens the window in which
+// truncation can legitimately advance past oplogStart and turn a good dump
+// into a reported overflow.
+const oplogReadRetryDelay = 250 * time.Millisecond
+
+// findOldestOplogEntry returns the oldest entry still in the oplog.
+//
+// Scanning the front of the oplog in $natural order races the server's oplog
+// truncation: on a busy oplog the entries being read can be deleted mid-scan,
+// which fails the whole read with CappedPositionLost even though the scan had
+// already found its one document. That says nothing about whether the dump's
+// starting timestamp survived, so such a read is retried rather than reported.
+func (dump *MongoDump) findOldestOplogEntry() (db.Oplog, error) {
+	var lastErr error
+	wait := oplogReadRetryDelay
+	for attempt := range oplogReadAttempts {
+		if attempt > 0 {
+			time.Sleep(wait)
+			wait *= 2
+		}
+
+		var tempBSON bson.Raw
+
+		lastErr = failOplogCheckReadFailpoint()
+		if lastErr == nil {
+			lastErr = dump.SessionProvider.FindOne(
+				"local",
+				dump.oplogCollection,
+				0,
+				nil,
+				&bson.M{"$natural": 1},
+				&tempBSON,
+				0,
+			)
+		}
+
+		if lastErr == nil {
+			oldestOplogEntry := db.Oplog{}
+			if err := bson.Unmarshal(tempBSON, &oldestOplogEntry); err != nil {
+				return db.Oplog{}, err
+			}
+			return oldestOplogEntry, nil
+		}
+
+		if !isCappedPositionLost(lastErr) {
+			return db.Oplog{}, fmt.Errorf("unable to read entry from oplog: %w", lastErr)
+		}
+
+		log.Logvf(log.DebugLow, "oplog read lost its position, retrying: %v", lastErr)
+	}
+
+	return db.Oplog{}, fmt.Errorf(
+		"unable to read entry from oplog after %d attempts: %w",
+		oplogReadAttempts,
+		lastErr,
+	)
+}
+
+// isCappedPositionLost reports whether err is the server saying that a
+// collection scan lost its place because the records it was reading were
+// deleted while it was reading them.
+func isCappedPositionLost(err error) bool {
+	var serverErr mongo.ServerError
+	return errors.As(err, &serverErr) && serverErr.HasErrorCode(cappedPositionLostErrCode)
+}
+
+// failOplogCheckReadFailpoint returns a synthetic CappedPositionLost error the
+// first time it is called with the FailOplogCheckRead failpoint enabled, so
+// that tests can exercise the retry in findOldestOplogEntry.
+func failOplogCheckReadFailpoint() error {
+	fp, ok := failpoint.DefaultManager.Get(failpoint.FailOplogCheckRead)
+	if !ok || !fp.FireOnce() {
+		return nil
+	}
+
+	return mongo.CommandError{
+		Code: cappedPositionLostErrCode,
+		Name: "CappedPositionLost",
+		Message: "CollectionScan died due to position in capped collection being deleted" +
+			" (injected by the FailOplogCheckRead failpoint)",
+	}
 }
 
 func oplogDocumentValidator(in []byte) error {

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -168,7 +168,7 @@ func (dump *MongoDump) findOldestOplogEntry() (db.Oplog, error) {
 
 		var tempBSON bson.Raw
 
-		lastErr = failOplogCheckReadFailpoint()
+		lastErr = injectedOplogCheckReadError()
 		if lastErr == nil {
 			lastErr = dump.SessionProvider.FindOne(
 				"local",
@@ -211,21 +211,17 @@ func isCappedPositionLost(err error) bool {
 	return errors.As(err, &serverErr) && serverErr.HasErrorCode(cappedPositionLostErrCode)
 }
 
-// failOplogCheckReadFailpoint returns a synthetic CappedPositionLost error the
-// first time it is called with the FailOplogCheckRead failpoint enabled, so
-// that tests can exercise the retry in findOldestOplogEntry.
-func failOplogCheckReadFailpoint() error {
+// injectedOplogCheckReadError returns the error, if any, that the
+// FailOplogCheckRead failpoint has been told to inject in place of the
+// oldest-entry read. Tests supply that error, so they can exercise both the
+// retry and the reporting in findOldestOplogEntry.
+func injectedOplogCheckReadError() error {
 	fp, ok := failpoint.DefaultManager.Get(failpoint.FailOplogCheckRead)
-	if !ok || !fp.FireOnce() {
+	if !ok {
 		return nil
 	}
 
-	return mongo.CommandError{
-		Code: cappedPositionLostErrCode,
-		Name: "CappedPositionLost",
-		Message: "CollectionScan died due to position in capped collection being deleted" +
-			" (injected by the FailOplogCheckRead failpoint)",
-	}
+	return fp.InjectedError()
 }
 
 func oplogDocumentValidator(in []byte) error {

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -669,3 +669,53 @@ func TestOplogRollover(t *testing.T) {
 		"mongodump should crash when the oplog rolls over during dumping",
 	)
 }
+
+// TestOplogCheckSurvivesCappedPositionLost verifies that a CappedPositionLost
+// error while reading the oldest oplog entry is retried, rather than being
+// reported as an oplog overflow.
+//
+// Reading the front of the oplog in $natural order races the server's oplog
+// truncation, so on a busy oplog the read can fail with CappedPositionLost
+// (TOOLS-4338). That used to surface as "oplog overflow", which wrongly told
+// users the dump may have lost oplog entries. The FailOplogCheckRead failpoint
+// injects that error once so the retry can be tested without having to race
+// real truncation.
+func TestOplogCheckSurvivesCappedPositionLost(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	// Oplog is not available in a standalone topology.
+	testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)
+
+	md, err := simpleMongoDumpInstance()
+	require.NoError(t, err)
+
+	md.ToolOptions.DB = ""
+	md.OutputOptions.Oplog = true
+	md.OutputOptions.Out = "oplog_capped_position_lost"
+	require.NoError(t, md.Init())
+	defer os.RemoveAll(md.OutputOptions.Out)
+
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.FailOplogCheckRead.String()))
+	defer failpoint.DefaultManager.Reset()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.FailOplogCheckRead)
+	require.True(t, ok, "FailOplogCheckRead failpoint should be enabled")
+
+	require.NoError(
+		t,
+		md.Dump(),
+		"mongodump should retry a lost oplog read instead of reporting an overflow",
+	)
+
+	// If the failpoint had not fired during the dump, this would be its first
+	// call and would return true, so this catches the dump silently passing
+	// because no error was ever injected.
+	require.False(
+		t,
+		fp.FireOnce(),
+		"the injected error should have fired during the dump, so the retry was really exercised",
+	)
+
+	oplogInfo, err := os.Stat(filepath.Join(md.OutputOptions.Out, "oplog.bson"))
+	require.NoError(t, err, "the retried dump should still have written an oplog")
+	require.NotZero(t, oplogInfo.Size(), "the dumped oplog should not be empty")
+}

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/bsonutil"
@@ -700,22 +702,82 @@ func TestOplogCheckSurvivesCappedPositionLost(t *testing.T) {
 	fp, ok := failpoint.DefaultManager.Get(failpoint.FailOplogCheckRead)
 	require.True(t, ok, "FailOplogCheckRead failpoint should be enabled")
 
+	var injectOnce sync.Once
+	var injected atomic.Int64
+	fp.SetErrorFunc(func() error {
+		var err error
+		injectOnce.Do(func() {
+			injected.Add(1)
+			err = cappedPositionLostError()
+		})
+		return err
+	})
+
 	require.NoError(
 		t,
 		md.Dump(),
 		"mongodump should retry a lost oplog read instead of reporting an overflow",
 	)
 
-	// If the failpoint had not fired during the dump, this would be its first
-	// call and would return true, so this catches the dump silently passing
-	// because no error was ever injected.
-	require.False(
+	require.EqualValues(
 		t,
-		fp.FireOnce(),
-		"the injected error should have fired during the dump, so the retry was really exercised",
+		1,
+		injected.Load(),
+		"the injected error fired during the dump, so the retry was really exercised",
 	)
 
 	oplogInfo, err := os.Stat(filepath.Join(md.OutputOptions.Out, "oplog.bson"))
 	require.NoError(t, err, "the retried dump should still have written an oplog")
 	require.NotZero(t, oplogInfo.Size(), "the dumped oplog should not be empty")
+}
+
+// TestOplogCheckReportsPersistentReadError verifies that when the oldest-entry
+// read keeps failing, mongodump reports that read error rather than claiming an
+// oplog overflow. The overflow message tells users the dump may have lost oplog
+// entries, which is a very different thing from the check itself being unable to
+// read (TOOLS-4338).
+func TestOplogCheckReportsPersistentReadError(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	// Oplog is not available in a standalone topology.
+	testtype.SkipUnlessTestType(t, testtype.ReplSetTestType)
+
+	md, err := simpleMongoDumpInstance()
+	require.NoError(t, err)
+
+	md.ToolOptions.DB = ""
+	md.OutputOptions.Oplog = true
+	md.OutputOptions.Out = "oplog_persistent_read_error"
+	require.NoError(t, md.Init())
+	defer os.RemoveAll(md.OutputOptions.Out)
+
+	require.NoError(t, failpoint.DefaultManager.Parse(failpoint.FailOplogCheckRead.String()))
+	defer failpoint.DefaultManager.Reset()
+
+	fp, ok := failpoint.DefaultManager.Get(failpoint.FailOplogCheckRead)
+	require.True(t, ok, "FailOplogCheckRead failpoint should be enabled")
+
+	fp.SetErrorFunc(cappedPositionLostError)
+
+	err = md.Dump()
+	require.ErrorContains(
+		t,
+		err,
+		"unable to check oplog for overflow",
+		"a read that never succeeds is reported as a failed check",
+	)
+	require.NotContains(
+		t,
+		err.Error(),
+		"oplog overflow:",
+		"a failed check is not reported as an oplog overflow",
+	)
+}
+
+func cappedPositionLostError() error {
+	return mongo.CommandError{
+		Code: cappedPositionLostErrCode,
+		Name: "CappedPositionLost",
+		Message: "CollectionScan died due to position in capped collection being deleted" +
+			" (injected by the FailOplogCheckRead failpoint)",
+	}
 }


### PR DESCRIPTION
`mongodump --oplog` could fail with "oplog overflow: mongodump was unable to capture all new oplog entries during execution" when the oplog had not overflowed at all. `checkOplogTimestampExists` returned `(false, err)` when it could not read the oplog, and `Dump` tested `!exists` before `err`, so any read failure was discarded and reported to the user as possible data loss.

The read failure seen in CI was `CappedPositionLost` (server code 136) on the check's own query against `local.oplog.rs`. Scanning the front of the oplog in `$natural` order races the server's oplog truncation: the records being read can be deleted mid-scan, which fails the whole read even though the scan had already found its single document. That says nothing about whether the dump's starting timestamp survived. The dump that produced this failure ran for 87ms against a 40MB oplog, so no real rollover was possible.

`Dump` now checks the error before the boolean at both call sites, so a read failure is reported as itself rather than as an overflow, and `findOldestOplogEntry` retries a read that lost its position up to four times with exponential backoff.

The retry cannot mask real data loss. Oplog truncation only ever removes the oldest records: if the starting timestamp is actually gone, every retry still reads an oldest timestamp newer than that starting timestamp, and the overflow is still reported. Exhausting the attempts returns an error, so the check fails closed. The cost is that each retry slightly widens the window in which truncation can legitimately advance past the starting timestamp, which can turn a good dump into a reported overflow.

The new `FailOplogCheckRead` failpoint and `Failpoint.FireOnce` inject that error once so the retry can be tested without racing real truncation.

`getCurrentOplogTime` runs the same scan with `$natural: -1`. Reading from the newest end is far less exposed to truncation, and its caller already handles its error correctly, so it is left alone.