### PR TITLE
TOOLS-4350 Remove various checks for Server versions earlier than 4.2

### DIFF
--- a/common/db/namespaces.go
+++ b/common/db/namespaces.go
@@ -52,10 +52,7 @@ func (ci *CollectionInfo) GetUUID() string {
 	return ""
 }
 
-// GetIndexes returns an iterator to thethe raw index info for a collection by
-// using the listIndexes command if available, or by falling back to querying
-// against system.indexes (pre-3.0 systems). nil is returned if the collection
-// does not exist.
+// GetIndexes returns an iterator to the raw index info for a collection.
 func GetIndexes(coll *mongo.Collection) (*mongo.Cursor, error) {
 	return coll.Indexes().List(context.Background())
 }

--- a/common/intents/intent.go
+++ b/common/intents/intent.go
@@ -508,9 +508,8 @@ func (mgr *Manager) AuthVersion() *Intent {
 	return mgr.versionIntent
 }
 
-// Finalize processes the intents for prioritization. Currently only two
-// kinds of prioritizers are supported. No more "Put" operations may be done
-// after finalize is called.
+// Finalize processes the intents for prioritization. No more "Put" operations
+// may be done after finalize is called.
 func (mgr *Manager) Finalize(pType PriorityType) {
 	switch pType {
 	case Legacy:
@@ -519,12 +518,6 @@ func (mgr *Manager) Finalize(pType PriorityType) {
 	case LongestTaskFirst:
 		log.Logv(log.DebugHigh, "finalizing intent manager with longest task first prioritizer")
 		mgr.prioritizer = newLongestTaskFirstPrioritizer(mgr.intentsByDiscoveryOrder)
-	case MultiDatabaseLTF:
-		log.Logv(
-			log.DebugHigh,
-			"finalizing intent manager with multi-database longest task first prioritizer",
-		)
-		mgr.prioritizer = newMultiDatabaseLTFPrioritizer(mgr.intentsByDiscoveryOrder)
 	default:
 		panic("cannot initialize IntentPrioritizer with unknown type")
 	}

--- a/common/intents/intent_prioritizer.go
+++ b/common/intents/intent_prioritizer.go
@@ -7,7 +7,6 @@
 package intents
 
 import (
-	"container/heap"
 	"sort"
 	"sync"
 )
@@ -17,7 +16,6 @@ type PriorityType int
 const (
 	Legacy PriorityType = iota
 	LongestTaskFirst
-	MultiDatabaseLTF
 )
 
 // IntentPrioritizer encapsulates the logic of scheduling intents
@@ -112,156 +110,4 @@ func (s BySizeAndView) Less(i, j int) bool {
 		return false
 	}
 	return s[i].Size > s[j].Size
-}
-
-// For sorting intents from largest to smallest size.
-type BySize []*Intent
-
-func (s BySize) Len() int           { return len(s) }
-func (s BySize) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s BySize) Less(i, j int) bool { return s[i].Size > s[j].Size }
-
-//===== Multi Database Longest Task First =====
-
-// multiDatabaseLTF is designed to properly schedule intents with two constraints:
-//  1. it is optimized to run in a multi-processor environment
-//  2. it is optimized for parallelism against 2.6's db-level write lock
-//
-// These goals result in a design that attempts to have as many different
-// database's intents being restored as possible and attempts to restore the
-// largest collections first.
-//
-// If we can have a minimum number of collections in flight for a given db,
-// we avoid lock contention in an optimal way on 2.6 systems. That is,
-// it is better to have two restore jobs where
-//
-//	job1 = "test.mycollection"
-//	job2 = "mydb2.othercollection"
-//
-// so that these collections do not compete for the db-level write lock.
-//
-// We also schedule the largest jobs first, in a greedy fashion, in order
-// to minimize total restoration time. Each database's intents are sorted
-// by decreasing file size at initialization, so that the largest jobs are
-// run first. Admittedly, .bson file size is not a direct predictor of restore
-// time, but there is certainly a strong correlation. Note that this attribute
-// is secondary to the multi-db scheduling laid out above, since multi-db will
-// get us bigger wins in terms of parallelism.
-type multiDatabaseLTFPrioritizer struct {
-	sync.Mutex
-	dbHeap     heap.Interface
-	counterMap map[string]*dbCounter
-}
-
-// newMultiDatabaseLTFPrioritizer takes in a list of intents and returns an
-// initialized prioritizer.
-func newMultiDatabaseLTFPrioritizer(intents []*Intent) *multiDatabaseLTFPrioritizer {
-	prioritizer := &multiDatabaseLTFPrioritizer{
-		counterMap: map[string]*dbCounter{},
-		dbHeap:     &DBHeap{},
-	}
-	heap.Init(prioritizer.dbHeap)
-	// first, create all database counters
-	for _, intent := range intents {
-		counter, exists := prioritizer.counterMap[intent.DB]
-		if !exists {
-			// initialize a new counter if one doesn't exist for DB
-			counter = &dbCounter{}
-			prioritizer.counterMap[intent.DB] = counter
-		}
-		counter.collections = append(counter.collections, intent)
-	}
-	// then ensure that all the dbCounters have sorted intents
-	for _, counter := range prioritizer.counterMap {
-		counter.SortCollectionsBySize()
-		heap.Push(prioritizer.dbHeap, counter)
-	}
-	return prioritizer
-}
-
-// Get returns the next prioritized intent and updates the count of active
-// restores for the returned intent's DB. Get is not thread safe, and depends
-// on the implementation of the intent manager to lock around it.
-func (mdb *multiDatabaseLTFPrioritizer) Get() *Intent {
-	mdb.Lock()
-	defer mdb.Unlock()
-
-	if mdb.dbHeap.Len() == 0 {
-		// we're out of things to return
-		return nil
-	}
-	//nolint:errcheck // the heap only contains *dbCounter values
-	optimalDB := heap.Pop(mdb.dbHeap).(*dbCounter)
-	optimalDB.active++
-	nextIntent := optimalDB.PopIntent()
-	// only release the db counter if it's out of collections
-	if len(optimalDB.collections) > 0 {
-		heap.Push(mdb.dbHeap, optimalDB)
-	}
-	return nextIntent
-}
-
-// Finish decreases the number of active restore jobs for the given intent's
-// database, and reshuffles the heap accordingly.
-func (mdb *multiDatabaseLTFPrioritizer) Finish(intent *Intent) {
-	mdb.Lock()
-	defer mdb.Unlock()
-
-	counter := mdb.counterMap[intent.DB]
-	counter.active--
-	// only fix up the heap if the counter is still in the heap
-	if len(counter.collections) > 0 {
-		// This is an O(n) operation on the heap. We could make all heap
-		// operations O(log(n)) if we set up dbCounters to track their own
-		// position in the heap, but in practice this overhead is likely negligible.
-		heap.Init(mdb.dbHeap)
-	}
-}
-
-type dbCounter struct {
-	active      int
-	collections []*Intent
-}
-
-func (dbc *dbCounter) SortCollectionsBySize() {
-	sort.Sort(BySize(dbc.collections))
-}
-
-// PopIntent returns the largest intent remaining for the database.
-func (dbc *dbCounter) PopIntent() *Intent {
-	var intent *Intent
-	if len(dbc.collections) > 0 {
-		intent, dbc.collections = dbc.collections[0], dbc.collections[1:]
-	}
-	return intent
-}
-
-// Returns the largest collection of the databases with the least active restores.
-// Implements the container/heap interface. None of its methods are meant to be
-// called directly.
-type DBHeap []*dbCounter
-
-func (dbh DBHeap) Len() int      { return len(dbh) }
-func (dbh DBHeap) Swap(i, j int) { dbh[i], dbh[j] = dbh[j], dbh[i] }
-func (dbh DBHeap) Less(i, j int) bool {
-	if dbh[i].active == dbh[j].active {
-		// prioritize the largest bson file if dbs have the same number
-		// of restorations in progress
-		return dbh[i].collections[0].Size > dbh[j].collections[0].Size
-	}
-	return dbh[i].active < dbh[j].active
-}
-
-func (dbh *DBHeap) Push(x any) {
-	//nolint:errcheck
-	*dbh = append(*dbh, x.(*dbCounter))
-}
-
-func (dbh *DBHeap) Pop() any {
-	// for container/heap package: removes the top entry and resizes the heap array
-	old := *dbh
-	n := len(old)
-	toPop := old[n-1]
-	*dbh = old[0 : n-1]
-	return toPop
 }

