### PR TITLE
TOOLS-4351 Close session providers created by testutil test helpers

### DIFF
--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -26,10 +26,13 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
-// GetBareSession returns an mgo.Session from the environment or
-// from a default host and port.
-func GetBareSession() (*mongo.Client, error) {
-	sessionProvider, _, err := GetBareSessionProvider()
+// GetBareSession returns a client from the environment or from a default host
+// and port. The underlying session provider is closed when the test ends, so
+// the returned client must not be used after that.
+func GetBareSession(t *testing.T) (*mongo.Client, error) {
+	t.Helper()
+
+	sessionProvider, _, err := GetBareSessionProvider(t)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +44,17 @@ func GetBareSession() (*mongo.Client, error) {
 }
 
 // GetBareSessionProvider returns a session provider from the environment or
-// from a default host and port.
-func GetBareSessionProvider() (*db.SessionProvider, *options.ToolOptions, error) {
+// from a default host and port. The provider is closed when the test ends, so
+// the caller must not close it, and must not use it after that.
+//
+// An unclosed provider leaves the driver's topology-monitoring goroutines
+// running for the remainder of the test binary's run, which is why this takes a
+// *testing.T rather than leaving the close to each caller.
+func GetBareSessionProvider(
+	t *testing.T,
+) (*db.SessionProvider, *options.ToolOptions, error) {
+	t.Helper()
+
 	toolOptions, err := GetToolOptions()
 	if err != nil {
 		return nil, nil, fmt.Errorf(
@@ -55,6 +67,7 @@ func GetBareSessionProvider() (*db.SessionProvider, *options.ToolOptions, error)
 	if err != nil {
 		return nil, nil, err
 	}
+	t.Cleanup(sessionProvider.Close)
 
 	return sessionProvider, toolOptions, nil
 }
@@ -183,7 +196,7 @@ func CompareFCV(x, y string) (int, error) {
 }
 
 func SkipIfFCVLessThan(t *testing.T, versionStr string, reason string) {
-	session, err := GetBareSession()
+	session, err := GetBareSession(t)
 	require.NoError(t, err)
 
 	fcv := GetFCV(session)
@@ -204,8 +217,9 @@ func SkipIfFCVLessThan(t *testing.T, versionStr string, reason string) {
 // only permitted on a standalone: a replica set rejects direct oplog writes and
 // mongos rejects writes to the local database.
 func SkipUnlessStandalone(t *testing.T) {
-	sessionProvider, _, err := GetBareSessionProvider()
+	sessionProvider, _, err := GetBareSessionProvider(t)
 	require.NoError(t, err)
+
 	nodeType, err := sessionProvider.GetNodeType()
 	require.NoError(t, err)
 	if nodeType != db.Standalone {

--- a/common/testutil/timeseries.go
+++ b/common/testutil/timeseries.go
@@ -12,7 +12,7 @@ import (
 // This sets up a timeseries collection and inserts 1000 logical documents into 10 bucket documents.
 // The timeField is 'ts', the metaField  is 'my_meta', and there's an index on 'my_meta.device'.
 func SetUpTimeseries(t *testing.T, dbName string, colName string) {
-	sessionProvider, _, err := GetBareSessionProvider()
+	sessionProvider, _, err := GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 
 	timeseriesOptions := bson.D{

--- a/integration/dumprestore/oplog_replset_test.go
+++ b/integration/dumprestore/oplog_replset_test.go
@@ -22,7 +22,7 @@ func (s *DumpRestoreSuite) TestOplogReplayFromLocalOplogRS() {
 
 	const collName = "coll"
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to the server")
 
 	testDB := session.Database(uniqueDBName())
@@ -109,7 +109,7 @@ func (s *DumpRestoreSuite) TestOplogReplayFromLocalOplogRS() {
 // latestOplogTimestamp returns the ts of the newest entry in local.oplog.rs,
 // which is the checkpoint the dump query filters on.
 func (s *DumpRestoreSuite) latestOplogTimestamp() bson.Timestamp {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to the server")
 
 	var entry struct {

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,7 +36,7 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 	s.T().Logf("start %#q", s.T().Name())
 	ctx := s.Context()
 
-	provider, _, err := testutil.GetBareSessionProvider()
+	provider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "should get session provider")
 
 	s.T().Logf("getting session")
@@ -74,7 +75,7 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 	eg.Go(func() error {
 		defer writer.Close()
 
-		dump, err := getArchiveMongoDump(writer)
+		dump, err := getArchiveMongoDump(s.T(), writer)
 		if err != nil {
 			return errors.Wrap(err, "create mongodump")
 		}
@@ -89,7 +90,7 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 	eg.Go(func() error {
 		defer reader.Close()
 
-		restore, err := getArchiveMongoRestore(reader)
+		restore, err := getArchiveMongoRestore(s.T(), reader)
 		if err != nil {
 			return errors.Wrap(err, "create mongorestore")
 		}
@@ -118,7 +119,7 @@ func (s *DumpRestoreSuite) TestPipedDumpRestore() {
 }
 
 func (s *DumpRestoreSuite) TestDumpAndRestoreConfigDB() {
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	s.Run(
@@ -151,7 +152,7 @@ var userDefinedConfigCollectionNames = []string{
 }
 
 func (s *DumpRestoreSuite) testDumpAndRestoreConfigDBIncludesAllCollections() {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	configDB := session.Database("config")
@@ -185,7 +186,7 @@ func (s *DumpRestoreSuite) testDumpAndRestoreConfigDBIncludesAllCollections() {
 }
 
 func (s *DumpRestoreSuite) testDumpAndRestoreAllDBsIgnoresSomeConfigCollections() {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	// Drop any databases that other tests may have left behind with validators
@@ -250,8 +251,8 @@ func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, e
 	return restore, nil
 }
 
-func getArchiveMongoDump(output io.WriteCloser) (*mongodump.MongoDump, error) {
-	provider, toolOpts, err := testutil.GetBareSessionProvider()
+func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoDump, error) {
+	provider, toolOpts, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for dump")
 	}
@@ -275,8 +276,8 @@ func getArchiveMongoDump(output io.WriteCloser) (*mongodump.MongoDump, error) {
 	return dump, nil
 }
 
-func getArchiveMongoRestore(input io.ReadCloser) (*mongorestore.MongoRestore, error) {
-	_, toolOpts, err := testutil.GetBareSessionProvider()
+func getArchiveMongoRestore(t *testing.T, input io.ReadCloser) (*mongorestore.MongoRestore, error) {
+	_, toolOpts, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for restore")
 	}
@@ -319,7 +320,7 @@ func listIndexes[T any](ctx context.Context, coll *mongo.Collection, target *T) 
 func (s *DumpRestoreSuite) TestRestoreZeroTimestamp() {
 	ctx := s.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()
@@ -381,7 +382,7 @@ func (s *DumpRestoreSuite) TestRestoreZeroTimestamp() {
 func (s *DumpRestoreSuite) TestRestoreZeroTimestamp_NonClobber() {
 	ctx := s.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()
@@ -495,7 +496,7 @@ func (s *DumpRestoreSuite) TestRestoreMultipleIDIndexes() {
 					s.Run(
 						fmt.Sprintf("attempt %d", attemptNum),
 						func() {
-							session, err := testutil.GetBareSession()
+							session, err := testutil.GetBareSession(s.T())
 							s.Require().NoError(err, "should connect to server")
 
 							ctx := s.Context()
@@ -565,7 +566,7 @@ func (s *DumpRestoreSuite) TestRestoreMultipleIDIndexes() {
 	}
 }
 func (s *DumpRestoreSuite) TestRestoreUsersOrRoles() {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "no server available")
 
 	s.Run("drops tempusers and temproles", func() {
@@ -649,7 +650,7 @@ func (s *DumpRestoreSuite) TestRestoreUsersOrRoles() {
 func (s *DumpRestoreSuite) TestUnversionedIndexes() {
 	ctx := s.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "no cluster available")
 
 	defer sessionProvider.Close()
@@ -752,7 +753,7 @@ func (s *DumpRestoreSuite) TestUnversionedIndexes() {
 func (s *DumpRestoreSuite) TestRestoreTimeseriesCollectionsWithMixedSchema() {
 	ctx := s.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "no cluster available")
 
 	defer sessionProvider.Close()
@@ -815,7 +816,7 @@ func (s *DumpRestoreSuite) TestRestoreTimeseriesCollectionsWithMixedSchema() {
 }
 
 func (s *DumpRestoreSuite) TestIgnoreMongoDBInternal() {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err)
 
 	if ok, _ := sessionProvider.IsReplicaSet(); !ok {
@@ -827,7 +828,7 @@ func (s *DumpRestoreSuite) TestIgnoreMongoDBInternal() {
 	testName := s.DBName()
 	dbName := s.DBName(util.MongoDBInternalDBPrefix)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "must connect to server")
 
 	internalColl := client.Database(dbName).Collection(testName)
@@ -902,7 +903,7 @@ func (s *DumpRestoreSuite) TestIgnoreMongoDBInternal() {
 func (s *DumpRestoreSuite) TestFinalNewlinesInNamespaces() {
 	ctx := s.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to server")
 
 	allNames := []string{

--- a/integration/dumprestore/suite_test.go
+++ b/integration/dumprestore/suite_test.go
@@ -169,7 +169,7 @@ func (s *DumpRestoreSuite) timeseriesBucketsMayHaveMixedSchemaData(
 }
 
 func (s *DumpRestoreSuite) setupTimeseriesWithMixedSchema(dbName string, collName string) {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "get session provider")
 
 	serverVersion, err := sessionProvider.ServerVersionArray()
@@ -221,7 +221,7 @@ func (s *DumpRestoreSuite) setupTimeseriesWithMixedSchema(dbName string, collNam
 // because the suite's DBName truncates to 63 bytes, which leaves too few
 // distinguishing characters for these deeply nested subtests.
 func (s *DumpRestoreSuite) database(name string) *mongo.Database {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(s.T())
 	s.Require().NoError(err, "can connect to the server")
 
 	return session.Database("dumprestore_" + name)

--- a/integration/sharedsuite/suite.go
+++ b/integration/sharedsuite/suite.go
@@ -20,9 +20,10 @@ func (s *IntegrationSuite) Context() context.Context {
 	return s.T().Context()
 }
 
-// Client creates a new MongoDB client. The caller is responsible for cleanup.
+// Client creates a new MongoDB client. It is disconnected when the test ends,
+// so the caller must not use it after that.
 func (s *IntegrationSuite) Client() *mongo.Client {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "no cluster available")
 
 	client, err := sessionProvider.GetSession()
@@ -76,7 +77,7 @@ func (s *IntegrationSuite) RequireFCVAtLeast(wantFCV string) {
 }
 
 func (s *IntegrationSuite) ServerVersion() db.Version {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(s.T())
 	s.Require().NoError(err, "no cluster available")
 
 	serverVersion, err := sessionProvider.ServerVersionArray()

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -189,7 +189,7 @@ func readBSONIntoDatabase(t *testing.T, dir, restoreDBName string) error {
 		return fmt.Errorf("error finding '%v' on local FS", dir)
 	}
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func readBSONIntoDatabase(t *testing.T, dir, restoreDBName string) error {
 }
 
 func setUpMongoDumpTestData(t *testing.T) error {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func setUpMongoDumpTestData(t *testing.T) error {
 }
 
 func setupTimeseriesWithMixedSchema(t *testing.T, dbName string, collName string) {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 
 	serverVersion, err := sessionProvider.ServerVersionArray()
@@ -345,8 +345,8 @@ func timeseriesCollName(version db.Version, base string) string {
 	return common.TimeseriesBucketPrefix + base
 }
 
-func setUpDBView(dbName string, colName string) error {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+func setUpDBView(t *testing.T, dbName string, colName string) error {
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return err
 	}
@@ -365,8 +365,8 @@ func setUpDBView(dbName string, colName string) error {
 	return nil
 }
 
-func turnOnProfiling(dbName string) error {
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+func turnOnProfiling(t *testing.T, dbName string) error {
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func countSnapshotCmds(
 // function returns.  Any errors are passed back on the errs channel.
 func backgroundInsert(t *testing.T, ready, done chan struct{}, errs chan error) {
 	defer close(errs)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		errs <- err
 		close(ready)
@@ -451,7 +451,7 @@ func backgroundInsert(t *testing.T, ready, done chan struct{}, errs chan error) 
 }
 
 func tearDownMongoDumpTestData(t *testing.T) error {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func tearDownMongoDumpTestData(t *testing.T) error {
 }
 
 func dropDB(t *testing.T, dbName string) error {
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -547,7 +547,7 @@ func testDumpOneCollection(t *testing.T, md *MongoDump, dumpDir string) {
 	So(err, ShouldBeNil)
 	So(fileDirExists(dumpDBDir), ShouldBeTrue)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	So(err, ShouldBeNil)
 
 	countColls, err := countNonIndexBSONFiles(dumpDBDir)
@@ -628,7 +628,7 @@ func TestMongoDumpConnectedToAtlasProxy(t *testing.T) {
 
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	defer sessionProvider.Close()
 
@@ -790,7 +790,7 @@ func TestMongoDumpBSON(t *testing.T) {
 		Convey(
 			"testing that using MongoDump WITH a query dumps a subset of documents in a database and/or collection",
 			func() {
-				session, err := testutil.GetBareSession()
+				session, err := testutil.GetBareSession(t)
 				So(err, ShouldBeNil)
 				md, err := simpleMongoDumpInstance()
 				So(err, ShouldBeNil)
@@ -858,7 +858,7 @@ func TestMongoDumpBSONLongCollectionName(t *testing.T) {
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -971,7 +971,7 @@ func TestDumpPreludeMetadataJson(t *testing.T) {
 		err = setUpMongoDumpTestData(t)
 		So(err, ShouldBeNil)
 
-		sessionProvider, _, _ := testutil.GetBareSessionProvider()
+		sessionProvider, _, _ := testutil.GetBareSessionProvider(t)
 		So(sessionProvider, ShouldNotBeNil)
 		serverVersion, err := sessionProvider.ServerVersion()
 		So(err, ShouldBeNil)
@@ -1072,7 +1072,7 @@ func TestMongoDumpMetaData(t *testing.T) {
 	log.SetWriter(io.Discard)
 
 	Convey("With a MongoDump instance", t, func() {
-		session, err := testutil.GetBareSession()
+		session, err := testutil.GetBareSession(t)
 		So(session, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 
@@ -1172,7 +1172,7 @@ func TestMongoDumpOplog(t *testing.T) {
 	t.Skip()
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1268,7 +1268,7 @@ func TestMongoDumpTOOLS2174(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1325,7 +1325,7 @@ func TestMongoDumpTOOLS1952(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1361,7 +1361,7 @@ func TestMongoDumpTOOLS1952(t *testing.T) {
 	}
 
 	// Turn on profiling.
-	if err = turnOnProfiling(dbName); err != nil {
+	if err = turnOnProfiling(t, dbName); err != nil {
 		t.Fatalf("Failed to turn on profiling: %v", err)
 	}
 
@@ -1392,7 +1392,7 @@ func TestMongoDumpTOOLS2498(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1518,10 +1518,10 @@ func TestMongoDumpViewsAsCollections(t *testing.T) {
 
 		colName := "dump_view_as_collection"
 		dbName := testDB
-		err = setUpDBView(dbName, colName)
+		err = setUpDBView(t, dbName, colName)
 		So(err, ShouldBeNil)
 
-		err = turnOnProfiling(testDB)
+		err = turnOnProfiling(t, testDB)
 		So(err, ShouldBeNil)
 
 		Convey("testing that the dumped directory contains information about metadata", func() {
@@ -1558,7 +1558,7 @@ func TestMongoDumpViewsAsCollections(t *testing.T) {
 			})
 
 			Convey("testing dumping a view, we should not hint index", func() {
-				session, err := testutil.GetBareSession()
+				session, err := testutil.GetBareSession(t)
 				So(err, ShouldBeNil)
 
 				dbStruct := session.Database(dbName)
@@ -1593,7 +1593,7 @@ func TestMongoDumpViews(t *testing.T) {
 
 		colName := "dump_views"
 		dbName := testDB
-		err = setUpDBView(dbName, colName)
+		err = setUpDBView(t, dbName, colName)
 		So(err, ShouldBeNil)
 
 		Convey("testing that the dumped directory contains information about metadata", func() {
@@ -1628,7 +1628,7 @@ func TestMongoDumpViews(t *testing.T) {
 			})
 
 			Convey("testing dumping a view, we should not hint index", func() {
-				session, err := testutil.GetBareSession()
+				session, err := testutil.GetBareSession(t)
 				So(err, ShouldBeNil)
 
 				dbStruct := session.Database(dbName)
@@ -1743,7 +1743,7 @@ func TestCount(t *testing.T) {
 		err := setUpMongoDumpTestData(t)
 		So(err, ShouldBeNil)
 
-		session, err := testutil.GetBareSession()
+		session, err := testutil.GetBareSession(t)
 		So(err, ShouldBeNil)
 
 		collection := session.Database(testDB).Collection(testCollectionNames[0])
@@ -1787,7 +1787,7 @@ func TestCount(t *testing.T) {
 func TestTimeseriesCollections(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "get session")
 
 	fcv := testutil.GetFCV(session)
@@ -1795,7 +1795,7 @@ func TestTimeseriesCollections(t *testing.T) {
 		t.Skipf("Requires server with FCV 5.0 or later; found %v", fcv)
 	}
 
-	sp, _, err := testutil.GetBareSessionProvider()
+	sp, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 
 	serverVersion, err := sp.ServerVersionArray()
@@ -2180,7 +2180,7 @@ func TestTimeseriesCollections(t *testing.T) {
 func TestDumpTimeseriesCollectionsWithMixedSchema(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "get session")
 
 	fcv := testutil.GetFCV(session)
@@ -2188,7 +2188,7 @@ func TestDumpTimeseriesCollectionsWithMixedSchema(t *testing.T) {
 		t.Skipf("Requires server with FCV 5.0 or later; found %v", fcv)
 	}
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 
 	serverVersion, err := sessionProvider.ServerVersionArray()
@@ -2268,7 +2268,7 @@ func TestFailDuringResharding(t *testing.T) {
 		"this test requires permissions that may not be available for an Atlas cluster",
 	)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("Failed to get session provider: %v", err)
 	}
@@ -2440,7 +2440,7 @@ func TestOptionsOrderIsPreserved(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 
 	collName := "students"
@@ -2540,7 +2540,7 @@ func TestBrokenPipe(t *testing.T) {
 		collName = "docs"
 	)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	client, err := sessionProvider.GetSession()
 	require.NoError(t, err)
@@ -2573,7 +2573,7 @@ func TestMongoDumpMaxEstimatedScanBytes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 	defer sessionProvider.Close()
 
@@ -2698,10 +2698,10 @@ func TestTimeseriesDumpConcurrentWithSetFCV(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "get session")
 
-	sp, _, err := testutil.GetBareSessionProvider()
+	sp, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "get session provider")
 
 	serverVersion, err := sp.ServerVersionArray()

--- a/mongodump/oplog_dump_test.go
+++ b/mongodump/oplog_dump_test.go
@@ -73,7 +73,7 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 
 	log.SetWriter(io.Discard)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
 	require.NoError(t, fp.Reached(context.TODO()))
-	require.NoError(t, vectoredInsert(ctx))
+	require.NoError(t, vectoredInsert(t, ctx))
 	fp.Signal()
 
 	require.NoError(t, <-dumpErrCh)
@@ -152,8 +152,8 @@ func TestOplogDumpVectoredInsertsOplog(t *testing.T) {
 	)
 }
 
-func vectoredInsert(ctx context.Context) error {
-	client, err := testutil.GetBareSession()
+func vectoredInsert(t *testing.T, ctx context.Context) error {
+	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 	fp, ok := failpoint.DefaultManager.Get(failpoint.PauseUntilResumed)
 	require.True(t, ok, "PauseUntilResumed failpoint should be enabled")
 	require.NoError(t, fp.Reached(context.TODO()))
-	require.NoError(t, createIndexesAndCollModIndexUniqueness(ctx))
+	require.NoError(t, createIndexesAndCollModIndexUniqueness(t, ctx))
 	fp.Signal()
 
 	require.NoError(t, <-dumpErrCh)
@@ -284,8 +284,8 @@ func TestOplogDumpCollModIndexUniqueness(t *testing.T) {
 	require.Equal(t, 4, forceNonUniqueCount)
 }
 
-func createIndexesAndCollModIndexUniqueness(ctx context.Context) error {
-	client, err := testutil.GetBareSession()
+func createIndexesAndCollModIndexUniqueness(t *testing.T, ctx context.Context) error {
+	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		return err
 	}
@@ -364,7 +364,7 @@ func TestOplogDumpBypassDocumentValidation(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestOplogDumpBypassDocumentValidation(t *testing.T) {
 }
 
 func createCollectionWithValidatorAndInsertBypassValidation(ctx context.Context, t *testing.T) {
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 
 	testCollName := testCollectionNames[0]
@@ -504,7 +504,7 @@ func TestOplogDumpCollModTTL(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 
 	testCollName := testCollectionNames[0]
@@ -596,7 +596,7 @@ func TestOplogDumpCollModTTL(t *testing.T) {
 }
 
 func convertIndexToTTL(ctx context.Context, t *testing.T) {
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 
 	testCollName := testCollectionNames[0]

--- a/mongoexport/mongoexport.go
+++ b/mongoexport/mongoexport.go
@@ -124,6 +124,7 @@ func New(opts Options) (*MongoExport, error) {
 
 	exporter.version, err = provider.ServerVersionArray()
 	if err != nil {
+		provider.Close()
 		return nil, util.SetupError{
 			Err:     err,
 			Message: "failed to get server version",

--- a/mongoexport/mongoexport_test.go
+++ b/mongoexport/mongoexport_test.go
@@ -101,7 +101,7 @@ func TestMongoExportTOOLS2174(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "no cluster available")
 
 	serverVersion, err := sessionProvider.ServerVersionArray()
@@ -156,7 +156,7 @@ func TestMongoExportTOOLS1952(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "no cluster available")
 
 	session, err := sessionProvider.GetSession()
@@ -242,7 +242,7 @@ func TestBadOptions(t *testing.T) {
 	dbName := "test"
 	collName := "mongoexport-bad-options"
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestBrokenPipe(t *testing.T) {
 		collName = "docs"
 	)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	client, err := sessionProvider.GetSession()
 	require.NoError(t, err)
@@ -706,7 +706,7 @@ func TestMongoExportMaxEstimatedScanBytes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "no cluster available")
 	defer sessionProvider.Close()
 

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -1456,7 +1456,7 @@ func TestImportMIOSOE(t *testing.T) {
 		t.Fatalf("Could not generate test data: %v", err)
 	}
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available?? (%v)", err)
 	}

--- a/mongorestore/dumprestore_auth_test.go
+++ b/mongorestore/dumprestore_auth_test.go
@@ -39,9 +39,9 @@ func TestDumpRestoreEnforcesAuthRoles(t *testing.T) {
 		restoreFooUser     = "enforces_restfoo"
 	)
 
-	adminClient, err := testutil.GetBareSession()
+	adminClient, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	serverVersion, err := sessionProvider.ServerVersionArray()
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func dumpRestorePreservesAdminUsersAndRoles(t *testing.T, backupRole, restoreRol
 		customRole2 = "preserves_custom2" // used in drop_restore_overrides_mutations subtest
 	)
 
-	adminClient, err := testutil.GetBareSession()
+	adminClient, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 
 	adminDB := adminClient.Database("admin")
@@ -460,7 +460,7 @@ func dumpRestoreSingleDBWithUsersAndRoles(t *testing.T) {
 		barUser2Name       = "singledb_baruser2"  // used in admin_db subtest
 	)
 
-	adminClient, err := testutil.GetBareSession()
+	adminClient, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 
 	adminDB := adminClient.Database("admin")
@@ -924,9 +924,9 @@ func TestRestoreWithDBUserPreservesIndexes(t *testing.T) {
 		dbUser = "restorewithauth_user"
 	)
 
-	adminClient, err := testutil.GetBareSession()
+	adminClient, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	serverVersion, err := sessionProvider.ServerVersionArray()
 	require.NoError(t, err)

--- a/mongorestore/invalid_input_test.go
+++ b/mongorestore/invalid_input_test.go
@@ -367,7 +367,7 @@ func writeNonDumpFile(t *testing.T) string {
 // finishes.
 func testClientWithDroppedDB(t *testing.T, dbName string) *mongo.Client {
 	t.Helper()
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "connecting to the test server")
 	t.Cleanup(func() { _ = client.Database(dbName).Drop(t.Context()) })
 	return client

--- a/mongorestore/metadata_test.go
+++ b/mongorestore/metadata_test.go
@@ -26,12 +26,12 @@ const ExistsDB = "restore_collection_exists"
 
 func TestMongoRestoreConnectedToAtlasProxy(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	defer sessionProvider.Close()
 	restore := &MongoRestore{
@@ -67,13 +67,13 @@ func TestMongoRestoreConnectedToAtlasProxy(t *testing.T) {
 
 func TestCollectionExists(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
 
 	Convey("With a test mongorestore", t, func() {
-		sessionProvider, _, err := testutil.GetBareSessionProvider()
+		sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 		So(err, ShouldBeNil)
 		defer sessionProvider.Close()
 

--- a/mongorestore/mongorestore_archive_test.go
+++ b/mongorestore/mongorestore_archive_test.go
@@ -46,7 +46,7 @@ var (
 
 func TestMongorestoreShortArchive(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -101,7 +101,7 @@ func TestMongorestoreShortArchive(t *testing.T) {
 
 func TestMongorestoreArchiveWithOplog(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -125,7 +125,7 @@ func TestMongorestoreArchiveWithOplog(t *testing.T) {
 
 func TestMongorestoreBadFormatArchive(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -163,7 +163,7 @@ func TestReadDumpServerVersionFromArchive(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
 	withArchiveMongodump(t, func(archivePath string) {
-		sessionProvider, _, err := testutil.GetBareSessionProvider()
+		sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 		require.NoError(err)
 		args := []string{
 			NumParallelCollectionsOption, "1",
@@ -197,7 +197,7 @@ func TestMongorestoreArchiveAdminNamespaces(t *testing.T) {
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	fcv := testutil.GetFCV(session)
@@ -218,7 +218,7 @@ func TestMongorestoreArchiveAdminNamespaces(t *testing.T) {
 func testRestoreAdminNamespaces(t *testing.T) {
 	require := require.New(t)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()
@@ -273,7 +273,7 @@ func testRestoreAdminNamespaces(t *testing.T) {
 func testRestoreAdminNamespacesAsAtlasProxy(t *testing.T) {
 	require := require.New(t)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()
@@ -423,8 +423,8 @@ func runArchiveMongodump(t *testing.T, file string, dumpArgs ...string) string {
 }
 
 // GetArchiveMongoDump returns a MongoDump that’s ready to call Dump().
-func GetArchiveMongoDump(output io.WriteCloser) (*mongodump.MongoDump, error) {
-	provider, toolOpts, err := testutil.GetBareSessionProvider()
+func GetArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoDump, error) {
+	provider, toolOpts, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for dump")
 	}
@@ -448,8 +448,8 @@ func GetArchiveMongoDump(output io.WriteCloser) (*mongodump.MongoDump, error) {
 	return dump, nil
 }
 
-func GetArchiveMongoRestore(input io.ReadCloser) (*MongoRestore, error) {
-	_, toolOpts, err := testutil.GetBareSessionProvider()
+func GetArchiveMongoRestore(t *testing.T, input io.ReadCloser) (*MongoRestore, error) {
+	_, toolOpts, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for dump")
 	}

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -141,7 +141,7 @@ func TestMongorestore(t *testing.T) {
 		testtype.ShardedIntegrationTestType,
 	)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -284,7 +284,7 @@ func TestMongoRestoreSpecialCharactersCollectionNames(t *testing.T) {
 		testtype.ShardedIntegrationTestType,
 	)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -392,7 +392,7 @@ func TestMongorestoreLongCollectionName(t *testing.T) {
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -508,7 +508,7 @@ func TestMongorestoreLongCollectionName(t *testing.T) {
 
 func TestMongorestorePreserveUUID(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -667,7 +667,7 @@ func TestMongorestoreMIOSOE(t *testing.T) {
 		t.Fatalf("Couldn't generate test data %v", err)
 	}
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -743,7 +743,7 @@ func TestMongorestoreMIOSOE(t *testing.T) {
 
 func TestDeprecatedIndexOptions(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -819,7 +819,7 @@ func TestDeprecatedIndexOptions(t *testing.T) {
 func TestFixDuplicatedLegacyIndexes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -913,7 +913,7 @@ func TestFixDuplicatedLegacyIndexes(t *testing.T) {
 func TestDeprecatedIndexOptionsOn44FCV(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1052,7 +1052,7 @@ func TestKnownCollections(t *testing.T) {
 		testtype.IntegrationTestType,
 		testtype.ShardedIntegrationTestType,
 	)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1097,7 +1097,7 @@ func TestKnownCollections(t *testing.T) {
 
 func TestReadPreludeMetadata(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1196,7 +1196,7 @@ func TestReadPreludeMetadata(t *testing.T) {
 
 func TestFixHashedIndexes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1299,7 +1299,7 @@ func TestAutoIndexIdLocalDB(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	ctx := t.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1315,7 +1315,7 @@ func TestAutoIndexIdLocalDB(t *testing.T) {
 		)
 	}
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1370,7 +1370,7 @@ func TestAutoIndexIdNonLocalDB(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	ctx := t.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1386,7 +1386,7 @@ func TestAutoIndexIdNonLocalDB(t *testing.T) {
 		)
 	}
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -1500,7 +1500,7 @@ func TestSkipSystemCollections(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	ctx := t.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1581,7 +1581,7 @@ func TestSkipStartAndAbortIndexBuild(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	ctx := t.Context()
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1649,7 +1649,7 @@ func TestCommitIndexBuild(t *testing.T) {
 	ctx := t.Context()
 	testDB := "commit_index"
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1739,7 +1739,7 @@ func TestCreateIndexes(t *testing.T) {
 	ctx := t.Context()
 	testDB := "create_indexes"
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1824,7 +1824,7 @@ func TestGeoHaystackIndexes(t *testing.T) {
 	ctx := t.Context()
 	dbName := "geohaystack_test"
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No cluster available: %v", err)
 	}
@@ -1888,7 +1888,7 @@ func TestRestoreTimeseriesCollections(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	dbName := "timeseries_test"
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err, "no cluster available")
 
 	defer sessionProvider.Close()
@@ -2403,7 +2403,7 @@ func TestRestoreClusteredIndex(t *testing.T) {
 
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	fcv := testutil.GetFCV(session)
@@ -2433,7 +2433,7 @@ func TestRestoreClusteredIndex(t *testing.T) {
 func testRestoreClusteredIndexFromDump(t *testing.T, indexName string) {
 	require := require.New(t)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()
@@ -2467,7 +2467,7 @@ func testRestoreClusteredIndexFromDump(t *testing.T, indexName string) {
 func testRestoreClusteredIndexFromOplog(t *testing.T, indexName string) {
 	require := require.New(t)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(err, "can connect to server")
 
 	dbName := uniqueDBName()

--- a/mongorestore/mongorestore_txn_test.go
+++ b/mongorestore/mongorestore_txn_test.go
@@ -38,7 +38,7 @@ type txnTestDataCase struct {
 
 func TestMongorestoreTxns(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}

--- a/mongorestore/oplog_edges_test.go
+++ b/mongorestore/oplog_edges_test.go
@@ -26,7 +26,7 @@ import (
 func TestOplogReplayConflict(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 	coll := client.Database("test").Collection("data")
 	require.NoError(t, coll.Drop(context.Background()), "dropping target collection")
@@ -60,7 +60,7 @@ func TestOplogReplayPriorityOplog(t *testing.T) {
 	// mongos rejects writes to the local database.
 	testutil.SkipUnlessStandalone(t)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 	testDB := client.Database("test")
 	dataColl := testDB.Collection("data")
@@ -112,7 +112,7 @@ func TestOplogReplayPriorityOplog(t *testing.T) {
 func TestOplogReplayNoop(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 	coll := client.Database("test").Collection("data")
 	require.NoError(t, coll.Drop(context.Background()), "dropping target collection")
@@ -150,12 +150,12 @@ func TestOplogReplayNoop(t *testing.T) {
 func TestOplogReplayPreservesComplexIDOrder(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	require.NoError(t, err)
 	serverVersion, err := sessionProvider.ServerVersionArray()
 	require.NoError(t, err)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 	testDB := client.Database("test")
 	coll := testDB.Collection("foobar")
@@ -253,7 +253,7 @@ func writeOplogUpdate(t *testing.T, path, ns string, id bson.D) {
 func TestOplogReplaySizeSafety(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	client, err := testutil.GetBareSession()
+	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)
 	testDB := client.Database("test")
 	coll := testDB.Collection("op")

--- a/mongorestore/oplog_test.go
+++ b/mongorestore/oplog_test.go
@@ -135,7 +135,7 @@ func TestValidOplogLimitChecking(t *testing.T) {
 func TestOplogRestore(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -181,7 +181,7 @@ func TestOplogRestore(t *testing.T) {
 func TestOplogRestoreWithDuplicateIndexKeys(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -217,14 +217,14 @@ func TestOplogRestoreWithDuplicateIndexKeys(t *testing.T) {
 func TestOplogRestoreUpdatesIndexCatalog(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
 	//nolint:errcheck
 	defer session.Disconnect(t.Context())
 
-	sessionProvider, _, err := testutil.GetBareSessionProvider()
+	sessionProvider, _, err := testutil.GetBareSessionProvider(t)
 	if err != nil {
 		t.Fatalf("No session provider available")
 	}
@@ -496,7 +496,7 @@ func TestOplogRestoreUpdatesIndexCatalog(t *testing.T) {
 func TestOplogRestoreMaxDocumentSize(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -604,7 +604,7 @@ func generateOplogWith16MiBDocument() ([]byte, error) {
 
 func TestOplogRestoreTools2002(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
-	_, err := testutil.GetBareSession()
+	_, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("No server available")
 	}
@@ -706,7 +706,7 @@ func testOplogRestoreVectoredInsert(t *testing.T, linked bool) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -786,7 +786,7 @@ func TestOplogRestoreCollModIndexUniqueness(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -850,7 +850,7 @@ func TestOplogRestoreBypassDocumentValidation(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -901,7 +901,7 @@ func TestOplogRestoreCollModTTLIndex(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	if err != nil {
 		t.Fatalf("Failed to get session: %v", err)
 	}
@@ -957,7 +957,7 @@ func TestOplogRestoreViewlessTimeseriesConversion(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "should be able to get a session")
 	//nolint:errcheck
 	defer session.Disconnect(ctx)
@@ -1053,7 +1053,7 @@ func TestOplogRestoreDropIdent(t *testing.T) {
 
 	ctx := t.Context()
 
-	session, err := testutil.GetBareSession()
+	session, err := testutil.GetBareSession(t)
 	require.NoError(t, err, "should be able to get a session")
 	//nolint:errcheck
 	defer session.Disconnect(ctx)


### PR DESCRIPTION
A `db.SessionProvider` that is never closed can leave the driver's background topology-monitoring goroutines running. In tests those goroutines survive for the rest of the test binary's run.

In most cases, these clients were created via`testutil.GetBareSession` and `testutil.GetBareSessionProvider`. This PR changes these functions to take a `*testing.T` and register a cleanup func that closes the session.

It also fixes a spot in mongoexport itself that leaves a connection open when it encounters an error.