### PR TITLE
TOOLS-4350 Require MongoDB Server 4.2 or newer

### DIFF
--- a/common/db/db.go
+++ b/common/db/db.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongo-tools/common"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/youmark/pkcs8"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -124,8 +125,28 @@ func NewSessionProvider(opts options.ToolOptions) (*SessionProvider, error) {
 		return nil, fmt.Errorf("failed to connect to %s: %v", opts.ParsedConnString(), err)
 	}
 
-	// create the provider
-	return &SessionProvider{client: client}, nil
+	sp := &SessionProvider{client: client}
+
+	uri := util.SanitizeURI(opts.ConnectionString)
+
+	version, err := sp.ServerVersionArray()
+	if err != nil {
+		sp.Close()
+		return nil, fmt.Errorf(
+			"could not determine the version of the server at %s: %w",
+			uri,
+			err,
+		)
+	}
+	if !version.IsSupportedServer() {
+		sp.Close()
+		return nil, fmt.Errorf(
+			"the server at %s reports version %s, but these tools require %s or newer",
+			uri, version, MinimumSupportedServerVersion,
+		)
+	}
+
+	return sp, nil
 }
 
 // addClientCertFromFile adds a client certificate to the configuration given a path to the

--- a/common/db/version.go
+++ b/common/db/version.go
@@ -10,6 +10,11 @@ import (
 
 type Version [3]int
 
+// MinimumSupportedServerVersion is the oldest MongoDB Server release these tools
+// work against. The code paths for older servers have been removed, so running
+// against one risks silently producing wrong results.
+var MinimumSupportedServerVersion = Version{4, 2, 0}
+
 func (v1 Version) Cmp(v2 Version) int {
 	for i := range v1 {
 		if v1[i] < v2[i] {
@@ -55,6 +60,12 @@ func (v Version) String() string {
 
 func (v Version) IsEmpty() bool {
 	return v == Version{}
+}
+
+// IsSupportedServer indicates whether the version is new enough for these tools
+// to work against.
+func (v Version) IsSupportedServer() bool {
+	return v.GTE(MinimumSupportedServerVersion)
 }
 
 // SupportsRawData indicates whether the version supports the rawData CRUD API.

--- a/common/db/version_test.go
+++ b/common/db/version_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionCmp(t *testing.T) {
@@ -105,5 +106,32 @@ func TestStrToVersion(t *testing.T) {
 		if got != c.v {
 			t.Errorf("StrToVersion(%v): got %v; wanted: %v, error: %v", c.str, got, c.v, err)
 		}
+	}
+}
+
+func TestIsSupportedServer(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	cases := []struct {
+		version   Version
+		supported bool
+	}{
+		{Version{}, false},
+		{Version{3, 6, 23}, false},
+		{Version{4, 0, 28}, false},
+		{Version{4, 1, 9}, false},
+		{Version{4, 2, 0}, true},
+		{Version{4, 4, 1}, true},
+		{Version{8, 0, 0}, true},
+	}
+
+	for _, c := range cases {
+		assert.Equal(
+			t,
+			c.supported,
+			c.version.IsSupportedServer(),
+			"IsSupportedServer() for %s",
+			c.version,
+		)
 	}
 }


### PR DESCRIPTION
This applies to every tool that connects to the Server.