--- a/common/intents/intent_prioritizer_test.go
+++ b/common/intents/intent_prioritizer_test.go
@@ -7,7 +7,6 @@
 package intents
 
 import (
-	"container/heap"
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/testtype"
@@ -37,76 +36,6 @@ func TestLegacyPrioritizer(t *testing.T) {
 	assert.Less(t, it1.DB, it2.DB)
 }
 
-func TestBasicDBHeapBehavior(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
-
-	t.Run("dbCounters with different active counts", func(t *testing.T) {
-		dbheap := &DBHeap{}
-		heap.Init(dbheap)
-		heap.Push(dbheap, &dbCounter{75, nil})
-		heap.Push(dbheap, &dbCounter{121, nil})
-		heap.Push(dbheap, &dbCounter{76, nil})
-		heap.Push(dbheap, &dbCounter{51, nil})
-		heap.Push(dbheap, &dbCounter{82, nil})
-		heap.Push(dbheap, &dbCounter{117, nil})
-		heap.Push(dbheap, &dbCounter{49, nil})
-		heap.Push(dbheap, &dbCounter{101, nil})
-		heap.Push(dbheap, &dbCounter{122, nil})
-		heap.Push(dbheap, &dbCounter{33, nil})
-		heap.Push(dbheap, &dbCounter{0, nil})
-
-		// pop in active order, least to greatest
-		prev := -1
-		for dbheap.Len() > 0 {
-			//nolint:errcheck // the heap only contains *dbCounter values
-			popped := heap.Pop(dbheap).(*dbCounter)
-			assert.Greater(t, popped.active, prev)
-			prev = popped.active
-		}
-	})
-
-	t.Run("dbCounters with different bson sizes", func(t *testing.T) {
-		dbheap := &DBHeap{}
-		heap.Init(dbheap)
-		heap.Push(dbheap, &dbCounter{0, []*Intent{{Size: 70}}})
-		heap.Push(dbheap, &dbCounter{0, []*Intent{{Size: 1024}}})
-		heap.Push(dbheap, &dbCounter{0, []*Intent{{Size: 97}}})
-		heap.Push(dbheap, &dbCounter{0, []*Intent{{Size: 3}}})
-		heap.Push(dbheap, &dbCounter{0, []*Intent{{Size: 1024 * 1024}}})
-
-		// pop in size order, greatest to least
-		prev := int64(1024*1024 + 1) // Maximum
-		for dbheap.Len() > 0 {
-			//nolint:errcheck // the heap only contains *dbCounter values
-			popped := heap.Pop(dbheap).(*dbCounter)
-			assert.Less(t, popped.collections[0].Size, prev)
-			prev = popped.collections[0].Size
-		}
-	})
-}
-
-func TestDBCounterCollectionSorting(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
-
-	dbc := &dbCounter{
-		collections: []*Intent{
-			{Size: 100},
-			{Size: 1000},
-			{Size: 1},
-			{Size: 10},
-		},
-	}
-
-	// popping should return in decreasing BSONSize
-	dbc.SortCollectionsBySize()
-	assert.EqualValues(t, 1000, dbc.PopIntent().Size)
-	assert.EqualValues(t, 100, dbc.PopIntent().Size)
-	assert.EqualValues(t, 10, dbc.PopIntent().Size)
-	assert.EqualValues(t, 1, dbc.PopIntent().Size)
-	assert.Nil(t, dbc.PopIntent())
-	assert.Nil(t, dbc.PopIntent())
-}
-
 func TestBySizeAndView(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
@@ -133,50 +62,4 @@ func TestBySizeAndView(t *testing.T) {
 	assert.Equal(t, "non-view2", prioritizer.Get().C)
 	assert.Equal(t, "non-view3", prioritizer.Get().C)
 
-}
-
-func TestSimulatedMultiDBJob(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
-
-	intents := []*Intent{
-		{C: "small", DB: "db2", Size: 32},
-		{C: "medium", DB: "db2", Size: 128},
-		{C: "giant", DB: "db1", Size: 1024},
-		{C: "tiny", DB: "db1", Size: 2},
-	}
-	prioritizer := newMultiDatabaseLTFPrioritizer(intents)
-	require.NotNil(t, prioritizer)
-
-	// We're simulating two job threads here.
-
-	i0 := prioritizer.Get()
-	require.NotNil(t, i0)
-	assert.Equal(t, "giant", i0.C, "first intent collection is largest bson file")
-	assert.Equal(t, "db1", i0.DB, "first intent db is largest bson file")
-
-	i1 := prioritizer.Get()
-	require.NotNil(t, i1)
-	assert.Equal(t, "medium", i1.C, "second intent collection is largest bson file for db2")
-	assert.Equal(t, "db2", i1.DB, "second intent db is largest bson file for db2")
-
-	// second job finishes the smaller intent
-	prioritizer.Finish(i1)
-
-	i2 := prioritizer.Get()
-	require.NotNil(t, i2)
-	assert.Equal(t, "small", i2.C, "third intent collection is from db2")
-	assert.Equal(t, "db2", i2.DB, "second intent db is from db2")
-	prioritizer.Finish(i2)
-
-	i3 := prioritizer.Get()
-	require.NotNil(t, i3)
-	assert.Equal(t, "tiny", i3.C, "final intent collection is from db1")
-	assert.Equal(t, "db1", i3.DB, "final intent db is from db1")
-
-	// we expect 2 active db1 jobs
-	counter, ok := prioritizer.counterMap["db1"]
-	require.True(t, ok)
-	assert.Equal(t, 2, counter.active, "both db1 jobs are still running")
-
-	assert.Zero(t, prioritizer.dbHeap.Len(), "prioritizer heap is empty")
 }

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -62,8 +62,7 @@ func (dump *MongoDump) dumpMetadata(
 		meta.Type = intent.Type
 	}
 
-	// Second, we read the collection's index information by either calling
-	// listIndexes (pre-2.7 systems) or querying system.indexes.
+	// Second, we read the collection's index information by calling listIndexes.
 	// We keep a running list of all the indexes
 	// for the current collection as we iterate over the cursor, and include
 	// that list as the "indexes" field of the metadata document.

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -164,16 +164,6 @@ func (restore *MongoRestore) CreateIndexes(
 		// update the namespace of the index before inserting
 		index.Options["ns"] = dbName + "." + collectionName
 
-		// check for length violations before building the command
-		if restore.serverVersion.LT(db.Version{4, 2, 0}) {
-			fullIndexName := fmt.Sprintf("%v.$%v", index.Options["ns"], index.Options["name"])
-			if len(fullIndexName) > 127 {
-				return fmt.Errorf(
-					"cannot restore index with namespace %#q: "+
-						"namespace is too long (max size is 127 bytes)", fullIndexName)
-			}
-		}
-
 		nameStr, isString := index.Options["name"].(string)
 		if !isString {
 			return fmt.Errorf(
@@ -201,6 +191,7 @@ func (restore *MongoRestore) CreateIndexes(
 	rawCommand := bson.D{
 		{"createIndexes", collectionName},
 		{"indexes", indexes},
+		{"ignoreUnknownIndexOptions", true},
 	}
 
 	log.Logvf(
@@ -208,10 +199,6 @@ func (restore *MongoRestore) CreateIndexes(
 		"\trun create Index command for indexes: %v",
 		strings.Join(indexNames, ", "),
 	)
-
-	if restore.serverVersion.GTE(db.Version{4, 1, 9}) {
-		rawCommand = append(rawCommand, bson.E{"ignoreUnknownIndexOptions", true})
-	}
 
 	ctx, cancel := restore.writeContext()
 	defer cancel()
@@ -278,26 +265,24 @@ func (restore *MongoRestore) CreateCollection(
 
 }
 
-// UpdateAutoIndexId updates {autoIndexId: false} to {autoIndexId: true} if the server version is
-// >= 4.0 and the database is not `local`.
+// UpdateAutoIndexId removes {autoIndexId: ...} on servers that reject it, and otherwise
+// updates {autoIndexId: false} to {autoIndexId: true} if the database is not `local`.
 func (restore *MongoRestore) UpdateAutoIndexId(options bson.D) bson.D {
-	if restore.serverVersion.GTE(db.Version{4, 0, 0}) {
-		for i, elem := range options {
-			if elem.Key == "autoIndexId" {
-				if restore.serverVersion.GTE(db.Version{8, 2, 0}) {
-					options = append(options[:i], options[i+1:]...)
-					log.Logvf(
-						log.Always,
-						"autoIndexId is not allowed in server versions >= 8.2.0. Removing.",
-					)
-				} else if elem.Value == false &&
-					restore.ToolOptions.DB != "local" {
-					options[i].Value = true
-					log.Logvf(
-						log.Always,
-						"{autoIndexId: false} is not allowed in server versions >= 4.0. Changing to {autoIndexId: true}.",
-					)
-				}
+	for i, elem := range options {
+		if elem.Key == "autoIndexId" {
+			if restore.serverVersion.GTE(db.Version{8, 2, 0}) {
+				options = append(options[:i], options[i+1:]...)
+				log.Logvf(
+					log.Always,
+					"autoIndexId is not allowed in server versions >= 8.2.0. Removing.",
+				)
+			} else if elem.Value == false &&
+				restore.ToolOptions.DB != "local" {
+				options[i].Value = true
+				log.Logvf(
+					log.Always,
+					"{autoIndexId: false} is not allowed. Changing to {autoIndexId: true}.",
+				)
 			}
 		}
 	}

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -652,16 +652,9 @@ func (restore *MongoRestore) Restore() Result {
 	if restore.InputOptions.Archive != "" {
 		restore.manager.UsePrioritizer(restore.archive.Demux.NewPrioritizer(restore.manager))
 	} else if restore.OutputOptions.NumParallelCollections > 1 {
-		// 3.0+ has collection-level locking for writes, so it is most efficient to
-		// prioritize by collection size. Pre-3.0 we try to avoid inserting into collections
-		// in the same database simultaneously due to the database-level locking.
-		// Up to 4.2, foreground index builds take a database-level lock for the entire build,
-		// but this prioritizer is not used for index builds so we don't need to worry about that here.
-		if restore.serverVersion.GTE(db.Version{3, 0, 0}) {
-			restore.manager.Finalize(intents.LongestTaskFirst)
-		} else {
-			restore.manager.Finalize(intents.MultiDatabaseLTF)
-		}
+		// Writes take a collection-level lock, so it is most efficient to prioritize by
+		// collection size.
+		restore.manager.Finalize(intents.LongestTaskFirst)
 	} else {
 		// use legacy restoration order if we are single-threaded
 		restore.manager.Finalize(intents.Legacy)

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -993,55 +993,39 @@ func TestLongIndexName(t *testing.T) {
 			So(dropErr, ShouldBeNil)
 		}()
 
-		if restore.serverVersion.LT(db.Version{4, 2, 0}) {
-			Convey(
-				"Creating index with a full name longer than 127 bytes should fail (<4.2)",
-				func() {
-					restore.TargetDirectory = "testdata/longindextestdump"
-					result := restore.Restore()
-					So(result.Err, ShouldNotBeNil)
-					So(
-						result.Err.Error(),
-						ShouldContainSubstring,
-						"namespace is too long (max size is 127 bytes)",
-					)
-				},
-			)
-		} else {
-			Convey(
-				"Creating index with a full name longer than 127 bytes should succeed (>=4.2)",
-				func() {
-					restore.TargetDirectory = "testdata/longindextestdump"
-					result := restore.Restore()
-					So(result.Err, ShouldBeNil)
+		Convey(
+			"Creating index with a full name longer than 127 bytes should succeed",
+			func() {
+				restore.TargetDirectory = "testdata/longindextestdump"
+				result := restore.Restore()
+				So(result.Err, ShouldBeNil)
 
-					indexes := session.Database("longindextest").
-						Collection("test_collection").
-						Indexes()
-					c, err := indexes.List(t.Context())
+				indexes := session.Database("longindextest").
+					Collection("test_collection").
+					Indexes()
+				c, err := indexes.List(t.Context())
+				So(err, ShouldBeNil)
+
+				type indexRes struct {
+					Name string
+				}
+				var names []string
+				for c.Next(t.Context()) {
+					var r indexRes
+					err := c.Decode(&r)
 					So(err, ShouldBeNil)
-
-					type indexRes struct {
-						Name string
-					}
-					var names []string
-					for c.Next(t.Context()) {
-						var r indexRes
-						err := c.Decode(&r)
-						So(err, ShouldBeNil)
-						names = append(names, r.Name)
-					}
-					So(len(names), ShouldEqual, 2)
-					sort.Strings(names)
-					So(names[0], ShouldEqual, "_id_")
-					So(
-						names[1],
-						ShouldEqual,
-						"a_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-					)
-				},
-			)
-		}
+					names = append(names, r.Name)
+				}
+				So(len(names), ShouldEqual, 2)
+				sort.Strings(names)
+				So(names[0], ShouldEqual, "_id_")
+				So(
+					names[1],
+					ShouldEqual,
+					"a_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				)
+			},
+		)
 
 	})
 }

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -366,11 +366,6 @@ func (restore *MongoRestore) HandleNonTxnOp(oplogCtx *oplogContext, op db.Oplog)
 			}
 			return nil
 		case "collMod":
-			if restore.serverVersion.GTE(db.Version{4, 1, 11}) {
-				_, _ = bsonutil.RemoveKey("noPadding", &op.Object)
-				_, _ = bsonutil.RemoveKey("usePowerOf2Sizes", &op.Object)
-			}
-
 			indexModValue, found := bsonutil.RemoveKey("index", &op.Object)
 			if !found {
 				break
@@ -553,30 +548,11 @@ func ParseTimestampFlag(ts string) (bson.Timestamp, error) {
 	return bson.Timestamp{T: secsU32, I: incU32}, nil
 }
 
-// Server versions 3.6.0-3.6.8 and 4.0.0-4.0.2 require a 'ui' field
-// in the createIndexes command.
-func (restore *MongoRestore) needsCreateIndexWorkaround() bool {
-	sv := restore.serverVersion
-	if (sv.GTE(db.Version{3, 6, 0}) && sv.LTE(db.Version{3, 6, 8})) ||
-		(sv.GTE(db.Version{4, 0, 0}) && sv.LTE(db.Version{4, 0, 2})) {
-		return true
-	}
-	return false
-}
-
 // filterUUIDs removes 'ui' entries from ops, including nested applyOps ops.
-// It also modifies ops that rely on 'ui'.
 func (restore *MongoRestore) filterUUIDs(op db.Oplog) (db.Oplog, error) {
 	// Remove UUIDs from oplog entries
 	if !restore.OutputOptions.PreserveUUID {
 		op.UI = nil
-
-		// The createIndexes oplog command requires 'ui' for some server versions, so
-		// in that case we fall back to an old-style system.indexes insert.
-		if op.Operation == "c" && op.Object[0].Key == "createIndexes" &&
-			restore.needsCreateIndexWorkaround() {
-			return convertCreateIndexToIndexInsert(op)
-		}
 	}
 
 	// Check for and filter nested applyOps ops
@@ -602,34 +578,6 @@ func (restore *MongoRestore) filterRecordIdsReplicated(op db.Oplog) db.Oplog {
 	}
 
 	return op
-}
-
-// convertCreateIndexToIndexInsert converts from new-style create indexes
-// command to old style special index insert.
-func convertCreateIndexToIndexInsert(op db.Oplog) (db.Oplog, error) {
-	dbName, _ := util.SplitNamespace(op.Namespace)
-
-	cmdValue := op.Object[0].Value
-	collName, ok := cmdValue.(string)
-	if !ok {
-		return db.Oplog{}, fmt.Errorf("unknown format for createIndexes")
-	}
-
-	indexSpec := op.Object[1:]
-	if len(indexSpec) < 3 {
-		return db.Oplog{}, fmt.Errorf("unknown format for createIndexes, index spec " +
-			"must have at least \"v\", \"key\", and \"name\" fields")
-	}
-
-	// createIndexes does not include the "ns" field but index inserts
-	// do. Add it as the third field, after "v", "key", and "name".
-	ns := bson.D{{"ns", fmt.Sprintf("%s.%s", dbName, collName)}}
-	indexSpec = append(indexSpec[:3], append(ns, indexSpec[3:]...)...)
-	op.Object = indexSpec
-	op.Namespace = fmt.Sprintf("%s.system.indexes", dbName)
-	op.Operation = "i"
-
-	return op, nil
 }
 
 // extractIndexDocumentFromCommitIndexBuilds extracts the index specs out of  "commitIndexBuild" oplog entry and convert to IndexDocument

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -551,12 +551,6 @@ func (restore *MongoRestore) convertLegacyIndexes(
 
 		indexKeys = append(indexKeys, index.Key)
 
-		// It is preferable to use the ignoreUnknownIndexOptions on the createIndex command to
-		// force the server to remove unknown options. But ignoreUnknownIndexOptions was only added in 4.1.9.
-		// So for pre 3.4 indexes being added to servers < 4.1.9 we must strip the options here.
-		if restore.serverVersion.LT(db.Version{4, 1, 9}) {
-			bsonutil.ConvertLegacyIndexOptions(index.Options)
-		}
 		indexesConverted = append(indexesConverted, index)
 	}
 	return indexesConverted


### PR DESCRIPTION
We haven't tested with pre-4.2 versions for over a year. In addition, our public documentation has said that we do not support cross-version restore of metadata, oplog replay, etc. since May of 2024.

This PR makes the following changes:

- mongorestore/metadata.go - drop the 127-byte index namespace check that only applied to servers < 4.2
- mongorestore/metadata.go - always send `ignoreUnknownIndexOptions` on `createIndexes` rather than gating on >= 4.1.9
- mongorestore/metadata.go - drop the >= 4.0 guard in `UpdateAutoIndexId`
- mongorestore/oplog.go - don't attempt to strip `noPadding` and `usePowerOf2Sizes` when running `collMod`; these are MMAPv1 options and no supported dump source can emit them
- mongorestore/oplog.go - remove `needsCreateIndexWorkaround` and `convertCreateIndexToIndexInsert`, which only applied to 3.6.x and 4.0.x versions
- mongorestore/restore.go - remove the client-side index option strip for servers < 4.1.9; the server now always does this via `ignoreUnknownIndexOptions`
- mongorestore/mongorestore.go - always use the `LongestTaskFirst` prioritizer, since every supported server has collection-level write locking
- common/db/namespaces.go, mongodump/metadata_dump.go - fix comments describing `system.indexes` fallbacks that no longer exist in the code