### PR TITLE
TOOLS-4353 Fix broken NO_CLEANUP check in mongorestore fixtures

### DIFF
--- a/mongorestore/fixtures_test.go
+++ b/mongorestore/fixtures_test.go
@@ -159,10 +159,10 @@ func (tdd *testDumpDir) Create() error {
 	return nil
 }
 
-// Cleanup removes the test directory unless "NO_CLEANUP" is set in the environment.
+// Cleanup removes the test directory unless the `TOOLS_TESTING_NO_CLEANUP` env
+// var is set to a non-empty value, matching testutil.MakeTempDir.
 func (tdd *testDumpDir) Cleanup() error {
-	noCleanup := os.Getenv("NO_CLEANUP")
-	if noCleanup == "0" {
+	if os.Getenv("TOOLS_TESTING_NO_CLEANUP") != "" {
 		return nil
 	}
 	return os.RemoveAll(tdd.Path())


### PR DESCRIPTION
`The testDumpDir.Cleanup` method was totally backwards and wrong. It was checking the wrong env var and it checked for the wrong value.