### PR TITLE
TOOLS-4351 Close session providers created by mongofiles and mongoimport test helpers

### DIFF
--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -110,23 +110,32 @@ func tearDownGridFSTestData(t *testing.T) error {
 	return nil
 }
 
-func simpleMongoFilesInstanceWithID(command, ID string) (*MongoFiles, error) {
-	return simpleMongoFilesInstanceWithFilenameAndID(command, "", ID)
+func simpleMongoFilesInstanceWithID(t *testing.T, command, ID string) (*MongoFiles, error) {
+	t.Helper()
+	return simpleMongoFilesInstanceWithFilenameAndID(t, command, "", ID)
 }
 
-func simpleMongoFilesInstanceWithFilename(command, fname string) (*MongoFiles, error) {
-	return simpleMongoFilesInstanceWithFilenameAndID(command, fname, "")
+func simpleMongoFilesInstanceWithFilename(
+	t *testing.T,
+	command, fname string,
+) (*MongoFiles, error) {
+	t.Helper()
+	return simpleMongoFilesInstanceWithFilenameAndID(t, command, fname, "")
 }
 
-func simpleMongoFilesInstanceCommandOnly(command string) (*MongoFiles, error) {
-	return simpleMongoFilesInstanceWithFilenameAndID(command, "", "")
+func simpleMongoFilesInstanceCommandOnly(t *testing.T, command string) (*MongoFiles, error) {
+	t.Helper()
+	return simpleMongoFilesInstanceWithFilenameAndID(t, command, "", "")
 }
 
 func simpleMongoFilesInstanceWithMultipleFileNames(
+	t *testing.T,
 	command string,
 	fnames ...string,
 ) (*MongoFiles, error) {
-	mongofiles, err := simpleMongoFilesInstanceCommandOnly(command)
+	t.Helper()
+
+	mongofiles, err := simpleMongoFilesInstanceCommandOnly(t, command)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +144,16 @@ func simpleMongoFilesInstanceWithMultipleFileNames(
 	return mongofiles, nil
 }
 
-func simpleMongoFilesInstanceWithFilenameAndID(command, fname, ID string) (*MongoFiles, error) {
+// An unclosed session provider leaves the driver's topology-monitoring
+// goroutines running for the remainder of the test binary's run, so the
+// returned MongoFiles is closed when the test ends and must not be used after
+// that.
+func simpleMongoFilesInstanceWithFilenameAndID(
+	t *testing.T,
+	command, fname, ID string,
+) (*MongoFiles, error) {
+	t.Helper()
+
 	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	if err != nil {
 		return nil, err
@@ -150,6 +168,7 @@ func simpleMongoFilesInstanceWithFilenameAndID(command, fname, ID string) (*Mong
 		FileName:        fname,
 		Id:              ID,
 	}
+	t.Cleanup(mongofiles.Close)
 
 	return &mongofiles, nil
 }
@@ -166,7 +185,11 @@ func simpleMockMongoFilesInstanceWithFilename(command, fname string) *MongoFiles
 	}
 }
 
-func getMongofilesWithArgs(args ...string) (*MongoFiles, error) {
+// The returned MongoFiles is closed when the test ends, for the same reason as
+// simpleMongoFilesInstanceWithFilenameAndID, and must not be used after that.
+func getMongofilesWithArgs(t *testing.T, args ...string) (*MongoFiles, error) {
+	t.Helper()
+
 	opts, err := ParseOptions(args, "", "")
 	if err != nil {
 		return nil, err
@@ -176,6 +199,7 @@ func getMongofilesWithArgs(args ...string) (*MongoFiles, error) {
 	if err != nil {
 		return nil, err
 	}
+	t.Cleanup(mf.Close)
 
 	return mf, nil
 }
@@ -243,8 +267,10 @@ func getFilesAndBytesFromLines(lines []string) map[string]int {
 	return results
 }
 
-func getFilesAndBytesListFromGridFS() (map[string]int, error) {
-	mfAfter, err := simpleMongoFilesInstanceCommandOnly("list")
+func getFilesAndBytesListFromGridFS(t *testing.T) (map[string]int, error) {
+	t.Helper()
+
+	mfAfter, err := simpleMongoFilesInstanceCommandOnly(t, "list")
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +401,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Testing the 'list' command with a file that isn't in GridFS should", func() {
-			mf, err := simpleMongoFilesInstanceWithFilename("list", "gibberish")
+			mf, err := simpleMongoFilesInstanceWithFilename(t, "list", "gibberish")
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -387,7 +413,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		})
 
 		Convey("Testing the 'list' command with files that are in GridFS should", func() {
-			mf, err := simpleMongoFilesInstanceWithFilename("list", "testf")
+			mf, err := simpleMongoFilesInstanceWithFilename(t, "list", "testf")
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -405,7 +431,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		})
 
 		Convey("Testing the 'search' command with files that are in GridFS should", func() {
-			mf, err := simpleMongoFilesInstanceWithFilename("search", "file")
+			mf, err := simpleMongoFilesInstanceWithFilename(t, "search", "file")
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -423,7 +449,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		})
 
 		Convey("Testing the 'get' command with a file that is in GridFS should", func() {
-			mf, err := simpleMongoFilesInstanceWithFilename("get", "testfile1")
+			mf, err := simpleMongoFilesInstanceWithFilename(t, "get", "testfile1")
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -468,7 +494,7 @@ func TestMongoFilesCommands(t *testing.T) {
 
 		Convey("Testing the 'get' command with multiple files that are in GridFS should", func() {
 			localTestFiles := []string{"testfile1", "testfile2", "testfile3"}
-			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("get", localTestFiles...)
+			mf, err := simpleMongoFilesInstanceWithMultipleFileNames(t, "get", localTestFiles...)
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -519,11 +545,11 @@ func TestMongoFilesCommands(t *testing.T) {
 		})
 
 		Convey("Testing the 'get_id' command with a file that is in GridFS should", func() {
-			_, err := simpleMongoFilesInstanceWithFilename("get", "testfile1")
+			_, err := simpleMongoFilesInstanceWithFilename(t, "get", "testfile1")
 			So(err, ShouldBeNil)
 
 			id := idOfFile("testfile1")
-			mf, err := simpleMongoFilesInstanceWithID("get_id", id)
+			mf, err := simpleMongoFilesInstanceWithID(t, "get_id", id)
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -929,7 +955,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		})
 
 		Convey("Testing the 'get_regex' command should", func() {
-			mf, err := simpleMongoFilesInstanceCommandOnly(GetRegex)
+			mf, err := simpleMongoFilesInstanceCommandOnly(t, GetRegex)
 			So(err, ShouldBeNil)
 
 			Convey(
@@ -1004,7 +1030,7 @@ func TestMongoFilesCommands(t *testing.T) {
 				filepath.FromSlash("testdata/lorem_ipsum_multi_args_2.txt"),
 			}
 
-			mf, err := simpleMongoFilesInstanceWithMultipleFileNames("put", localTestFiles...)
+			mf, err := simpleMongoFilesInstanceWithMultipleFileNames(t, "put", localTestFiles...)
 			So(err, ShouldBeNil)
 
 			var buff bytes.Buffer
@@ -1030,7 +1056,7 @@ func TestMongoFilesCommands(t *testing.T) {
 			})
 
 			Convey("and files should exist in GridFS", func() {
-				bytesGotten, err := getFilesAndBytesListFromGridFS()
+				bytesGotten, err := getFilesAndBytesListFromGridFS(t)
 				So(err, ShouldBeNil)
 
 				// Check that the only files included are the local test
@@ -1049,7 +1075,7 @@ func TestMongoFilesCommands(t *testing.T) {
 					const localFileName = "lorem_ipsum_copy.txt"
 					buff.Truncate(0)
 					for i, testFile := range localTestFiles {
-						mfAfter, err := simpleMongoFilesInstanceWithFilename("get", testFile)
+						mfAfter, err := simpleMongoFilesInstanceWithFilename(t, "get", testFile)
 						So(err, ShouldBeNil)
 						So(mf, ShouldNotBeNil)
 
@@ -1107,7 +1133,7 @@ func TestMongoFilesCommands(t *testing.T) {
 		)
 
 		Convey("Testing the 'delete' command with a file that is in GridFS should", func() {
-			mf, err := simpleMongoFilesInstanceWithFilename("delete", "testfile2")
+			mf, err := simpleMongoFilesInstanceWithFilename(t, "delete", "testfile2")
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -1121,7 +1147,7 @@ func TestMongoFilesCommands(t *testing.T) {
 				So(buff.Len(), ShouldNotEqual, 0)
 
 				Convey("check that the file has been deleted from GridFS", func() {
-					bytesGotten, err := getFilesAndBytesListFromGridFS()
+					bytesGotten, err := getFilesAndBytesListFromGridFS(t)
 					So(err, ShouldEqual, nil)
 					So(len(bytesGotten), ShouldEqual, len(testFiles)-1)
 
@@ -1132,11 +1158,11 @@ func TestMongoFilesCommands(t *testing.T) {
 
 		Convey("Testing the 'delete_id' command with a file that is in GridFS should", func() {
 			// hack to grab an _id
-			_, err := simpleMongoFilesInstanceWithFilename("get", "testfile2")
+			_, err := simpleMongoFilesInstanceWithFilename(t, "get", "testfile2")
 			So(err, ShouldBeNil)
 
 			idString := idOfFile("testfile2")
-			mf, err := simpleMongoFilesInstanceWithID("delete_id", idString)
+			mf, err := simpleMongoFilesInstanceWithID(t, "delete_id", idString)
 			So(err, ShouldBeNil)
 			So(mf, ShouldNotBeNil)
 
@@ -1150,7 +1176,7 @@ func TestMongoFilesCommands(t *testing.T) {
 				So(buff.Len(), ShouldNotEqual, 0)
 
 				Convey("check that the file has been deleted from GridFS", func() {
-					bytesGotten, err := getFilesAndBytesListFromGridFS()
+					bytesGotten, err := getFilesAndBytesListFromGridFS(t)
 					So(err, ShouldEqual, nil)
 					So(len(bytesGotten), ShouldEqual, len(testFiles)-1)
 
@@ -1175,6 +1201,7 @@ func TestDefaultWriteConcern(t *testing.T) {
 
 	Convey("with a URI that doesn't specify write concern", t, func() {
 		mf, err := getMongofilesWithArgs(
+			t,
 			"get", "filename",
 			"--uri", uriWithoutWriteConcern(toolOptions.URI.ConnectionString),
 		)
@@ -1188,6 +1215,7 @@ func TestDefaultWriteConcern(t *testing.T) {
 
 	Convey("with no URI and no write concern option", t, func() {
 		mf, err := getMongofilesWithArgs(
+			t,
 			"get", "filename",
 			"--host", strings.Join(toolOptions.URI.ConnString.Hosts, ","),
 		)
@@ -1221,6 +1249,7 @@ func uriWithoutWriteConcern(uri string) string {
 func runPutIDTestCase(idToTest string, t *testing.T) {
 	remoteName := "remoteName"
 	mongoFilesInstance, err := simpleMongoFilesInstanceWithFilenameAndID(
+		t,
 		"put_id",
 		remoteName,
 		idToTest,
@@ -1242,13 +1271,13 @@ func runPutIDTestCase(idToTest string, t *testing.T) {
 	So(buff.Len(), ShouldNotEqual, 0)
 
 	t.Log("and its filename should exist when the 'list' command is run")
-	bytesGotten, err := getFilesAndBytesListFromGridFS()
+	bytesGotten, err := getFilesAndBytesListFromGridFS(t)
 	So(err, ShouldBeNil)
 	So(bytesGotten, ShouldContainKey, remoteName)
 
 	t.Log("and get_id should have exactly the same content as the original file")
 
-	mfAfter, err := simpleMongoFilesInstanceWithID("get_id", idToTest)
+	mfAfter, err := simpleMongoFilesInstanceWithID(t, "get_id", idToTest)
 	So(err, ShouldBeNil)
 	So(mfAfter, ShouldNotBeNil)
 

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -165,8 +165,20 @@ func newOptions() Options {
 	}
 }
 
-func NewMongoImport() (*MongoImport, error) {
-	return New(newOptions())
+// An unclosed session provider leaves the driver's topology-monitoring
+// goroutines running for the remainder of the test binary's run, so the
+// returned MongoImport is closed when the test ends and must not be used after
+// that.
+func NewMongoImport(t *testing.T) (*MongoImport, error) {
+	t.Helper()
+
+	imp, err := New(newOptions())
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(imp.Close)
+
+	return imp, nil
 }
 
 // NewMockMongoImport gets an instance of MongoImport with no underlying SessionProvider.
@@ -186,7 +198,11 @@ func NewMockMongoImport() *MongoImport {
 	}
 }
 
-func getImportWithArgs(additionalArgs ...string) (*MongoImport, error) {
+// The returned MongoImport is closed when the test ends, for the same reason as
+// NewMongoImport, and must not be used after that.
+func getImportWithArgs(t *testing.T, additionalArgs ...string) (*MongoImport, error) {
+	t.Helper()
+
 	opts, err := ParseOptions(append(testutil.GetBareArgs(), additionalArgs...), "", "")
 	if err != nil {
 		return nil, fmt.Errorf("error parsing args: %v", err)
@@ -203,6 +219,7 @@ func getImportWithArgs(additionalArgs ...string) (*MongoImport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making new instance of mongorestore: %v", err)
 	}
+	t.Cleanup(imp.Close)
 
 	return imp, nil
 }
@@ -622,7 +639,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("no error should be thrown for CSV import on test data and all "+
 			"CSV data lines should be imported correctly", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -637,7 +654,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("an error should be thrown for JSON import on test data that is "+
 			"JSON array", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.File = "testdata/test_array.json"
@@ -648,7 +665,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("TOOLS-247: no error should be thrown for JSON import on test "+
 			"data and all documents should be imported correctly", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.File = "testdata/test_plain2.json"
@@ -659,7 +676,7 @@ func TestImportDocuments(t *testing.T) {
 			So(numFailed, ShouldEqual, 0)
 		})
 		Convey("CSV import with --ignoreBlanks should import only non-blank fields", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -680,7 +697,7 @@ func TestImportDocuments(t *testing.T) {
 			So(checkOnlyHasDocuments(t, imp.SessionProvider, expectedDocuments), ShouldBeNil)
 		})
 		Convey("CSV import without --ignoreBlanks should include blanks", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -699,7 +716,7 @@ func TestImportDocuments(t *testing.T) {
 			So(checkOnlyHasDocuments(t, imp.SessionProvider, expectedDocuments), ShouldBeNil)
 		})
 		Convey("no error should be thrown for CSV import on test data with --upsertFields", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -721,7 +738,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("no error should be thrown for CSV import on test data with "+
 			"--stopOnError. Only documents before error should be imported", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -745,7 +762,7 @@ func TestImportDocuments(t *testing.T) {
 		Convey(
 			"CSV import with duplicate _id's should not error if --stopOnError is not set",
 			func() {
-				imp, err := NewMongoImport()
+				imp, err := NewMongoImport(t)
 				So(err, ShouldBeNil)
 				imp.IngestOptions.Mode = modeInsert
 				imp.InputOptions.Type = CSV
@@ -778,7 +795,7 @@ func TestImportDocuments(t *testing.T) {
 			},
 		)
 		Convey("no error should be thrown for CSV import on test data with --drop", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -800,7 +817,7 @@ func TestImportDocuments(t *testing.T) {
 			So(checkOnlyHasDocuments(t, imp.SessionProvider, expectedDocuments), ShouldBeNil)
 		})
 		Convey("CSV import on test data with --headerLine should succeed", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -818,7 +835,7 @@ func TestImportDocuments(t *testing.T) {
 			So(err, ShouldBeNil)
 			csvFile.Close()
 
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -832,7 +849,7 @@ func TestImportDocuments(t *testing.T) {
 			So(numFailed, ShouldEqual, 0)
 		})
 		Convey("CSV import with --mode=upsert and --upsertFields should succeed", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -854,7 +871,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("CSV import with --mode=delete should succeed", func() {
 			// First import 3 documents
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -868,7 +885,7 @@ func TestImportDocuments(t *testing.T) {
 			So(numFailed, ShouldEqual, 0)
 
 			// Then delete two documents
-			imp, err = NewMongoImport()
+			imp, err = NewMongoImport(t)
 			So(err, ShouldBeNil)
 
 			imp.InputOptions.Type = CSV
@@ -891,7 +908,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("CSV import with --mode=delete and --upsertFields should succeed", func() {
 			// First import 3 documents
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -905,7 +922,7 @@ func TestImportDocuments(t *testing.T) {
 			So(numFailed, ShouldEqual, 0)
 
 			// Then delete two documents
-			imp, err = NewMongoImport()
+			imp, err = NewMongoImport(t)
 			So(err, ShouldBeNil)
 
 			imp.InputOptions.Type = CSV
@@ -930,7 +947,7 @@ func TestImportDocuments(t *testing.T) {
 		Convey("CSV import with --mode=delete and --ignoreBlanks should not take any action for "+
 			"documents that have blank values for upsert fields", func() {
 			// First import 3 documents
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -944,7 +961,7 @@ func TestImportDocuments(t *testing.T) {
 			So(numFailed, ShouldEqual, 0)
 
 			// Then delete two documents
-			imp, err = NewMongoImport()
+			imp, err = NewMongoImport(t)
 			So(err, ShouldBeNil)
 
 			imp.InputOptions.Type = CSV
@@ -969,7 +986,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("CSV import with --mode=upsert/--upsertFields with duplicate id should succeed "+
 			"even if stopOnError is set", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.InputOptions.Type = CSV
 			imp.InputOptions.File = "testdata/test_duplicate.csv"
@@ -996,7 +1013,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("an error should be thrown for CSV import on test data with "+
 			"duplicate _id if --stopOnError is set", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -1019,7 +1036,7 @@ func TestImportDocuments(t *testing.T) {
 		})
 		Convey("an error should be thrown for JSON import on test data that "+
 			"is a JSON array without passing --jsonArray", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.File = "testdata/test_array.json"
@@ -1036,7 +1053,7 @@ func TestImportDocuments(t *testing.T) {
 			So(jsonInputReader.StreamDocument(t.Context(), true, docChan), ShouldNotBeNil)
 		})
 		Convey("an error should be thrown for invalid CSV import on test data", func() {
-			imp, err := NewMongoImport()
+			imp, err := NewMongoImport(t)
 			So(err, ShouldBeNil)
 			imp.IngestOptions.Mode = modeInsert
 			imp.InputOptions.Type = CSV
@@ -1053,7 +1070,7 @@ func TestImportDocuments(t *testing.T) {
 		Convey(
 			"CSV import with --mode=upsert/--upsertFields with a nested upsert field should succeed when repeated",
 			func() {
-				imp, err := NewMongoImport()
+				imp, err := NewMongoImport(t)
 				So(err, ShouldBeNil)
 				imp.InputOptions.Type = CSV
 				imp.InputOptions.File = "testdata/test_nested_upsert.csv"
@@ -1069,7 +1086,7 @@ func TestImportDocuments(t *testing.T) {
 				So(n, ShouldEqual, 1)
 
 				// Repeat must succeed
-				imp, err = NewMongoImport()
+				imp, err = NewMongoImport(t)
 				So(err, ShouldBeNil)
 				imp.InputOptions.Type = CSV
 				imp.InputOptions.File = "testdata/test_nested_upsert.csv"
@@ -1417,7 +1434,7 @@ func nestedFieldsTestHelper(
 			So(err, ShouldBeNil)
 		}()
 
-		imp, err := NewMongoImport()
+		imp, err := NewMongoImport(t)
 		So(err, ShouldBeNil)
 
 		imp.InputOptions.Type = CSV
@@ -1515,7 +1532,7 @@ func TestImportMIOSOE(t *testing.T) {
 	coll := database.Collection("mio")
 
 	Convey("default restore ignores dup key errors", t, func() {
-		imp, err := getImportWithArgs(mioSoeFile,
+		imp, err := getImportWithArgs(t, mioSoeFile,
 			"--collection", coll.Name(),
 			"--db", database.Name(),
 			"--drop")
@@ -1534,7 +1551,7 @@ func TestImportMIOSOE(t *testing.T) {
 	})
 
 	Convey("--maintainInsertionOrder stops exactly on dup key errors", t, func() {
-		imp, err := getImportWithArgs(mioSoeFile,
+		imp, err := getImportWithArgs(t, mioSoeFile,
 			"--collection", coll.Name(),
 			"--db", database.Name(),
 			"--drop",
@@ -1556,7 +1573,7 @@ func TestImportMIOSOE(t *testing.T) {
 	})
 
 	Convey("--stopOnError stops on dup key errors", t, func() {
-		imp, err := getImportWithArgs(mioSoeFile,
+		imp, err := getImportWithArgs(t, mioSoeFile,
 			"--collection", coll.Name(),
 			"--db", database.Name(),
 			"--drop",
@@ -1955,6 +1972,7 @@ func newImportTestClient(t *testing.T, dbName string) *mongo.Client {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		require.NoError(t, client.Database(dbName).Drop(ctx))
+		sessionProvider.Close()
 	})
 	return client
 }


### PR DESCRIPTION
This is a follow-up to PR #1169 that makes sure we close test clients created outside the session methods in `testutil`.