### PR TITLE
TOOLS-4263 Move the throwaway mongod helper into sharedsuite

### DIFF
--- a/integration/dumprestore/server_death_test.go
+++ b/integration/dumprestore/server_death_test.go
@@ -1,19 +1,11 @@
 package dumprestore
 
 import (
-	"bytes"
-	"net"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
-	"sync"
 	"time"
 
-	"github.com/mongodb/mongo-tools/common/db"
-	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/integration/sharedsuite"
 	"github.com/mongodb/mongo-tools/mongodump"
-	"github.com/mongodb/mongo-tools/release/platform"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
@@ -33,8 +25,8 @@ func (s *DumpRestoreSuite) TestDumpFailsWhenServerDies() {
 		collName = "bar"
 	)
 
-	mongod := s.startThrowawayMongod()
-	coll := mongod.client.Database(dbName).Collection(collName)
+	mongod := s.StartThrowawayMongod()
+	coll := mongod.Client.Database(dbName).Collection(collName)
 	s.seedSlowDumpData(coll)
 
 	// The dump reads every document through a $where that sleeps, so it is still
@@ -79,146 +71,6 @@ const serverDiedErrors = `(?i)error reading from db|error reading collection|` +
 	`connection closed|interrupted|socket was unexpectedly closed|` +
 	`incomplete read of message header`
 
-// throwawayMongod is a mongod this test owns, so it can be killed without
-// disturbing the deployment the rest of the suite shares.
-type throwawayMongod struct {
-	process *os.Process
-	host    string
-	client  *mongo.Client
-	stderr  *lockedBuffer
-}
-
-// lockedBuffer collects a subprocess's output for a failure message. os/exec fills it
-// from a goroutine of its own, so reading it while the process is still running needs
-// the lock.
-type lockedBuffer struct {
-	mutex  sync.Mutex
-	buffer bytes.Buffer
-}
-
-func (b *lockedBuffer) Write(p []byte) (int, error) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	return b.buffer.Write(p)
-}
-
-func (b *lockedBuffer) String() string {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	return b.buffer.String()
-}
-
-func (s *DumpRestoreSuite) startThrowawayMongod() *throwawayMongod {
-	binary := s.mongodBinary()
-	dbPath := s.T().TempDir()
-	port := s.freePort()
-
-	// No auth and no TLS, whatever the deployment under test uses: nothing else
-	// connects to this server, and the test builds its own arguments for it.
-	cmd := exec.CommandContext(
-		s.Context(),
-		binary,
-		"--port", port,
-		"--dbpath", dbPath,
-		"--bind_ip", "localhost",
-	)
-
-	// Kept so that a mongod which refuses to start can say why, instead of the test
-	// only reporting that it never came up.
-	stderr := &lockedBuffer{}
-	cmd.Stderr = stderr
-
-	s.Require().NoError(cmd.Start(), "can start a mongod of our own from %s", binary)
-
-	mongod := &throwawayMongod{
-		process: cmd.Process,
-		host:    net.JoinHostPort("localhost", port),
-		stderr:  stderr,
-	}
-	s.T().Cleanup(func() {
-		// The test kills this process itself; this is only for the paths where it
-		// did not get that far.
-		_ = mongod.process.Kill()
-		_ = cmd.Wait()
-	})
-
-	mongod.client = s.waitForMongod(mongod)
-
-	return mongod
-}
-
-// mongodBinary returns the path to a mongod this test can start. CI downloads one
-// alongside the built tools and nothing tells the test where it is, so the default is
-// the path relative to the package directory, which is where go test runs.
-func (s *DumpRestoreSuite) mongodBinary() string {
-	if fromEnv := os.Getenv(mongodBinaryEnvVar); fromEnv != "" {
-		return fromEnv
-	}
-
-	binary := filepath.Join("..", "..", "bin", "mongod"+platform.GetLocalBinaryExt())
-	if _, err := os.Stat(binary); err == nil {
-		return binary
-	}
-
-	onPath, err := exec.LookPath("mongod")
-	if err == nil {
-		return onPath
-	}
-
-	s.T().Skipf(
-		"skipping because this test starts a mongod of its own and there is none at %s,"+
-			" none on the PATH, and %s is not set",
-		binary,
-		mongodBinaryEnvVar,
-	)
-
-	return ""
-}
-
-const mongodBinaryEnvVar = "TOOLS_TESTING_MONGOD_BINARY"
-
-// freePort returns a port nothing is listening on, by taking one from the operating
-// system and handing it straight back. Something else could claim it in between, in
-// which case mongod fails to bind and the test reports that it never came up.
-func (s *DumpRestoreSuite) freePort() string {
-	listener, err := net.Listen("tcp", "localhost:0")
-	s.Require().NoError(err, "can find a free port to start a mongod on")
-	defer func() {
-		s.Require().NoError(listener.Close(), "can release the port again")
-	}()
-
-	_, port, err := net.SplitHostPort(listener.Addr().String())
-	s.Require().NoError(err, "can read the port back out of the listener's address")
-
-	return port
-}
-
-func (s *DumpRestoreSuite) waitForMongod(mongod *throwawayMongod) *mongo.Client {
-	client := s.throwawayClient(mongod.host)
-	s.Require().Eventually(
-		func() bool { return client.Ping(s.Context(), nil) == nil },
-		mongodStartupTimeout,
-		mongodPollInterval,
-		"the mongod started on %s comes up; its stderr was:\n%s",
-		mongod.host,
-		mongod.stderr,
-	)
-	s.T().Cleanup(func() {
-		// The server this client is connected to is killed by the time the test
-		// ends, so a failure to disconnect from it is not a failure of the test.
-		_ = client.Disconnect(s.Context())
-	})
-
-	return client
-}
-
-const (
-	mongodStartupTimeout = 30 * time.Second
-	mongodPollInterval   = 100 * time.Millisecond
-)
-
 func (s *DumpRestoreSuite) seedSlowDumpData(coll *mongo.Collection) {
 	docs := make([]any, slowDumpDocCount)
 	for i := range docs {
@@ -237,13 +89,13 @@ const slowDumpDocCount = 1000
 // long the dump itself ran, which is what tells a dump the kill interrupted apart
 // from one that had already failed for some other reason.
 func (s *DumpRestoreSuite) dumpWhileKillingServer(
-	mongod *throwawayMongod,
+	mongod *sharedsuite.ThrowawayMongod,
 	dumpArgs ...string,
 ) (time.Duration, error) {
 	opts, err := mongodump.ParseOptions(
 		append(
 			[]string{
-				"--host", mongod.host,
+				"--host", mongod.Host,
 				"--serverSelectionTimeout", strconv.Itoa(serverSelectionTimeoutSeconds),
 			},
 			dumpArgs...,
@@ -263,7 +115,7 @@ func (s *DumpRestoreSuite) dumpWhileKillingServer(
 	killed := make(chan error, 1)
 	go func() {
 		time.Sleep(dumpHeadStart)
-		killed <- mongod.process.Kill()
+		killed <- mongod.Process.Kill()
 	}()
 
 	start := time.Now()
@@ -285,27 +137,3 @@ const serverSelectionTimeoutSeconds = 2
 // The dump takes tens of seconds to finish, so this only has to be long enough for
 // it to have started reading.
 const dumpHeadStart = time.Second
-
-// throwawayClient connects to a server that has neither auth nor TLS, whatever the
-// deployment the suite otherwise talks to requires.
-func (s *DumpRestoreSuite) throwawayClient(host string) *mongo.Client {
-	toolOptions := &options.ToolOptions{
-		Connection: &options.Connection{Host: host},
-		Auth:       &options.Auth{},
-		SSL:        &options.SSL{},
-		Namespace:  &options.Namespace{},
-		URI:        &options.URI{},
-	}
-	s.Require().NoError(
-		toolOptions.NormalizeOptionsAndURI(),
-		"can normalize options for the throwaway mongod",
-	)
-
-	sessionProvider, err := db.NewSessionProvider(*toolOptions)
-	s.Require().NoError(err, "can build a session provider for the throwaway mongod")
-
-	client, err := sessionProvider.GetSession()
-	s.Require().NoError(err, "can get a session for the throwaway mongod")
-
-	return client
-}

--- a/integration/sharedsuite/throwaway_mongod.go
+++ b/integration/sharedsuite/throwaway_mongod.go
@@ -1,0 +1,188 @@
+package sharedsuite
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/mongodb/mongo-tools/common/db"
+	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/release/platform"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// ThrowawayMongod is a mongod the test owns, so it can be killed, left
+// uninitiated, or otherwise mistreated without disturbing the deployment the rest
+// of the suite shares.
+type ThrowawayMongod struct {
+	Process *os.Process
+	Host    string
+	Client  *mongo.Client
+	Stderr  *LockedBuffer
+}
+
+// LockedBuffer collects a subprocess's output for a failure message. os/exec fills
+// it from a goroutine of its own, so reading it while the process is still running
+// needs the lock.
+type LockedBuffer struct {
+	mutex  sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *LockedBuffer) Write(p []byte) (int, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.buffer.Write(p)
+}
+
+func (b *LockedBuffer) String() string {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.buffer.String()
+}
+
+// StartThrowawayMongod starts a mongod of the suite's own with the given extra
+// arguments, and waits for it to answer. It is killed when the test ends.
+func (s *IntegrationSuite) StartThrowawayMongod(extraArgs ...string) *ThrowawayMongod {
+	binary := s.mongodBinary()
+	port := s.FreePort()
+
+	// No auth and no TLS, whatever the deployment under test uses: nothing else
+	// connects to this server, and the caller builds its own arguments for it.
+	args := []string{
+		"--port", port,
+		"--dbpath", s.T().TempDir(),
+		"--bind_ip", "localhost",
+	}
+	cmd := exec.CommandContext(s.Context(), binary, append(args, extraArgs...)...)
+
+	// Kept so that a mongod which refuses to start can say why, instead of the test
+	// only reporting that it never came up.
+	stderr := &LockedBuffer{}
+	cmd.Stderr = stderr
+
+	s.Require().NoError(cmd.Start(), "can start a mongod of our own from %s", binary)
+
+	mongod := &ThrowawayMongod{
+		Process: cmd.Process,
+		Host:    net.JoinHostPort("localhost", port),
+		Stderr:  stderr,
+	}
+	s.T().Cleanup(func() {
+		// A test that kills this process itself has already done so; this is for
+		// every other path.
+		_ = mongod.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	mongod.Client = s.waitForMongod(mongod)
+
+	return mongod
+}
+
+// mongodBinary returns the path to a mongod the suite can start. CI downloads one
+// alongside the built tools and nothing tells the test where it is, so the default
+// is a path relative to the directory go test runs in, which is the package
+// directory of the test that called this, not of this file. That is two levels
+// down from the repo root for every caller under integration/, and a caller at
+// another depth has to set the environment variable instead.
+func (s *IntegrationSuite) mongodBinary() string {
+	if fromEnv := os.Getenv(mongodBinaryEnvVar); fromEnv != "" {
+		return fromEnv
+	}
+
+	binary := filepath.Join("..", "..", "bin", "mongod"+platform.GetLocalBinaryExt())
+	if _, err := os.Stat(binary); err == nil {
+		return binary
+	}
+
+	onPath, err := exec.LookPath("mongod")
+	if err == nil {
+		return onPath
+	}
+
+	s.T().Skipf(
+		"skipping because this test starts a mongod of its own and there is none at %s,"+
+			" none on the PATH, and %s is not set",
+		binary,
+		mongodBinaryEnvVar,
+	)
+
+	return ""
+}
+
+const mongodBinaryEnvVar = "TOOLS_TESTING_MONGOD_BINARY"
+
+// FreePort returns a port nothing is listening on, by taking one from the operating
+// system and handing it straight back. Something else could claim it in between, in
+// which case mongod fails to bind and the test reports that it never came up.
+func (s *IntegrationSuite) FreePort() string {
+	listener, err := net.Listen("tcp", "localhost:0")
+	s.Require().NoError(err, "can find a free port to start a mongod on")
+	defer func() {
+		s.Require().NoError(listener.Close(), "can release the port again")
+	}()
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	s.Require().NoError(err, "can read the port back out of the listener's address")
+
+	return port
+}
+
+// waitForMongod returns a client for a mongod that is answering. It pings rather
+// than selecting a writable server, so that it also comes back for a replica set
+// member that has no primary.
+func (s *IntegrationSuite) waitForMongod(mongod *ThrowawayMongod) *mongo.Client {
+	client := s.throwawayClient(mongod.Host)
+	s.Require().Eventually(
+		func() bool { return client.Ping(s.Context(), nil) == nil },
+		mongodStartupTimeout,
+		mongodPollInterval,
+		"the mongod started on %s comes up; its stderr was:\n%s",
+		mongod.Host,
+		mongod.Stderr,
+	)
+	s.T().Cleanup(func() {
+		// The server this client is connected to may be dead by the time the test
+		// ends, so a failure to disconnect from it is not a failure of the test.
+		_ = client.Disconnect(s.Context())
+	})
+
+	return client
+}
+
+const (
+	mongodStartupTimeout = 30 * time.Second
+	mongodPollInterval   = 100 * time.Millisecond
+)
+
+// throwawayClient connects to a server that has neither auth nor TLS, whatever the
+// deployment the suite otherwise talks to requires. It connects directly, so it
+// does not need the server to be part of a working replica set.
+func (s *IntegrationSuite) throwawayClient(host string) *mongo.Client {
+	toolOptions := &options.ToolOptions{
+		Connection: &options.Connection{Host: host},
+		Auth:       &options.Auth{},
+		SSL:        &options.SSL{},
+		Namespace:  &options.Namespace{},
+		URI:        &options.URI{},
+	}
+	s.Require().NoError(
+		toolOptions.NormalizeOptionsAndURI(),
+		"can normalize options for the throwaway mongod",
+	)
+
+	sessionProvider, err := db.NewSessionProvider(*toolOptions)
+	s.Require().NoError(err, "can build a session provider for the throwaway mongod")
+
+	client, err := sessionProvider.GetSession()
+	s.Require().NoError(err, "can get a session for the throwaway mongod")
+
+	return client
+}


### PR DESCRIPTION
The dump server-death test starts a mongod of its own so that it can kill it
without disturbing the deployment the rest of the suite shares. A mongoimport test
converted next needs the same thing for a different reason: a replica set that was
never initiated has no primary, which is what that test is about. Rather than stand
up a second copy in `integration/exportimport`, the machinery moves to the package
both suites already embed.

- `integration/dumprestore/server_death_test.go` -> `integration/sharedsuite/throwaway_mongod.go` - `throwawayMongod` and its `startThrowawayMongod`, along with the `LockedBuffer` that collects the process's stderr for a failure message, become exported members of `sharedsuite`. `StartThrowawayMongod` now takes extra mongod arguments, so a caller can ask for one that belongs to a named replica set.

No behavior changes. The server-death test's assertions are untouched; only the
names it calls them through move.