### PR TITLE
TOOLS-4100 Skip profile-level-2 tests under disaggregated storage

### DIFF
--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
@@ -325,6 +327,59 @@ func SkipForAtlasCluster(t *testing.T, reason string) {
 			)
 		}
 	}
+}
+
+// SkipForDisaggregatedStorage will skip the test if the server is running with disaggregated
+// storage (DSC) enabled.
+//
+// Use this for tests that depend on a server feature DSC does not support, naming that feature in
+// the reason. It deliberately keys off DSC rather than off the unsupported operation failing, so an
+// unexpected failure of that same operation elsewhere still fails the test loudly instead of
+// quietly skipping it.
+func SkipForDisaggregatedStorage(t *testing.T, reason string) {
+	session, err := GetBareSession(t)
+	require.NoError(t, err, "getting a session to check for disaggregated storage")
+
+	if isDisaggregatedStorage(t, session) {
+		t.Skipf("Skipping test because the server uses disaggregated storage: %s", reason)
+	}
+}
+
+// A disaggregated server reports this as its WiredTiger storage type, where a normal one reports
+// "file".
+const disaggregatedStorageType = "layered"
+
+// The storage type comes from $collStats rather than from a server parameter because the parameter
+// naming DSC only exists on mongod: through a mongos it looks exactly like a server too old to know
+// it, and the test would run instead of skipping.
+func isDisaggregatedStorage(t *testing.T, session *mongo.Client) bool {
+	opts := mopt.Database().SetReadConcern(readconcern.Majority())
+	coll := session.Database("admin", opts).Collection("system.version")
+
+	pipeline := mongo.Pipeline{
+		bson.D{{"$collStats", bson.D{{"storageStats", bson.D{}}}}},
+		bson.D{{"$project", bson.D{{"type", "$storageStats.wiredTiger.type"}}}},
+	}
+
+	cursor, err := coll.Aggregate(t.Context(), pipeline)
+	require.NoError(t, err, "fetching the cluster storage type")
+
+	var stats []struct {
+		Type string `bson:"type"`
+	}
+	require.NoError(
+		t,
+		cursor.All(t.Context(), &stats),
+		"reading the cluster storage type",
+	)
+
+	for _, stat := range stats {
+		if stat.Type == disaggregatedStorageType {
+			return true
+		}
+	}
+
+	return false
 }
 
 // WriteTempFile writes the contents of r to a tempfile, then hands you back the (closed) file.

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -1323,6 +1323,10 @@ func TestMongoDumpTOOLS2174(t *testing.T) {
 // Test dumping a collection while respecting no index scan for wired tiger.
 func TestMongoDumpTOOLS1952(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it reads system.profile, and DSC does not support profile level 2",
+	)
 	log.SetWriter(io.Discard)
 
 	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
@@ -1510,6 +1514,10 @@ func TestMongoDumpOrderedQuery(t *testing.T) {
 
 func TestMongoDumpViewsAsCollections(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it reads system.profile, and DSC does not support profile level 2",
+	)
 	log.SetWriter(io.Discard)
 
 	Convey("With a MongoDump instance", t, func() {

--- a/mongoexport/mongoexport_test.go
+++ b/mongoexport/mongoexport_test.go
@@ -154,6 +154,10 @@ func TestMongoExportTOOLS2174(t *testing.T) {
 // this is not a wired tiger collection.
 func TestMongoExportTOOLS1952(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it reads system.profile, and DSC does not support profile level 2",
+	)
 	log.SetWriter(io.Discard)
 
 	sessionProvider, _, err := testutil.GetBareSessionProvider(t)


### PR DESCRIPTION
Three integration tests enable database profiling at level 2 and then read `system.profile` to assert the query the tool actually issued. This profile level isn't supported with DSC clusters, so we skip them when testing with DSC.

