### PR TITLE
TOOLS-4263 Convert the last two qa-test JS tests to Go and remove the qa-tests CI

### DIFF
--- a/integration/dumprestore/index_roundtrip_test.go
+++ b/integration/dumprestore/index_roundtrip_test.go
@@ -2,6 +2,7 @@ package dumprestore
 
 import (
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"github.com/mongodb/mongo-tools/mongorestore"
@@ -205,6 +206,83 @@ func (s *DumpRestoreSuite) indexSpecs(coll *mongo.Collection) []bson.D {
 	)
 
 	return specs
+}
+
+// TestNoIndexRestore checks that --noIndexRestore brings back the data without
+// the secondary indexes. The _id index is not the restore's to skip: the server
+// creates it with the collection.
+func (s *DumpRestoreSuite) TestNoIndexRestore() {
+	testDB := s.database("no_index_restore")
+	withoutIndexes := testDB.Collection("coll1")
+	withIndexes := testDB.Collection("coll2")
+
+	insertedIDs := make([]int, 0, 10)
+	docs := make([]any, 0, 10)
+	for i := range 10 {
+		insertedIDs = append(insertedIDs, i)
+		docs = append(docs, bson.D{{"_id", i}, {"num", i + 1}, {"s", strconv.Itoa(i)}})
+	}
+
+	for _, coll := range []*mongo.Collection{withoutIndexes, withIndexes} {
+		_, err := coll.InsertMany(s.Context(), docs)
+		s.Require().NoError(err, "can insert into %#q", coll.Name())
+	}
+
+	_, err := withIndexes.Indexes().CreateMany(s.Context(), []mongo.IndexModel{
+		{Keys: bson.D{{"num", 1}}},
+		{Keys: bson.D{{"num", 1}, {"s", -1}}},
+	})
+	s.Require().NoError(err, "can create the secondary indexes on %#q", withIndexes.Name())
+	s.Require().ElementsMatch(
+		[]string{"_id_", "num_1", "num_1_s_-1"},
+		s.indexNames(withIndexes),
+		"both secondary indexes were created before the dump",
+	)
+
+	s.withBSONMongodump(func(dir string) {
+		s.dropDB(testDB)
+
+		result := s.runRestore(mongorestore.NoIndexRestoreOption, dir)
+		s.Require().NoError(result.Err, "can restore with --noIndexRestore")
+	}, "--db", testDB.Name())
+
+	for _, coll := range []*mongo.Collection{withoutIndexes, withIndexes} {
+		s.Assert().Equal(
+			insertedIDs,
+			s.intDocumentIDs(coll),
+			"every document in %#q is restored, and only those",
+			coll.Name(),
+		)
+		s.Assert().Equal(
+			[]string{"_id_"},
+			s.indexNames(coll),
+			"--noIndexRestore leaves %#q with only the _id index",
+			coll.Name(),
+		)
+	}
+}
+
+// intDocumentIDs returns the _id of every document in the collection, sorted.
+func (s *DumpRestoreSuite) intDocumentIDs(coll *mongo.Collection) []int {
+	cursor, err := coll.Find(s.Context(), bson.D{})
+	s.Require().NoError(err, "can read the documents in %#q", coll.Name())
+
+	var docs []struct {
+		ID int `bson:"_id"`
+	}
+	s.Require().NoError(
+		cursor.All(s.Context(), &docs),
+		"can decode the documents in %#q",
+		coll.Name(),
+	)
+
+	ids := make([]int, 0, len(docs))
+	for _, doc := range docs {
+		ids = append(ids, doc.ID)
+	}
+	slices.Sort(ids)
+
+	return ids
 }
 
 // TestIndexVersionRoundTrip checks which version a restored index ends up at:

--- a/mongofiles/delete_test.go
+++ b/mongofiles/delete_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongofiles
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestDeleteRemovesEveryVersionOfAFilename checks that one delete removes every
+// GridFS file stored under the given name, and the chunks holding their
+// contents. A put does not replace an earlier file of the same name unless asked
+// to, so a name can stand for many files.
+func TestDeleteRemovesEveryVersionOfAFilename(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	client := emptyGridFSClient(t)
+	localFile := loremIpsumFiles[0]
+
+	for range 10 {
+		runPut(t, StorageOptions{}, localFile)
+	}
+	require.EqualValues(
+		t,
+		10,
+		countFiles(t, client, testDB, "fs.files", bson.D{{"filename", localFile}}),
+		"each put stores another GridFS file under the same name",
+	)
+	require.Positive(
+		t,
+		countFiles(t, client, testDB, "fs.chunks", bson.D{}),
+		"the puts wrote chunks",
+	)
+
+	mf := mongoFilesWithStorageOptions(t, "delete", StorageOptions{})
+	mf.FileName = localFile
+	_, err := mf.Run(false)
+	require.NoError(t, err, "can delete %#q", localFile)
+
+	assert.EqualValues(
+		t,
+		0,
+		countFiles(t, client, testDB, "fs.files", bson.D{}),
+		"the delete removes every version of the name from fs.files",
+	)
+	assert.EqualValues(
+		t,
+		0,
+		countFiles(t, client, testDB, "fs.chunks", bson.D{}),
+		"the delete leaves no orphaned chunks behind in fs.chunks",
+	)
+}


