### PR TITLE
TOOLS-4100 Respect `TOOLS_TESTING_MONGOD` in `common/db` integration tests

### DIFF
--- a/common/db/buffered_bulk_test.go
+++ b/common/db/buffered_bulk_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/assert"
@@ -21,18 +20,7 @@ import (
 func TestBufferedBulkInserterInserts(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-		},
-		URI:  &options.URI{},
-		SSL:  &ssl,
-		Auth: &auth,
-	}
-	err := opts.NormalizeOptionsAndURI()
-	require.NoError(t, err)
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 	require.NotNil(t, provider)

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -17,75 +17,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
-// var block and functions copied from testutil to avoid import cycle.
 var (
-	UserAdmin              = "uAdmin"
-	UserAdminPassword      = "password"
-	CreatedUserNameEnv     = "TOOLS_TESTING_AUTH_USERNAME"
-	CreatedUserPasswordEnv = "TOOLS_TESTING_AUTH_PASSWORD"
-	PKCS8Password          = "TOOLS_TESTING_PKCS8_PASSWORD"
-	kerberosUsername       = "drivers%40LDAPTEST.10GEN.CC"
-	kerberosConnection     = "ldaptest.10gen.cc:27017"
+	PKCS8Password      = "TOOLS_TESTING_PKCS8_PASSWORD"
+	kerberosUsername   = "drivers%40LDAPTEST.10GEN.CC"
+	kerberosConnection = "ldaptest.10gen.cc:27017"
 )
-
-func DBGetAuthOptions() options.Auth {
-	if testtype.HasTestType(testtype.AuthTestType) {
-		return options.Auth{
-			Username: os.Getenv(CreatedUserNameEnv),
-			Password: os.Getenv(CreatedUserPasswordEnv),
-			Source:   "admin",
-		}
-	}
-
-	return options.Auth{}
-}
-
-func DBGetSSLOptions() options.SSL {
-	if testtype.HasTestType(testtype.SSLTestType) {
-		return options.SSL{
-			UseSSL:        true,
-			SSLCAFile:     "../db/testdata/ca-ia.pem",
-			SSLPEMKeyFile: "../db/testdata/test-client.pem",
-		}
-	}
-
-	return options.SSL{
-		UseSSL: false,
-	}
-}
-
-func DBGetConnString() *options.URI {
-	if testtype.HasTestType(testtype.SSLTestType) {
-		return &options.URI{
-			ConnString: &connstring.ConnString{
-				SSLCaFileSet:                   true,
-				SSLCaFile:                      "../db/testdata/ca-ia.pem",
-				SSLClientCertificateKeyFileSet: true,
-				SSLClientCertificateKeyFile:    "../db/testdata/test-client.pem",
-			},
-		}
-	}
-
-	return &options.URI{}
-}
 
 func TestNewSessionProvider(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-		},
