### PR TITLE
Add a mise hook to run `npm install` on entering the project

### DIFF
--- a/etc/maybe-run-npm-install.sh
+++ b/etc/maybe-run-npm-install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+# verbose is intentionally disabled since this runs every time someone enters the project directory.
+
+cd "$MISE_PROJECT_ROOT"
+
+command -v eslint >/dev/null && command -v github-codeowners >/dev/null && command -v oxfmt >/dev/null && exit 0
+
+set -o verbose
+
+npm install

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,10 @@ node = { version = "22.22.0", postinstall = "$MISE_TOOL_INSTALL_PATH/bin/npm ins
 "npm:github-codeowners" = "0.2.1"
 "npm:oxfmt" = "0.52.0"
 
+[hooks]
+# This exists for the sake of worktrees, since we need to run `npm install` in every new worktree.
+enter = "./etc/maybe-run-npm-install.sh"
+
 [settings]
 # This prevents us from upgrading to anything that was released less than 7 days ago. It gives us a
 # bit of protection against supply-chain attacks.


### PR DESCRIPTION
This is helpful for worktrees, which need their own `npm install` for things like `github-codeowners`.