### PR DESCRIPTION
- `test/qa-tests/jstests/files/mongofiles_delete.js` -> `mongofiles/delete_test.go` - `TestDeleteRemovesEveryVersionOfAFilename`. A put does not replace an earlier file of the same name unless asked to, so ten puts of one name leave ten GridFS files; the test then asserts that a single `delete` of that name removes all ten and leaves `fs.chunks` empty. The existing goconvey `delete` case in `mongofiles/mongofiles_test.go` deletes a single file and checks only that its name is gone from `fs.files`, so neither the every-version behavior nor the chunk cleanup was covered.
- `test/qa-tests/jstests/restore/no_index_restore.js` -> `integration/dumprestore/index_roundtrip_test.go` - `TestNoIndexRestore`. Two collections are dumped, one with two secondary indexes and one with none, then dropped and restored with `--noIndexRestore`. Each comes back with all of its documents and only its `_id` index, which the server creates with the collection rather than the restore. The pre-existing `--noIndexRestore` coverage in `mongorestore/mongorestore_test.go` is for the time-series `system.buckets` clustered index, read from a checked-in dump, and says nothing about ordinary secondary indexes.

Both JS files are deleted. No test JS remains under `test/qa-tests/jstests`.

Each test asserts the exact set of `_id`s rather than a document count, so it also
catches a document that should not be there. Both add a check that the setup they
depend on really happened - that the puts wrote chunks, and that the secondary
indexes existed before the dump - because without it the post-restore assertion of
an empty `fs.chunks`, or of an `_id`-only index list, would hold just as well if
the setup had silently done nothing.

Coverage notes:

`mongofiles_delete.js` ran against a standalone, a replica set, and a sharded
cluster, under both plain and auth passthroughs. The Go test runs against whatever
one server the integration suite is pointed at. `mongofiles/sharded_gridfs_test.go`
is the only sharded test in the package and it never issues a `delete`, so sharded
`delete` coverage is not carried over. It is worth having: `deleteAll` removes
chunks per file, and chunk distribution is exactly what sharding changes.

`no_index_restore.js` used `plain_28.config.js`, a single topology, so the suite
conversion loses nothing there.

The collection with no secondary indexes only proves that the restore does not
invent indexes; the collection with two is what makes the test able to fail. Both
are kept because the JS had the same pair.

Removes the qa-tests CI infrastructure, which now has nothing to run:

- `test/qa-tests/` - deleted. All four resmoke suites selected only `jstests/{dump,files,import,restore}/*.js`, which are now all gone. `test/shell_common/libs/` is shared with `test/legacy42` and stays; `scripts/run-legacy-tests.sh` drives the mongo shell directly and never touches `test/qa-tests/buildscripts`, so the directory was self-contained.
- `scripts/run_qa.sh` and the `run qa-tests` function in `common.yml` - deleted, along with the twelve `qa-tests-*` and `qa-dump-restore-*` task definitions and the `resmoke_use_tls`, `resmoke_args`, and `excludes` expansions that only fed them. Buildvariants select tasks by tag, so no buildvariant task list changes.
- `scripts/setup-credentials.sh` and the `setup credentials` function - deleted. The script's only job was writing `mci.buildlogger` and copying it into `test/qa-tests`, where resmoke hardcodes its location. The `legacy-jstests-*` tasks also called it, but `run-legacy-tests.sh` never reads the file, and with `test/qa-tests` gone the `cp` would have failed under `errexit`. `get buildnumber` goes with it: `builder_num` was only ever read by that script.
- The `attach.results` for `report.json` in `post` - `run_qa.sh` was the only thing that produced that file. The `pkill -f buildlogger.py` and `pkill -f smoke.py` entries in the `killall_mci` default are dropped for the same reason.
- eslint - `precious.toml` only ever pointed it at `test/qa-tests/jstests/**/*.js`, so with those files gone it lints nothing. The command, `.eslintrc.yml`, `.eslintignore`, and the `mise.toml`/`package.json` entries all go. The `.eslintignore` entry for `test/shell_common/libs/replsettest-*.js` was already dead - the include glob never matched those paths.
- The `github_pr_aliases` entry for `rhel88` drops `qa-dump-restore` and `qa-tests`. It also picks up `native-cert-ssl`, which the generator in `evergreen/evergreen.go` already emitted but `common.yml` had not been regenerated for. `TestGitHubPRAliasBlockIsUpToDate` was failing before this commit because of that drift and passes now.

The `mongodump_passthrough` resmoke included at the top of `common.yml` is a
different harness with its own functions and its own `builder_num`, and is
untouched.