### PR TITLE
TOOLS-4355 Clamp the maximum number of goroutines to run when restoring an archive

### DIFF
--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -41,6 +42,11 @@ const (
 	deprecatedDBAndCollectionsOptionsWarning = "The --db and --collection flags are deprecated for " +
 		"this use-case; please use --nsInclude instead, " +
 		"i.e. with --nsInclude=${DATABASE}.${COLLECTION}"
+
+	// maxParallelCollectionsPerProc bounds how many parallel collections an archive's
+	// header can request per GOMAXPROCS, so a crafted or corrupt archive can't force
+	// mongorestore to spin up an unreasonable number of goroutines.
+	maxParallelCollectionsPerProc = 4
 )
 
 var (
@@ -450,18 +456,10 @@ func (restore *MongoRestore) Restore() Result {
 		restore.OutputOptions.NumInsertionWorkers = restore.OutputOptions.NumParallelCollections
 	}
 	if restore.InputOptions.Archive != "" {
-		if int(
-			restore.archive.Prelude.Header.ConcurrentCollections,
-		) > restore.OutputOptions.NumParallelCollections {
-			restore.OutputOptions.NumParallelCollections = int(
-				restore.archive.Prelude.Header.ConcurrentCollections,
-			)
-			log.Logvf(
-				log.Always,
-				"setting number of parallel collections to number of parallel collections in archive (%v)",
-				restore.archive.Prelude.Header.ConcurrentCollections,
-			)
-		}
+		restore.OutputOptions.NumParallelCollections = numParallelCollectionsForArchive(
+			int(restore.archive.Prelude.Header.ConcurrentCollections),
+			restore.OutputOptions.NumParallelCollections,
+		)
 	}
 
 	// Create the demux before intent creation, because muted archive intents need
@@ -701,6 +699,37 @@ func (restore *MongoRestore) Restore() Result {
 	}
 
 	return result
+}
+
+// numParallelCollectionsForArchive returns the number of parallel collections to use
+// when restoring from an archive, raising currentNumParallelCollections to match the
+// concurrency the archive was written with. The archive's requested value is capped so
+// that a crafted or corrupt archive can't force mongorestore to spin up an unreasonable
+// number of goroutines.
+func numParallelCollectionsForArchive(
+	archiveConcurrentCollections, currentNumParallelCollections int,
+) int {
+	maxParallelCollections := runtime.GOMAXPROCS(0) * maxParallelCollectionsPerProc
+	if archiveConcurrentCollections > maxParallelCollections {
+		log.Logvf(
+			log.Always,
+			"archive requested %v parallel collections, which exceeds the maximum of %v for "+
+				"this machine; using the maximum instead",
+			archiveConcurrentCollections,
+			maxParallelCollections,
+		)
+		archiveConcurrentCollections = maxParallelCollections
+	}
+	if archiveConcurrentCollections > currentNumParallelCollections {
+		log.Logvf(
+			log.Always,
+			"setting number of parallel collections to %v, the number of concurrent collections "+
+				"used to write the archive (possibly capped for this machine)",
+			archiveConcurrentCollections,
+		)
+		return archiveConcurrentCollections
+	}
+	return currentNumParallelCollections
 }
 
 // ReadPreludeMetadata finds and parses the prelude.json file if it's present.

--- a/mongorestore/mongorestore_archive_concurrency_test.go
+++ b/mongorestore/mongorestore_archive_concurrency_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongorestore
+
+import (
+	"math"
+	"runtime"
+	"testing"
+
+	"github.com/mongodb/mongo-tools/common/testtype"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumParallelCollectionsForArchive(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	maxParallelCollections := runtime.GOMAXPROCS(0) * maxParallelCollectionsPerProc
+
+	tests := []struct {
+		name                          string
+		archiveConcurrentCollections  int
+		currentNumParallelCollections int
+		expected                      int
+	}{
+		{
+			name:                          "archive value lower than current setting is ignored",
+			archiveConcurrentCollections:  1,
+			currentNumParallelCollections: 4,
+			expected:                      4,
+		},
+		{
+			name:                          "archive value higher than current setting raises it",
+			archiveConcurrentCollections:  8,
+			currentNumParallelCollections: 4,
+			expected:                      8,
+		},
+		{
+			name:                          "excessive archive value is capped",
+			archiveConcurrentCollections:  math.MaxInt32,
+			currentNumParallelCollections: 4,
+			expected:                      maxParallelCollections,
+		},
+		{
+			name:                          "capped archive value still under current setting is ignored",
+			archiveConcurrentCollections:  math.MaxInt32,
+			currentNumParallelCollections: maxParallelCollections + 1,
+			expected:                      maxParallelCollections + 1,
+		},
+		{
+			name:                          "negative archive value is ignored",
+			archiveConcurrentCollections:  -1,
+			currentNumParallelCollections: 4,
+			expected:                      4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := numParallelCollectionsForArchive(
+				tt.archiveConcurrentCollections,
+				tt.currentNumParallelCollections,
+			)
+			assert.Equal(
+				t,
+				tt.expected,
+				actual,
+				"numParallelCollectionsForArchive(%d, %d) should return %d",
+				tt.archiveConcurrentCollections,
+				tt.currentNumParallelCollections,
+				tt.expected,
+			)
+		})
+	}
+}


### PR DESCRIPTION
Previously, this would accept any value up the max `int` value, which could cause an OOM when we tried to spin up that many goroutines.