-		URI:  DBGetConnString(),
-		SSL:  &ssl,
-		Auth: &auth,
-	}
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 
@@ -123,17 +66,7 @@ func TestConfigureClientForSRV(t *testing.T) {
 func TestDatabaseNames(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-		},
-		URI:  DBGetConnString(),
-		SSL:  &ssl,
-		Auth: &auth,
-	}
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 
@@ -160,17 +93,7 @@ func TestDatabaseNames(t *testing.T) {
 func TestFindOne(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-		},
-		URI:  DBGetConnString(),
-		SSL:  &ssl,
-		Auth: &auth,
-	}
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 
@@ -192,16 +115,7 @@ func TestFindOne(t *testing.T) {
 func TestGetIndexes(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-		},
-		URI:  DBGetConnString(),
-		SSL:  &ssl,
-		Auth: &auth,
-	}
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 	session, err := provider.GetSession()
@@ -247,18 +161,7 @@ func TestGetIndexes(t *testing.T) {
 func TestServerVersionArray(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 
-	auth := DBGetAuthOptions()
-	ssl := DBGetSSLOptions()
-
-	opts := options.ToolOptions{
-		Connection: &options.Connection{
-			Port: testopts.DefaultTestPort,
-			Host: "localhost",
-		},
-		URI:  DBGetConnString(),
-		SSL:  &ssl,
-		Auth: &auth,
-	}
+	opts := testopts.MustGetToolOptions(t)
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 
@@ -271,23 +174,23 @@ func TestServerCertificateVerification(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	testtype.SkipUnlessTestType(t, testtype.SSLTestType)
 
-	auth := DBGetAuthOptions()
-	sslOrigin := DBGetSSLOptions()
+	auth := testopts.GetAuthOptions()
+	sslOrigin := testopts.SSLOptionsWithCert("test-client.pem")
 
 	// intermediate certs only
 	ssl := sslOrigin
-	ssl.SSLCAFile = "../db/testdata/ia.pem"
+	ssl.SSLCAFile = testopts.TestDataPath("ia.pem")
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
 			Port:    testopts.DefaultTestPort,
 			Timeout: 10,
 		},
-		URI:  DBGetConnString(),
+		URI:  testopts.URIWithCert("test-client.pem"),
 		SSL:  &ssl,
 		Auth: &auth,
 	}
 
-	opts.ConnString.SSLCaFile = "../db/testdata/ia.pem"
+	opts.ConnString.SSLCaFile = testopts.TestDataPath("ia.pem")
 	provider, err := NewSessionProvider(opts)
 	require.NoError(t, err)
 	require.NoError(t, provider.client.Ping(t.Context(), nil))
@@ -299,24 +202,24 @@ func TestServerPKCS8Verification(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	testtype.SkipUnlessTestType(t, testtype.SSLTestType)
 
-	auth := DBGetAuthOptions()
+	auth := testopts.GetAuthOptions()
 	ssl := options.SSL{
 		UseSSL:    true,
-		SSLCAFile: "../db/testdata/ca-ia.pem",
+		SSLCAFile: testopts.TestDataPath("ca-ia.pem"),
 	}
 
 	t.Run("with unencrypted password", func(t *testing.T) {
-		ssl.SSLPEMKeyFile = "../db/testdata/test-client-pkcs8-unencrypted.pem"
+		ssl.SSLPEMKeyFile = testopts.TestDataPath("test-client-pkcs8-unencrypted.pem")
 		opts := options.ToolOptions{
 			Connection: &options.Connection{
 				Port:    testopts.DefaultTestPort,
 				Timeout: 10,
 			},
-			URI:  DBGetConnString(),
+			URI:  testopts.URIWithCert("test-client.pem"),
 			SSL:  &ssl,
 			Auth: &auth,
 		}
-		opts.ConnString.SSLCaFile = "../db/testdata/ca-ia.pem"
+		opts.ConnString.SSLCaFile = testopts.TestDataPath("ca-ia.pem")
 		provider, err := NewSessionProvider(opts)
 		require.NoError(t, err)
 		require.NoError(t, provider.client.Ping(t.Context(), nil))
@@ -324,18 +227,18 @@ func TestServerPKCS8Verification(t *testing.T) {
 	})
 
 	t.Run("with encrypted password", func(t *testing.T) {
-		ssl.SSLPEMKeyFile = "../db/testdata/test-client-pkcs8-encrypted.pem"
+		ssl.SSLPEMKeyFile = testopts.TestDataPath("test-client-pkcs8-encrypted.pem")
 		ssl.SSLPEMKeyPassword = os.Getenv(PKCS8Password)
 		opts := options.ToolOptions{
 			Connection: &options.Connection{
 				Port:    testopts.DefaultTestPort,
 				Timeout: 10,
 			},
-			URI:  DBGetConnString(),
+			URI:  testopts.URIWithCert("test-client.pem"),
 			SSL:  &ssl,
 			Auth: &auth,
 		}
-		opts.ConnString.SSLCaFile = "../db/testdata/ca-ia.pem"
+		opts.ConnString.SSLCaFile = testopts.TestDataPath("ca-ia.pem")
 		provider, err := NewSessionProvider(opts)
 		require.NoError(t, err)
 		require.NoError(t, provider.client.Ping(t.Context(), nil))

--- a/common/testopts/ssl_integration.go
+++ b/common/testopts/ssl_integration.go
@@ -7,11 +7,12 @@
 package testopts
 
 import (
+	"path/filepath"
 	"runtime"
-	"strings"
 
 	commonOpts "github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testtype"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
 func GetSSLArgs() []string {
@@ -26,22 +27,50 @@ func GetSSLArgs() []string {
 	return nil
 }
 
+// GetSSLOptions returns options presenting the test server certificate.
 func GetSSLOptions() commonOpts.SSL {
-	// Get current filename and location
-	_, filename, _, _ := runtime.Caller(0)
-	// Get the path to containing folder
-	foldername := filename[0:strings.LastIndex(filename, "/")]
-	caFile := foldername + "/../db/testdata/ca-ia.pem"
-	serverFile := foldername + "/../db/testdata/test-server.pem"
-	if testtype.HasTestType(testtype.SSLTestType) {
+	return SSLOptionsWithCert("test-server.pem")
+}
+
+// SSLOptionsWithCert returns options presenting the named certificate from common/db/testdata.
+// Tests that connect as a client need one of the client certificates rather than the server one
+// GetSSLOptions hands out.
+func SSLOptionsWithCert(certFile string) commonOpts.SSL {
+	if !testtype.HasTestType(testtype.SSLTestType) {
 		return commonOpts.SSL{
-			UseSSL:        true,
-			SSLCAFile:     caFile,
-			SSLPEMKeyFile: serverFile,
+			UseSSL: false,
 		}
 	}
 
 	return commonOpts.SSL{
-		UseSSL: false,
+		UseSSL:        true,
+		SSLCAFile:     TestDataPath("ca-ia.pem"),
+		SSLPEMKeyFile: TestDataPath(certFile),
 	}
+}
+
+// URIWithCert returns a URI whose ConnString carries the TLS file settings for the named
+// certificate. Options built by hand rather than by GetToolOptions need this, because a ConnString
+// the caller owns is also what lets it override one of those settings afterward.
+func URIWithCert(certFile string) *commonOpts.URI {
+	if !testtype.HasTestType(testtype.SSLTestType) {
+		return &commonOpts.URI{}
+	}
+
+	return &commonOpts.URI{
+		ConnString: &connstring.ConnString{
+			SSLCaFileSet:                   true,
+			SSLCaFile:                      TestDataPath("ca-ia.pem"),
+			SSLClientCertificateKeyFileSet: true,
+			SSLClientCertificateKeyFile:    TestDataPath(certFile),
+		},
+	}
+}
+
+// TestDataPath returns the absolute path of a file in common/db/testdata, so that a test naming a
+// certificate does not depend on its own package's location.
+func TestDataPath(file string) string {
+	_, thisFile, _, _ := runtime.Caller(0)
+
+	return filepath.Join(filepath.Dir(thisFile), "..", "db", "testdata", file)
 }

--- a/common/testopts/testopts.go
+++ b/common/testopts/testopts.go
@@ -12,9 +12,11 @@ package testopts
 import (
 	"fmt"
 	"os"
+	"testing"
 
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/wcwrapper"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
@@ -82,6 +84,17 @@ func GetToolOptions() (*options.ToolOptions, error) {
 	}
 
 	return toolOptions, nil
+}
+
+// MustGetToolOptions is GetToolOptions for the tests that have nothing left to do if the options
+// cannot be built.
+func MustGetToolOptions(t *testing.T) options.ToolOptions {
+	t.Helper()
+
+	opts, err := GetToolOptions()
+	require.NoError(t, err, "getting the tool options for the server under test")
+
+	return *opts
 }
 
 func GetBareArgs() []string {


### PR DESCRIPTION
This changes the integration tests in `common/db` to use the shared test code in `common/testopts`. This means these tests now respect  TOOLS_TESTING_MONGOD.

As part of this, this adds some additional helpers for constructing the URI and SSL options in the `testopts` code. This is needed by some of the integration tests in the `db` package.