### PR TITLE
TOOLS-4100 Move the test connection-options helpers into `common/testopts`

### DIFF
--- a/common/db/buffered_bulk_test.go
+++ b/common/db/buffered_bulk_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestBufferedBulkInserterInserts(t *testing.T) {
 	ssl := DBGetSSLOptions()
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 		},
 		URI:  &options.URI{},
 		SSL:  &ssl,

--- a/common/db/db.go
+++ b/common/db/db.go
@@ -53,11 +53,6 @@ const (
 	MaxBSONSize = 16 * 1024 * 1024 // 16MB - maximum BSON document size
 )
 
-// Default port for integration tests.
-const (
-	DefaultTestPort = "33333"
-)
-
 const (
 	// ignorable errors.
 	ErrDuplicateKeyCode         = 11000

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,6 @@ func DBGetSSLOptions() options.SSL {
 func DBGetConnString() *options.URI {
 	if testtype.HasTestType(testtype.SSLTestType) {
 		return &options.URI{
-			//ConnectionString: "mongodb://localhost" + DefaultTestPort + "/",
 			ConnString: &connstring.ConnString{
 				SSLCaFileSet:                   true,
 				SSLCaFile:                      "../db/testdata/ca-ia.pem",
@@ -80,7 +80,7 @@ func TestNewSessionProvider(t *testing.T) {
 
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 		},
 		URI:  DBGetConnString(),
 		SSL:  &ssl,
@@ -128,7 +128,7 @@ func TestDatabaseNames(t *testing.T) {
 
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 		},
 		URI:  DBGetConnString(),
 		SSL:  &ssl,
@@ -165,7 +165,7 @@ func TestFindOne(t *testing.T) {
 
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 		},
 		URI:  DBGetConnString(),
 		SSL:  &ssl,
@@ -196,7 +196,7 @@ func TestGetIndexes(t *testing.T) {
 	ssl := DBGetSSLOptions()
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 		},
 		URI:  DBGetConnString(),
 		SSL:  &ssl,
@@ -252,7 +252,7 @@ func TestServerVersionArray(t *testing.T) {
 
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port: DefaultTestPort,
+			Port: testopts.DefaultTestPort,
 			Host: "localhost",
 		},
 		URI:  DBGetConnString(),
@@ -279,7 +279,7 @@ func TestServerCertificateVerification(t *testing.T) {
 	ssl.SSLCAFile = "../db/testdata/ia.pem"
 	opts := options.ToolOptions{
 		Connection: &options.Connection{
-			Port:    DefaultTestPort,
+			Port:    testopts.DefaultTestPort,
 			Timeout: 10,
 		},
 		URI:  DBGetConnString(),
@@ -309,7 +309,7 @@ func TestServerPKCS8Verification(t *testing.T) {
 		ssl.SSLPEMKeyFile = "../db/testdata/test-client-pkcs8-unencrypted.pem"
 		opts := options.ToolOptions{
 			Connection: &options.Connection{
-				Port:    DefaultTestPort,
+				Port:    testopts.DefaultTestPort,
 				Timeout: 10,
 			},
 			URI:  DBGetConnString(),
@@ -328,7 +328,7 @@ func TestServerPKCS8Verification(t *testing.T) {
 		ssl.SSLPEMKeyPassword = os.Getenv(PKCS8Password)
 		opts := options.ToolOptions{
 			Connection: &options.Connection{
-				Port:    DefaultTestPort,
+				Port:    testopts.DefaultTestPort,
 				Timeout: 10,
 			},
 			URI:  DBGetConnString(),

--- a/common/testopts/auth.go
+++ b/common/testopts/auth.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package testutil
+package testopts
 
 import (
 	"os"

--- a/common/testopts/ssl_integration.go
+++ b/common/testopts/ssl_integration.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package testutil
+package testopts
 
 import (
 	"runtime"

--- a/common/testopts/testopts.go
+++ b/common/testopts/testopts.go
@@ -1,0 +1,99 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package testopts builds the connection options and command-line arguments that point a test at
+// the server under test. It is separate from testutil, which it would otherwise belong to, because
+// common/db's own tests need these helpers and testutil imports common/db.
+package testopts
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/wcwrapper"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
+)
+
+// DefaultTestPort is the port the test suites expect a mongod on unless the environment overrides it
+// through URIEnvVar.
+const DefaultTestPort = "33333"
+
+// URIEnvVar names the env var that points the test suites at the server under test, overriding
+// localhost:DefaultTestPort.
+const URIEnvVar = "TOOLS_TESTING_MONGOD"
+
+func GetToolOptions() (*options.ToolOptions, error) {
+	var toolOptions *options.ToolOptions
+	// get ToolOptions from URI or defaults
+	if uri := os.Getenv(URIEnvVar); uri != "" {
+		parse, err := connstring.ParseAndValidate(uri)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%#q from the %#q env var is not a valid connection string: %w",
+				uri,
+				URIEnvVar,
+				err,
+			)
+		}
+
+		fakeArgs := []string{"--uri=" + uri}
+		opts := options.EnabledOptions{Auth: parse.UsernameSet, URI: true}
+		toolOptions = options.New("mongodump", "", "", "", true, opts)
+
+		_, err = toolOptions.ParseArgs(fakeArgs)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not create toolOptions with %#q from the %#q env var: %w",
+				uri,
+				URIEnvVar,
+				err,
+			)
+		}
+
+		// ParseArgs does not set this, but tools like mongoimport and mongorestore
+		// dereference it without a nil check.
+		toolOptions.WriteConcern = wcwrapper.Majority()
+	} else {
+		ssl := GetSSLOptions()
+		auth := GetAuthOptions()
+		connection := &options.Connection{
+			Host: "localhost",
+			Port: DefaultTestPort,
+		}
+		toolOptions = &options.ToolOptions{
+			General:      &options.General{},
+			SSL:          &ssl,
+			Connection:   connection,
+			Auth:         &auth,
+			Verbosity:    &options.Verbosity{},
+			URI:          &options.URI{},
+			Namespace:    &options.Namespace{},
+			WriteConcern: wcwrapper.Majority(),
+		}
+	}
+
+	err := toolOptions.NormalizeOptionsAndURI()
+	if err != nil {
+		return nil, err
+	}
+
+	return toolOptions, nil
+}
+
+func GetBareArgs() []string {
+	args := []string{}
+
+	args = append(args, GetSSLArgs()...)
+	args = append(args, GetAuthArgs()...)
+	if uri := os.Getenv(URIEnvVar); uri != "" {
+		args = append(args, "--uri", uri)
+	} else {
+		args = append(args, "--host", "localhost", "--port", DefaultTestPort)
+	}
+
+	return args
+}

--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -19,13 +19,12 @@ import (
 
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/wcwrapper"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
 // GetBareSession returns a client from the environment or from a default host
@@ -57,7 +56,7 @@ func GetBareSessionProvider(
 ) (*db.SessionProvider, *options.ToolOptions, error) {
 	t.Helper()
 
-	toolOptions, err := GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"error getting tool options to create a bare session provider: %w",
@@ -72,80 +71,6 @@ func GetBareSessionProvider(
 	t.Cleanup(sessionProvider.Close)
 
 	return sessionProvider, toolOptions, nil
-}
-
-const uriEnvVar = "TOOLS_TESTING_MONGOD"
-
-func GetToolOptions() (*options.ToolOptions, error) {
-	var toolOptions *options.ToolOptions
-	// get ToolOptions from URI or defaults
-	if uri := os.Getenv(uriEnvVar); uri != "" {
-		parse, err := connstring.ParseAndValidate(uri)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"%#q from the %#q env var is not a valid connection string: %w",
-				uri,
-				uriEnvVar,
-				err,
-			)
-		}
-
-		fakeArgs := []string{"--uri=" + uri}
-		opts := options.EnabledOptions{Auth: parse.UsernameSet, URI: true}
-		toolOptions = options.New("mongodump", "", "", "", true, opts)
-
-		_, err = toolOptions.ParseArgs(fakeArgs)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"could not create toolOptions with %#q from the %#q env var: %w",
-				uri,
-				uriEnvVar,
-				err,
-			)
-		}
-
-		// ParseArgs does not set this, but tools like mongoimport and mongorestore
-		// dereference it without a nil check.
-		toolOptions.WriteConcern = wcwrapper.Majority()
-	} else {
-		ssl := GetSSLOptions()
-		auth := GetAuthOptions()
-		connection := &options.Connection{
-			Host: "localhost",
-			Port: db.DefaultTestPort,
-		}
-		toolOptions = &options.ToolOptions{
-			General:      &options.General{},
-			SSL:          &ssl,
-			Connection:   connection,
-			Auth:         &auth,
-			Verbosity:    &options.Verbosity{},
-			URI:          &options.URI{},
-			Namespace:    &options.Namespace{},
-			WriteConcern: wcwrapper.Majority(),
-		}
-	}
-
-	err := toolOptions.NormalizeOptionsAndURI()
-	if err != nil {
-		return nil, err
-	}
-
-	return toolOptions, nil
-}
-
-func GetBareArgs() []string {
-	args := []string{}
-
-	args = append(args, GetSSLArgs()...)
-	args = append(args, GetAuthArgs()...)
-	if uri := os.Getenv(uriEnvVar); uri != "" {
-		args = append(args, "--uri", uri)
-	} else {
-		args = append(args, "--host", "localhost", "--port", db.DefaultTestPort)
-	}
-
-	return args
 }
 
 // GetFCV returns the featureCompatibilityVersion string for an mgo Session
@@ -313,7 +238,7 @@ var atlasDomains = []string{
 
 // SkipForAtlasCluster will skip the test if `TOOLS_TESTING_MONGOD` is an Atlas URI.
 func SkipForAtlasCluster(t *testing.T, reason string) {
-	uri := os.Getenv(uriEnvVar)
+	uri := os.Getenv(testopts.URIEnvVar)
 	if uri == "" {
 		return
 	}
@@ -322,7 +247,7 @@ func SkipForAtlasCluster(t *testing.T, reason string) {
 		if strings.Contains(uri, d) {
 			t.Skipf(
 				"The %#q env var is for an Atlas cluster: %s",
-				uriEnvVar,
+				testopts.URIEnvVar,
 				reason,
 			)
 		}

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/archive"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/idx"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/mongodump"
@@ -235,7 +236,7 @@ func (s *DumpRestoreSuite) testDumpAndRestoreAllDBsIgnoresSomeConfigCollections(
 
 func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, error) {
 	opts, err := mongorestore.ParseOptions(
-		append(testutil.GetBareArgs(), additionalArgs...),
+		append(testopts.GetBareArgs(), additionalArgs...),
 		"",
 		"",
 	)

--- a/integration/dumprestore/suite_test.go
+++ b/integration/dumprestore/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/bsonutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/integration/sharedsuite"
@@ -41,7 +42,7 @@ func (s *DumpRestoreSuite) withBSONMongodump(testCase func(string), args ...stri
 
 func (s *DumpRestoreSuite) runMongodumpWithArgs(args ...string) {
 	cmd := []string{"go", "run", filepath.Join("..", "..", "mongodump", "main")}
-	cmd = append(cmd, testutil.GetBareArgs()...)
+	cmd = append(cmd, testopts.GetBareArgs()...)
 	cmd = append(cmd, args...)
 	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 	cmdStr := strings.Join(cmd, " ")

--- a/integration/exportimport/csv_test.go
+++ b/integration/exportimport/csv_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -42,7 +42,7 @@ func (s *ExportImportSuite) TestRoundTripFieldFile() {
 	s.Require().NoError(err)
 	s.Require().NoError(exportTarget.Close())
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "source"}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -64,7 +64,7 @@ func (s *ExportImportSuite) TestRoundTripFieldFile() {
 	s.Require().NoError(f.Close())
 
 	fields := "a,b,c"
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "dest"}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -165,7 +165,7 @@ func (s *ExportImportSuite) TestRoundTripNestedFieldsCSV() {
 	})
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "source"}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -185,7 +185,7 @@ func (s *ExportImportSuite) TestRoundTripNestedFieldsCSV() {
 	s.Require().NoError(err)
 	s.Require().NoError(tmpFile.Close())
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "dest"}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -230,7 +230,7 @@ func (s *ExportImportSuite) exportCSVAndImport(dbName, exportFields string, db *
 	s.Require().NoError(err)
 	s.Require().NoError(exportTarget.Close())
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "source"}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -251,7 +251,7 @@ func (s *ExportImportSuite) exportCSVAndImport(dbName, exportFields string, db *
 	s.Require().NoError(f.Close())
 
 	importFields := "a,b,c"
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "dest"}
 	mi, err := mongoimport.New(mongoimport.Options{

--- a/integration/exportimport/data_test.go
+++ b/integration/exportimport/data_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -33,7 +33,7 @@ func (s *ExportImportSuite) TestRoundTripBasicData() {
 	_, err := coll.InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 
@@ -56,7 +56,7 @@ func (s *ExportImportSuite) TestRoundTripBasicData() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -108,7 +108,7 @@ func (s *ExportImportSuite) TestRoundTripDataTypes() {
 	_, err := coll.InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 
@@ -131,7 +131,7 @@ func (s *ExportImportSuite) TestRoundTripDataTypes() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -178,7 +178,7 @@ func (s *ExportImportSuite) TestRoundTripDecimal128() {
 	_, err = coll.InsertOne(s.Context(), testDoc)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -199,7 +199,7 @@ func (s *ExportImportSuite) TestRoundTripDecimal128() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -261,7 +261,7 @@ func (s *ExportImportSuite) TestRoundTripViewExport() {
 	s.Require().NoError(err)
 	s.Assert().EqualValues(4, n, "should have 4 cities in California view")
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "citiesCA"}
 
@@ -284,7 +284,7 @@ func (s *ExportImportSuite) TestRoundTripViewExport() {
 
 	s.Require().NoError(db.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "CACities"}
 	mi, err := mongoimport.New(mongoimport.Options{

--- a/integration/exportimport/import_validation_test.go
+++ b/integration/exportimport/import_validation_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -41,7 +41,7 @@ func (s *ExportImportSuite) TestImportDocumentValidation() {
 	_, err := db.Collection(collName).InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := mongoexport.New(mongoexport.Options{

--- a/integration/exportimport/json_test.go
+++ b/integration/exportimport/json_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -90,7 +90,7 @@ func (s *ExportImportSuite) TestRoundTripJSONArray() {
 	_, err := coll.InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -112,7 +112,7 @@ func (s *ExportImportSuite) TestRoundTripJSONArray() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importWithoutFlagOpts, err := testutil.GetToolOptions()
+	importWithoutFlagOpts, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importWithoutFlagOpts.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -128,7 +128,7 @@ func (s *ExportImportSuite) TestRoundTripJSONArray() {
 	s.Require().NoError(err)
 	s.Assert().EqualValues(0, n, "nothing should have been imported without --jsonArray")
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err = mongoimport.New(mongoimport.Options{
@@ -162,7 +162,7 @@ func (s *ExportImportSuite) exportJSONAndImport(dbName, fields string, db *mongo
 	s.Require().NoError(err)
 	s.Require().NoError(tmpFile.Close())
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "source"}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -182,7 +182,7 @@ func (s *ExportImportSuite) exportJSONAndImport(dbName, fields string, db *mongo
 	s.Require().NoError(err)
 	s.Require().NoError(f.Close())
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "dest"}
 	mi, err := mongoimport.New(mongoimport.Options{

--- a/integration/exportimport/query_test.go
+++ b/integration/exportimport/query_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-tools/common/options"
-	"github.com/mongodb/mongo-tools/common/testutil"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -35,7 +35,7 @@ func (s *ExportImportSuite) TestRoundTripLimit() {
 	_, err := coll.InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -57,7 +57,7 @@ func (s *ExportImportSuite) TestRoundTripLimit() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -165,7 +165,7 @@ func (s *ExportImportSuite) TestRoundTripSortAndSkip() {
 	_, err := coll.InsertMany(s.Context(), docs)
 	s.Require().NoError(err)
 
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -186,7 +186,7 @@ func (s *ExportImportSuite) TestRoundTripSortAndSkip() {
 
 	s.Require().NoError(coll.Drop(s.Context()))
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -221,7 +221,7 @@ func (s *ExportImportSuite) exportAndImportWithQuery(
 		_, err := db.Collection("source").InsertMany(s.Context(), sourceDocs)
 		s.Require().NoError(err)
 	}
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "source"}
 	me, err := mongoexport.New(mongoexport.Options{
@@ -239,7 +239,7 @@ func (s *ExportImportSuite) exportAndImportWithQuery(
 	s.Require().NoError(err)
 	s.Require().NoError(tmpFile.Close())
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "dest"}
 	mi, err := mongoimport.New(mongoimport.Options{

--- a/integration/exportimport/suite_test.go
+++ b/integration/exportimport/suite_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
-	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/integration/sharedsuite"
 	"github.com/mongodb/mongo-tools/mongoexport"
 	"github.com/mongodb/mongo-tools/mongoimport"
@@ -28,7 +28,7 @@ func TestImportExport(t *testing.T) {
 }
 
 func (s *ExportImportSuite) ExportOptions() mongoexport.Options {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 
 	opts := mongoexport.Options{
@@ -46,7 +46,7 @@ func (s *ExportImportSuite) ExportOptions() mongoexport.Options {
 }
 
 func (s *ExportImportSuite) ImportOptions(dbName, collName string) mongoimport.Options {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	toolOptions.Namespace.DB = dbName
 	toolOptions.Namespace.Collection = collName
@@ -67,7 +67,7 @@ func (s *ExportImportSuite) importCollection(
 	filePath string,
 	ingestOpts mongoimport.IngestOptions,
 ) error {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	toolOptions.Namespace = ns
 	mi, err := mongoimport.New(mongoimport.Options{
@@ -86,7 +86,7 @@ func (s *ExportImportSuite) importCollection(
 func (s *ExportImportSuite) exportCollectionToFile(ns *options.Namespace) string {
 	exportFile, err := os.CreateTemp(s.T().TempDir(), "export-*.json")
 	s.Require().NoError(err)
-	exportToolOptions, err := testutil.GetToolOptions()
+	exportToolOptions, err := testopts.GetToolOptions()
 	s.Require().NoError(err)
 	exportToolOptions.Namespace = ns
 	me, err := mongoexport.New(mongoexport.Options{

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/json"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/pkg/errors"
@@ -62,7 +63,7 @@ const (
 )
 
 func simpleMongoDumpInstance() (*MongoDump, error) {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	if err != nil {
 		return nil, fmt.Errorf("error getting tool options to create a mongodump instance: %w", err)
 	}
@@ -2566,7 +2567,7 @@ func TestBrokenPipe(t *testing.T) {
 
 	args := append(
 		[]string{"run", filepath.Join("..", "mongodump", "main")},
-		testutil.GetBareArgs()...,
+		testopts.GetBareArgs()...,
 	)
 	args = append(args, "--db", dbName, "--archive=-")
 	testutil.AssertBrokenPipeHandled(t, exec.Command("go", args...))

--- a/mongoexport/mongoexport_test.go
+++ b/mongoexport/mongoexport_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ var (
 )
 
 func simpleMongoExportOpts() (Options, error) {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	if err != nil {
 		return Options{}, fmt.Errorf(
 			"error getting tool options to create a mongoexport instance: %w",
@@ -349,7 +350,7 @@ func TestBrokenPipe(t *testing.T) {
 
 	args := append(
 		[]string{"run", filepath.Join("..", "mongoexport", "main")},
-		testutil.GetBareArgs()...,
+		testopts.GetBareArgs()...,
 	)
 	args = append(args, "--db", dbName, "--collection", collName)
 	testutil.AssertBrokenPipeHandled(t, exec.Command("go", args...))
@@ -362,7 +363,7 @@ func TestExportNamespaceValidation(t *testing.T) {
 	log.SetWriter(io.Discard)
 
 	for _, dbName := range []string{"test.bar", `test"bar`} {
-		toolOptions, err := testutil.GetToolOptions()
+		toolOptions, err := testopts.GetToolOptions()
 		require.NoError(t, err)
 		toolOptions.Namespace = &options.Namespace{DB: dbName, Collection: "foo"}
 		_, err = New(Options{
@@ -373,7 +374,7 @@ func TestExportNamespaceValidation(t *testing.T) {
 		assert.Error(t, err, "db name %q should be rejected", dbName)
 	}
 
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = &options.Namespace{DB: "test", Collection: "system.foobar"}
 	me, err := New(Options{
@@ -393,7 +394,7 @@ func TestExportNoData(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 	log.SetWriter(io.Discard)
 
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = &options.Namespace{DB: "test", Collection: "mongoexport_no_data_test"}
 
@@ -437,7 +438,7 @@ func TestExportPretty(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	me, err := New(Options{
@@ -485,7 +486,7 @@ func TestExportWritesToStdout(t *testing.T) {
 	require.NoError(t, err)
 
 	args := []string{"go", "run", filepath.Join("..", "mongoexport", "main")}
-	args = append(args, testutil.GetBareArgs()...)
+	args = append(args, testopts.GetBareArgs()...)
 	args = append(args, "--db", dbName, "--collection", collName)
 	cmd := exec.Command(args[0], args[1:]...)
 	stdout, err := cmd.Output()
@@ -574,7 +575,7 @@ func TestExportNestedFieldsCSV(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 
@@ -617,7 +618,7 @@ func TestExportNestedFieldsCSV(t *testing.T) {
 
 func newExportTestClient(t *testing.T, dbName string) *mongo.Client {
 	t.Helper()
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err, "should get tool options")
 	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	require.NoError(t, err, "should create session provider")
@@ -631,7 +632,7 @@ func newExportTestClient(t *testing.T, dbName string) *mongo.Client {
 
 func exportWithType(t *testing.T, ns *options.Namespace, typeName string) (string, error) {
 	t.Helper()
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = ns
 	me, err := New(Options{

--- a/mongofiles/mongofiles_test.go
+++ b/mongofiles/mongofiles_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
-	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/common/wcwrapper"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +33,7 @@ import (
 var (
 	testDB = "mongofiles_test_db"
 
-	ssl         = testutil.GetSSLOptions()
+	ssl         = testopts.GetSSLOptions()
 	toolOptions = mustGetToolOptions()
 	testFiles   = map[string]bson.ObjectID{
 		"testfile1": bson.NewObjectID(),
@@ -44,7 +44,7 @@ var (
 )
 
 func mustGetToolOptions() *options.ToolOptions {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	if err != nil {
 		panic(fmt.Sprintf("could not get tool options: %v", err))
 	}

--- a/mongoimport/mongoimport_test.go
+++ b/mongoimport/mongoimport_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongo-tools/common"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	. "github.com/smartystreets/goconvey/convey"
@@ -145,7 +146,7 @@ func countDocuments(t *testing.T, sessionProvider *db.SessionProvider) (int, err
 // getBasicToolOptions returns a test helper to instantiate the session provider
 // for calls to StreamDocument.
 func getBasicToolOptions() *options.ToolOptions {
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	if err != nil {
 		panic(fmt.Sprintf("could not get tool options: %v", err))
 	}
@@ -203,7 +204,7 @@ func NewMockMongoImport() *MongoImport {
 func getImportWithArgs(t *testing.T, additionalArgs ...string) (*MongoImport, error) {
 	t.Helper()
 
-	opts, err := ParseOptions(append(testutil.GetBareArgs(), additionalArgs...), "", "")
+	opts, err := ParseOptions(append(testopts.GetBareArgs(), additionalArgs...), "", "")
 	if err != nil {
 		return nil, fmt.Errorf("error parsing args: %v", err)
 	}
@@ -1635,7 +1636,7 @@ func TestImportBooleanType(t *testing.T) {
 	}
 	require.NoError(t, tmpFile.Close())
 
-	importToolOptions, err := testutil.GetToolOptions()
+	importToolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	importToolOptions.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := New(Options{
@@ -1743,7 +1744,7 @@ func TestImportExtraFields(t *testing.T) {
 	fieldNames := []string{"a", "b", "c.xyz", "d.hij.lkm"}
 	fieldFilePath := writeFieldFile(t, tmpDir, "fieldfile", fieldNames)
 
-	toolOpts, err := testutil.GetToolOptions()
+	toolOpts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOpts.Namespace = &options.Namespace{DB: dbName, Collection: collName}
 	mi, err := New(Options{
@@ -1962,7 +1963,7 @@ func TestImportModeByID(t *testing.T) {
 
 func newImportTestClient(t *testing.T, dbName string) *mongo.Client {
 	t.Helper()
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err, "should get tool options")
 	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	require.NoError(t, err, "should create session provider")
@@ -1984,7 +1985,7 @@ func importCollection(
 	ingestOpts IngestOptions,
 ) error {
 	t.Helper()
-	toolOptions, err := testutil.GetToolOptions()
+	toolOptions, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOptions.Namespace = ns
 	mi, err := New(Options{
@@ -2002,7 +2003,7 @@ func importCollection(
 
 func importFromFile(t *testing.T, filePath, dbOverride, collOverride string) {
 	t.Helper()
-	toolOpts, err := testutil.GetToolOptions()
+	toolOpts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOpts.Namespace = &options.Namespace{DB: dbOverride, Collection: collOverride}
 	mi, err := New(Options{
@@ -2124,7 +2125,7 @@ func testImportFieldsForFormat(
 	})
 
 	t.Run(format+"/noFieldSpec", func(t *testing.T) {
-		toolOpts, err := testutil.GetToolOptions()
+		toolOpts, err := testopts.GetToolOptions()
 		require.NoError(t, err)
 		toolOpts.Namespace = &options.Namespace{DB: dbName, Collection: format + "testcoll"}
 		_, err = New(Options{
@@ -2150,7 +2151,7 @@ func importAndCheckFields(t *testing.T, client *mongo.Client, o importFieldsOpts
 	t.Helper()
 	collName := o.format + "testcoll"
 	require.NoError(t, client.Database(o.dbName).Collection(collName).Drop(t.Context()))
-	toolOpts, err := testutil.GetToolOptions()
+	toolOpts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	toolOpts.Namespace = &options.Namespace{DB: o.dbName, Collection: collName}
 	var ffPtr *string

--- a/mongorestore/dumprestore_auth_test.go
+++ b/mongorestore/dumprestore_auth_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/mongodump"
@@ -1003,7 +1004,7 @@ func TestRestoreWithDBUserPreservesIndexes(t *testing.T) {
 // baseToolOpts returns a fresh set of tool options from the environment.
 func baseToolOpts(t *testing.T) *options.ToolOptions {
 	t.Helper()
-	opts, err := testutil.GetToolOptions()
+	opts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	return opts
 }
@@ -1012,7 +1013,7 @@ func baseToolOpts(t *testing.T) *options.ToolOptions {
 // authentication overridden to use the given username and password.
 func toolOptsForUser(t *testing.T, username, password string) *options.ToolOptions {
 	t.Helper()
-	opts, err := testutil.GetToolOptions()
+	opts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	opts.Auth = &options.Auth{
 		Username: username,
@@ -1026,7 +1027,7 @@ func toolOptsForUser(t *testing.T, username, password string) *options.ToolOptio
 // authentication cleared. Connecting to an auth-required server will fail.
 func toolOptsNoAuth(t *testing.T) *options.ToolOptions {
 	t.Helper()
-	opts, err := testutil.GetToolOptions()
+	opts, err := testopts.GetToolOptions()
 	require.NoError(t, err)
 	opts.Auth = &options.Auth{}
 	return opts

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"github.com/mongodb/mongo-tools/common/wcwrapper"
@@ -61,7 +62,7 @@ func init() {
 }
 
 func getRestoreWithArgs(additionalArgs ...string) (*MongoRestore, error) {
-	opts, err := ParseOptions(append(testutil.GetBareArgs(), additionalArgs...), "", "")
+	opts, err := ParseOptions(append(testopts.GetBareArgs(), additionalArgs...), "", "")
 	if err != nil {
 		return nil, fmt.Errorf("error parsing args: %v", err)
 	}
@@ -1331,7 +1332,7 @@ func TestAutoIndexIdLocalDB(t *testing.T) {
 			//nolint:errcheck
 			defer dbName.Collection("test_auto_idx").Drop(ctx)
 
-			opts, err := ParseOptions(testutil.GetBareArgs(), "", "")
+			opts, err := ParseOptions(testopts.GetBareArgs(), "", "")
 			So(err, ShouldBeNil)
 
 			// Set retryWrites to false since it is unsupported on `local` db.
@@ -2682,7 +2683,7 @@ func runBSONMongodumpForCollection(
 func runMongodumpWithArgs(t *testing.T, args ...string) {
 	require := require.New(t)
 	cmd := []string{"go", "run", filepath.Join("..", "mongodump", "main")}
-	cmd = append(cmd, testutil.GetBareArgs()...)
+	cmd = append(cmd, testopts.GetBareArgs()...)
 	cmd = append(cmd, args...)
 	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 	cmdStr := strings.Join(cmd, " ")


### PR DESCRIPTION
The tests in `common/db` cannot call `common/testutil`, because `testutil` imports `common/db`. Previously, we worked around this by more or less copying the `testutil` code into `db`. But this copy was incomplete. It hard-coded `localhost:33333`and ignored the  `TOOLS_TESTING_MONGOD`env var.

This PR moves the common code to `common/testopts`. It _doesn't_ get rid of all the copied code in `common/db`. That will be done in a follow-up PR.