### PR TITLE
TOOLS-4263 Convert the last legacy JS test to Go and remove the legacy CI

### DIFF
--- a/integration/exportimport/query_test.go
+++ b/integration/exportimport/query_test.go
@@ -209,6 +209,79 @@ func (s *ExportImportSuite) TestRoundTripSortAndSkip() {
 	}
 }
 
+// TestRoundTripSortSkipAndLimit verifies that mongoexport passes a compound
+// --sort through whole, down to the direction of its second key, and that it
+// combines with --skip and --limit. Only the second key makes the answer
+// deterministic: sorting on a alone leaves the two a=3 documents in either
+// order, so a mongoexport that dropped the key would be flaky here rather than
+// reliably wrong, and one that flipped its direction selects a=3,b=4.
+//
+// The other two sort/skip/limit round trips in this file use a single ascending
+// key, and one of --skip or --limit but not both.
+func (s *ExportImportSuite) TestRoundTripSortSkipAndLimit() {
+	const dbName = "mongoimport_roundtrip_sortskiplimit_test"
+	const collName = "data"
+
+	client := s.Client()
+
+	coll := client.Database(dbName).Collection(collName)
+	_, err := coll.InsertMany(s.Context(), []any{
+		bson.D{{"a", 1}, {"b", 1}},
+		bson.D{{"a", 1}, {"b", 2}},
+		bson.D{{"a", 2}, {"b", 3}},
+		bson.D{{"a", 2}, {"b", 3}},
+		bson.D{{"a", 3}, {"b", 4}},
+		bson.D{{"a", 3}, {"b", 5}},
+	})
+	s.Require().NoError(err)
+
+	exportToolOptions, err := testutil.GetToolOptions()
+	s.Require().NoError(err)
+	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
+	me, err := mongoexport.New(mongoexport.Options{
+		ToolOptions: exportToolOptions,
+		OutputFormatOptions: &mongoexport.OutputFormatOptions{
+			Type: "json", JSONFormat: "relaxed",
+		},
+		InputOptions: &mongoexport.InputOptions{Sort: "{a:1, b:-1}", Skip: 4, Limit: 1},
+	})
+	s.Require().NoError(err)
+	defer me.Close()
+	tmpFile, err := os.CreateTemp(s.T().TempDir(), "export-*.json")
+	s.Require().NoError(err)
+	n, err := me.Export(tmpFile)
+	s.Require().NoError(err)
+	s.Require().NoError(tmpFile.Close())
+	s.Assert().EqualValues(1, n, "should export the single document left after the skip and limit")
+
+	s.Require().NoError(coll.Drop(s.Context()))
+
+	importToolOptions, err := testutil.GetToolOptions()
+	s.Require().NoError(err)
+	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
+	mi, err := mongoimport.New(mongoimport.Options{
+		ToolOptions:   importToolOptions,
+		InputOptions:  &mongoimport.InputOptions{File: tmpFile.Name(), ParseGrace: "stop"},
+		IngestOptions: &mongoimport.IngestOptions{},
+	})
+	s.Require().NoError(err)
+	imported, _, err := mi.ImportDocuments()
+	s.Require().NoError(err)
+	s.Assert().EqualValues(1, imported, "should import the one exported document")
+
+	count, err := coll.CountDocuments(s.Context(), bson.D{})
+	s.Require().NoError(err)
+	s.Assert().EqualValues(1, count, "collection should have exactly one document")
+
+	var got struct {
+		A int `bson:"a"`
+		B int `bson:"b"`
+	}
+	s.Require().NoError(coll.FindOne(s.Context(), bson.D{}).Decode(&got))
+	s.Assert().Equal(3, got.A, "the restored document has the a the skip and limit select")
+	s.Assert().Equal(5, got.B, "the restored document has the b the descending sort on b selects")
+}
+
 func (s *ExportImportSuite) exportAndImportWithQuery(
 	db *mongo.Database,
 	sourceDocs []any,


### PR DESCRIPTION
- `test/legacy42/jstests/tool/exportimport6.js` -> `integration/exportimport/query_test.go` - `TestRoundTripSortSkipAndLimit`. Six documents are exported with `--sort "{a:1, b:-1}" --skip 4 --limit 1`, the collection is dropped, and the export is imported back. Exactly one document survives, and it is a=3,b=5.

`query_test.go` already had `TestRoundTripLimit` and `TestRoundTripSortAndSkip`, but both sort on a single ascending key and use one of `--skip` or `--limit` rather than both. The compound sort is what this adds: with a descending second key, a=3,b=5 is the only correct answer, and flipping that key to ascending makes the test fail with `expected: 5, actual: 4`. Sorting on `a` alone would leave the two a=3 documents in either order, so an export that dropped the second key would be flaky here rather than reliably wrong.

The Go test also asserts the export and import counts, and asserts `a` as well as `b`, neither of which the JS did. It drops the JS test's `assert.eq(0, c.count())` precondition because `BeforeTest` in `integration/sharedsuite/suite.go` drops every non-system database before each test method, so an empty collection is structural rather than something to check.

No JS tests remain in this repo.

Removes the legacy CI infrastructure, which now has nothing to run:

- `test/legacy42/` - deleted. `scripts/run-legacy-tests.sh` ran `jstests/tool/*.js`, which was this one file, and `lib/run_mongod.js` was the harness it loaded.
- `scripts/run-legacy-tests.sh` and the `run legacy tests` function in `common.yml` - deleted, along with the ten `legacy-jstests-*` task definitions and the `test_path` expansion that only fed them. Buildvariants select these tasks by version tag, so no buildvariant task list changes.
- The `!.no-race` exclusions in the `rhel88-race` variant's task list, and the comment explaining them. Those ten tasks carried the only `no-race` tags in the file, so the selectors became no-ops. `evergreen validate` warns about the unmatched criteria if they are left behind.
- The `github_pr_aliases` entry for `rhel88` drops `legacy`, in `aliases()` in `evergreen/evergreen.go` and in the generated block in `common.yml` both. `TestGitHubPRAliasBlockIsUpToDate` compares the two, so they have to move together.

`test/shell_common/` stays. It is not legacy-test infrastructure: `scripts/create-repl-set.sh` and `scripts/create-sharded-cluster.sh` load `load_libs-<VERSION>.js` and the vendored `ReplSetTest`/`ShardingTest` from it to build the clusters the integration tests run against, and `load_libs_version` is still passed to both. The comments in those files that assumed the shell runs from `test/legacy42` are updated to describe the jsconfig `baseUrl` that actually resolves their import paths, and the "Adjust load libs" section of `server-version-support.md` is rewritten for the same reason - it described the shims as serving the legacy JS tests.