### PR TITLE
TOOLS-4350 Remove stale references to unsupported Server versions in comments and an error message

### DIFF
--- a/common/db/optime.go
+++ b/common/db/optime.go
@@ -9,8 +9,6 @@ import (
 
 // OpTime represents the values to uniquely identify an oplog entry.
 // An OpTime must always have a timestamp, but may or may not have a term.
-// The hash is set uniquely up until (and including) version 4.0, but is set
-// to zero in version 4.2+ with plans to remove it soon (see SERVER-36334).
 type OpTime struct {
 	Timestamp bson.Timestamp `json:"timestamp"`
 	Term      *int64         `json:"term"`

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -740,7 +740,7 @@ func (opts *ToolOptions) handleUnknownOption(
 	args []string,
 ) ([]string, error) {
 	if option == "dbpath" || option == "directoryperdb" || option == "journal" {
-		return args, fmt.Errorf("--dbpath and related flags are not supported in 3.0 tools.\n" +
+		return args, fmt.Errorf("--dbpath and related flags are not supported.\n" +
 			"See http://dochub.mongodb.org/core/tools-dbpath-deprecated for more information")
 	}
 

--- a/common/txn/meta.go
+++ b/common/txn/meta.go
@@ -60,7 +60,8 @@ func NewMeta(op db.Oplog) (Meta, error) {
 		return Meta{}, nil
 	}
 
-	// Default prevOpTime to empty to "upgrade" 4.0 transactions without it.
+	// Default prevOpTime to empty so that an entry lacking the field is not
+	// treated as part of a multi-op transaction. See IsMultiOp.
 	m := Meta{
 		id:         ID{lsid: string(op.LSID), txnNumber: *op.TxnNumber},
 		prevOpTime: emptyPrev,

--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -43,7 +43,7 @@ func (dump *MongoDump) dumpMetadata(
 	meta := Metadata{
 		// We have to initialize Indexes to an empty slice, not nil, so that an empty
 		// array is marshaled into json instead of null. That is, {indexes:[]} is okay
-		// but {indexes:null} will cause assertions in our legacy C++ mongotools
+		// but {indexes:null} is not.
 		Indexes: []bson.D{},
 	}
 


### PR DESCRIPTION
None of these change the tools' behavior. They are comments and one error message that refer to Server versions below the new 4.2 minimum or to code related to those versions.