### PR TITLE
TOOLS-4100 Use the standard test connection in the mongofiles write-concern tests

### DIFF
--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1173,7 +1174,10 @@ func TestDefaultWriteConcern(t *testing.T) {
 	}
 
 	Convey("with a URI that doesn't specify write concern", t, func() {
-		mf, err := getMongofilesWithArgs("get", "filename", "--uri", "mongodb://localhost:33333")
+		mf, err := getMongofilesWithArgs(
+			"get", "filename",
+			"--uri", uriWithoutWriteConcern(toolOptions.URI.ConnectionString),
+		)
 		So(err, ShouldBeNil)
 		So(
 			mf.ToolOptions.WriteConcern,
@@ -1183,7 +1187,10 @@ func TestDefaultWriteConcern(t *testing.T) {
 	})
 
 	Convey("with no URI and no write concern option", t, func() {
-		mf, err := getMongofilesWithArgs("get", "filename", "--port", "33333")
+		mf, err := getMongofilesWithArgs(
+			"get", "filename",
+			"--host", strings.Join(toolOptions.URI.ConnString.Hosts, ","),
+		)
 		So(err, ShouldBeNil)
 		So(
 			mf.ToolOptions.WriteConcern,
@@ -1191,6 +1198,24 @@ func TestDefaultWriteConcern(t *testing.T) {
 			wcwrapper.Majority(),
 		)
 	})
+}
+
+// TOOLS_TESTING_MONGOD may name a write concern, which would make the subtest above assert on that
+// instead of on the default it is testing for.
+func uriWithoutWriteConcern(uri string) string {
+	parsed, err := url.Parse(uri)
+	So(err, ShouldBeNil)
+
+	query := parsed.Query()
+	for key := range query {
+		switch strings.ToLower(key) {
+		case "w", "journal", "j", "wtimeoutms", "wtimeout", "safe":
+			query.Del(key)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
 }
 
 func runPutIDTestCase(idToTest string, t *testing.T) {

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -53,27 +53,11 @@ func checkOnlyHasDocuments(
 		return err
 	}
 
-	collection := session.Database(testDb).Collection(testCollection)
-	cursor, err := collection.Find(
-		t.Context(),
-		bson.D{},
-		mopt.Find().SetSort(bson.D{{"_id", 1}}),
-	)
+	docs, err := findAllDocumentsByID(t, session)
 	if err != nil {
 		return err
 	}
 
-	var docs []bson.M
-	for cursor.Next(t.Context()) {
-		decoder := bson.NewDecoder(bson.NewDocumentReader(bytes.NewReader(cursor.Current)))
-		decoder.DefaultDocumentM()
-		var doc bson.M
-		if err := decoder.Decode(&doc); err != nil {
-			return err
-		}
-
-		docs = append(docs, doc)
-	}
 	if len(docs) != len(expectedDocuments) {
 		return fmt.Errorf("document count mismatch: expected %#v, got %#v",
 			len(expectedDocuments), len(docs))
@@ -87,6 +71,60 @@ func checkOnlyHasDocuments(
 	}
 
 	return nil
+}
+
+// Some imports leave a document whose contents depend on which of several conflicting writes
+// reached the server first, which mongoimport only orders when --maintainInsertionOrder is set.
+// This passes if the collection matches any one of the acceptable outcomes.
+func checkOnlyHasOneOfDocumentSets(
+	t *testing.T,
+	sessionProvider *db.SessionProvider,
+	acceptableDocumentSets [][]bson.M,
+) error {
+	session, err := sessionProvider.GetSession()
+	if err != nil {
+		return err
+	}
+
+	docs, err := findAllDocumentsByID(t, session)
+	if err != nil {
+		return err
+	}
+
+	for _, expectedDocuments := range acceptableDocumentSets {
+		if reflect.DeepEqual(docs, expectedDocuments) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("document mismatch: expected any of %#v, got %#v",
+		acceptableDocumentSets, docs)
+}
+
+func findAllDocumentsByID(t *testing.T, session *mongo.Client) ([]bson.M, error) {
+	collection := session.Database(testDb).Collection(testCollection)
+	cursor, err := collection.Find(
+		t.Context(),
+		bson.D{},
+		mopt.Find().SetSort(bson.D{{"_id", 1}}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []bson.M
+	for cursor.Next(t.Context()) {
+		decoder := bson.NewDecoder(bson.NewDocumentReader(bytes.NewReader(cursor.Current)))
+		decoder.DefaultDocumentM()
+		var doc bson.M
+		if err := decoder.Decode(&doc); err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, doc)
+	}
+
+	return docs, cursor.Err()
 }
 
 func countDocuments(t *testing.T, sessionProvider *db.SessionProvider) (int, error) {
@@ -720,14 +758,23 @@ func TestImportDocuments(t *testing.T) {
 				So(numProcessed, ShouldEqual, 4)
 				So(numFailed, ShouldEqual, 1)
 
-				expectedDocuments := []bson.M{
-					{"_id": int32(1), "b": int32(2), "c": int32(3)},
-					{"_id": int32(3), "b": 5.4, "c": "string"},
-					{"_id": int32(5), "b": int32(6), "c": int32(6)},
-					{"_id": int32(8), "b": int32(6), "c": int32(6)},
+				// All docs except the one with a duplicate _id should be imported. This import is
+				// unordered (--maintainInsertionOrder is unset), which is what lets it continue
+				// past the duplicate key error, so whichever _id:5 row loses the race is the one
+				// that errors out and either may be the survivor.
+				var acceptableDocumentSets [][]bson.M
+				for _, cOfDuplicate := range []int32{6, 9} {
+					acceptableDocumentSets = append(acceptableDocumentSets, []bson.M{
+						{"_id": int32(1), "b": int32(2), "c": int32(3)},
+						{"_id": int32(3), "b": 5.4, "c": "string"},
+						{"_id": int32(5), "b": int32(6), "c": cOfDuplicate},
+						{"_id": int32(8), "b": int32(6), "c": int32(6)},
+					})
 				}
-				// all docs except the one with duplicate _id - should be imported
-				So(checkOnlyHasDocuments(t, imp.SessionProvider, expectedDocuments), ShouldBeNil)
+				So(
+					checkOnlyHasOneOfDocumentSets(t, imp.SessionProvider, acceptableDocumentSets),
+					ShouldBeNil,
+				)
 			},
 		)
 		Convey("no error should be thrown for CSV import on test data with --drop", func() {
@@ -931,6 +978,10 @@ func TestImportDocuments(t *testing.T) {
 			imp.IngestOptions.Mode = modeUpsert
 			imp.IngestOptions.StopOnError = true
 			imp.upsertFields = []string{"_id"}
+			// The file upserts _id:5 twice and this asserts the later row wins, which is only
+			// guaranteed when the writes are ordered. No document errors here, so ordering them
+			// does not change what this test covers.
+			imp.IngestOptions.MaintainInsertionOrder = true
 			numProcessed, numFailed, err := imp.ImportDocuments()
 			So(err, ShouldBeNil)
 			So(numProcessed, ShouldEqual, 5)


### PR DESCRIPTION
`TestDefaultWriteConcern` hardcoded `localhost:33333` while every other test in the file resolves its target through testutil. This failed with DSC tests, where the port is not always 33333. It also broke the `TOOLS_TESTING_MONGOD` for local testing as well.

This changes the tests to use `toolOptions.URI` instead.