### PR TITLE
TOOLS-4363 Add a guardrail to reject `--oplogReplay` and `--preserveUUID` when restoring to a sharded or DSC cluster

### DIFF
--- a/common/db/command.go
+++ b/common/db/command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mongodb/mongo-tools/common/db/dsc"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
 )
@@ -131,6 +132,16 @@ func (sp *SessionProvider) IsAtlasProxy() bool {
 		&bson.M{"atlasVersion": 1},
 	)
 	return result.Err() == nil
+}
+
+// IsDisaggregatedStorage reports whether the connected server uses disaggregated storage (DSC).
+func (sp *SessionProvider) IsDisaggregatedStorage() (bool, error) {
+	session, err := sp.GetSession()
+	if err != nil {
+		return false, err
+	}
+
+	return dsc.IsDisaggregatedStorage(context.Background(), session)
 }
 
 // GetNodeType checks if the connected SessionProvider is a mongos, standalone, or replset,

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mongodb/mongo-tools/common/db/dsctest"
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testtype"
@@ -39,6 +40,25 @@ func TestNewSessionProvider(t *testing.T) {
 	)
 
 	provider.Close()
+}
+
+func TestIsDisaggregatedStorage(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	opts := testopts.MustGetToolOptions(t)
+	provider, err := NewSessionProvider(opts)
+	require.NoError(t, err, "creating a session provider")
+	defer provider.Close()
+
+	// Against a DSC cluster the detector legitimately reports true, which is not what this test
+	// asserts, so skip there.
+	client, err := provider.GetSession()
+	require.NoError(t, err, "getting a session")
+	dsctest.SkipForDisaggregatedStorage(t, client, "the test asserts the non-DSC result")
+
+	isDSC, err := provider.IsDisaggregatedStorage()
+	require.NoError(t, err, "checking for disaggregated storage")
+	assert.False(t, isDSC, "a normal server reports no disaggregated storage")
 }
 
 func TestConfigureClientForSRV(t *testing.T) {

--- a/common/db/dsc/dsc.go
+++ b/common/db/dsc/dsc.go
@@ -1,0 +1,58 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package dsc detects whether a connected server uses disaggregated storage (DSC). The detector
+// works on a *mongo.Client so it can be shared between the production tools and the test suite.
+package dsc
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
+)
+
+// A disaggregated server reports this as its WiredTiger storage type, where a normal one reports
+// "file".
+const disaggregatedStorageType = "layered"
+
+// IsDisaggregatedStorage reports whether the connected server uses disaggregated storage (DSC).
+//
+// The storage type comes from $collStats rather than from a server parameter because the parameter
+// naming DSC only exists on mongod: through a mongos it looks exactly like a server too old to
+// know it, and the caller would run instead of failing fast.
+func IsDisaggregatedStorage(ctx context.Context, client *mongo.Client) (bool, error) {
+	opts := mopt.Database().SetReadConcern(readconcern.Majority())
+	coll := client.Database("admin", opts).Collection("system.version")
+
+	pipeline := mongo.Pipeline{
+		bson.D{{"$collStats", bson.D{{"storageStats", bson.D{}}}}},
+		bson.D{{"$project", bson.D{{"type", "$storageStats.wiredTiger.type"}}}},
+	}
+
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		return false, fmt.Errorf("fetching the cluster storage type: %w", err)
+	}
+
+	var stats []struct {
+		Type string `bson:"type"`
+	}
+	if err := cursor.All(ctx, &stats); err != nil {
+		return false, fmt.Errorf("reading the cluster storage type: %w", err)
+	}
+
+	for _, stat := range stats {
+		if stat.Type == disaggregatedStorageType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/common/db/dsctest/dsctest.go
+++ b/common/db/dsctest/dsctest.go
@@ -1,0 +1,53 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package dsctest provides test helpers for running against a server that uses disaggregated
+// storage (DSC). It lives in its own package, importing only the detector and the driver, so that
+// both common/testutil and tests inside common/db can use it without an import cycle.
+package dsctest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mongodb/mongo-tools/common/db/dsc"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// SkipForDisaggregatedStorage will skip the test if the server is running with disaggregated
+// storage (DSC) enabled.
+//
+// Use this for tests that depend on a server feature DSC does not support, naming that feature in
+// the reason. It deliberately keys off DSC rather than off the unsupported operation failing, so
+// an unexpected failure of that same operation elsewhere still fails the test loudly instead of
+// quietly skipping it.
+func SkipForDisaggregatedStorage(t *testing.T, client *mongo.Client, reason string) {
+	t.Helper()
+
+	isDSC, err := dsc.IsDisaggregatedStorage(t.Context(), client)
+	require.NoError(t, err, "checking for disaggregated storage")
+
+	if isDSC {
+		t.Skipf("Skipping test because the server uses disaggregated storage: %s", reason)
+	}
+}
+
+// SkipUnlessDisaggregatedStorage will skip the test if the server is not running with
+// disaggregated storage (DSC) enabled.
+//
+// Use this for tests that exercise a guardrail that only fires on a DSC cluster, so they only run
+// against the DSC CI variant.
+func SkipUnlessDisaggregatedStorage(t *testing.T, client *mongo.Client, reason string) {
+	t.Helper()
+
+	isDSC, err := dsc.IsDisaggregatedStorage(context.Background(), client)
+	require.NoError(t, err, "checking for disaggregated storage")
+
+	if !isDSC {
+		t.Skipf("Skipping test because the server does not use disaggregated storage: %s", reason)
+	}
+}

--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -18,13 +18,12 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongo-tools/common/db"
+	"github.com/mongodb/mongo-tools/common/db/dsctest"
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	mopt "go.mongodb.org/mongo-driver/v2/mongo/options"
-	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 )
 
 // GetBareSession returns a client from the environment or from a default host
@@ -262,49 +261,24 @@ func SkipForAtlasCluster(t *testing.T, reason string) {
 // unexpected failure of that same operation elsewhere still fails the test loudly instead of
 // quietly skipping it.
 func SkipForDisaggregatedStorage(t *testing.T, reason string) {
+	t.Helper()
+
 	session, err := GetBareSession(t)
 	require.NoError(t, err, "getting a session to check for disaggregated storage")
 
-	if isDisaggregatedStorage(t, session) {
-		t.Skipf("Skipping test because the server uses disaggregated storage: %s", reason)
-	}
+	dsctest.SkipForDisaggregatedStorage(t, session, reason)
 }
 
-// A disaggregated server reports this as its WiredTiger storage type, where a normal one reports
-// "file".
-const disaggregatedStorageType = "layered"
+// SkipUnlessDisaggregatedStorage will skip the test if the server is not running with disaggregated
+// storage (DSC) enabled.
+//
+// Use this for tests that exercise a guardrail that only fires on a DSC cluster, so they only run
+// against the DSC CI variant.
+func SkipUnlessDisaggregatedStorage(t *testing.T, reason string) {
+	session, err := GetBareSession(t)
+	require.NoError(t, err, "getting a session to check for disaggregated storage")
 
-// The storage type comes from $collStats rather than from a server parameter because the parameter
-// naming DSC only exists on mongod: through a mongos it looks exactly like a server too old to know
-// it, and the test would run instead of skipping.
-func isDisaggregatedStorage(t *testing.T, session *mongo.Client) bool {
-	opts := mopt.Database().SetReadConcern(readconcern.Majority())
-	coll := session.Database("admin", opts).Collection("system.version")
-
-	pipeline := mongo.Pipeline{
-		bson.D{{"$collStats", bson.D{{"storageStats", bson.D{}}}}},
-		bson.D{{"$project", bson.D{{"type", "$storageStats.wiredTiger.type"}}}},
-	}
-
-	cursor, err := coll.Aggregate(t.Context(), pipeline)
-	require.NoError(t, err, "fetching the cluster storage type")
-
-	var stats []struct {
-		Type string `bson:"type"`
-	}
-	require.NoError(
-		t,
-		cursor.All(t.Context(), &stats),
-		"reading the cluster storage type",
-	)
-
-	for _, stat := range stats {
-		if stat.Type == disaggregatedStorageType {
-			return true
-		}
-	}
-
-	return false
+	dsctest.SkipUnlessDisaggregatedStorage(t, session, reason)
 }
 
 // WriteTempFile writes the contents of r to a tempfile, then hands you back the (closed) file.

--- a/mongorestore/invalid_input_test.go
+++ b/mongorestore/invalid_input_test.go
@@ -19,6 +19,29 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+// TestApplyOpsGuardrail checks that `--oplogReplay` and `--preserveUUID` fail fast against a
+// sharded cluster, before any data is restored, since mongorestore implements both on top of the
+// `applyOps` command that shardec clusters do not support.
+func TestApplyOpsGuardrail(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.ShardedIntegrationTestType)
+
+	t.Run("--oplogReplay is rejected", func(t *testing.T) {
+		result := runRestoreFromArgs(t, OplogReplayOption, t.TempDir())
+		require.ErrorContains(
+			t, result.Err, "cannot use --oplogReplay",
+			"--oplogReplay against a sharded or DSC cluster errors",
+		)
+	})
+
+	t.Run("--preserveUUID is rejected", func(t *testing.T) {
+		result := runRestoreFromArgs(t, PreserveUUIDOption, DropOption, t.TempDir())
+		require.ErrorContains(
+			t, result.Err, "cannot use --preserveUUID",
+			"--preserveUUID against a sharded or DSC cluster errors",
+		)
+	})
+}
+
 // TestRestoreInvalidInput covers how mongorestore rejects invalid options and
 // invalid dump input: bad option combinations and values, dump targets that are
 // missing or of the wrong kind, and bson and metadata files it cannot read. Each
@@ -316,6 +339,10 @@ func testRestoreObjcheckValidBSON(t *testing.T) {
 }
 
 func testRestoreOplogReplayNoOplogFile(t *testing.T) {
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	result := runRestoreFromArgs(t, OplogReplayOption, t.TempDir())
 	require.ErrorContains(
 		t, result.Err, "no oplog file to replay",

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -322,6 +322,10 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 		return fmt.Errorf("cannot specify --preserveUUID without --drop")
 	}
 
+	if err := restore.checkApplyOpsGuardrail(); err != nil {
+		return err
+	}
+
 	// a single dash signals reading from stdin
 	if restore.TargetDirectory == "-" {
 		if restore.InputOptions.Archive != "" {
@@ -334,6 +338,27 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 	}
 	if restore.InputReader == nil {
 		restore.InputReader = os.Stdin
+	}
+
+	return nil
+}
+
+// checkApplyOpsGuardrail fails the restore when --oplogReplay or --preserveUUID is used against
+// either a sharded cluster. mongorestore implements both of these features on top of the `applyOps`
+// command, which sharded clusters do not support.
+func (restore *MongoRestore) checkApplyOpsGuardrail() error {
+	isSharded, err := restore.SessionProvider.IsMongos()
+	if err != nil {
+		return fmt.Errorf("error determining if the cluster is sharded: %w", err)
+	}
+
+	if isSharded {
+		if restore.InputOptions.OplogReplay {
+			return errors.New("cannot use --oplogReplay when restoring to a sharded cluster")
+		}
+		if restore.OutputOptions.PreserveUUID {
+			return errors.New("cannot use --preserveUUID when restoring to a sharded cluster")
+		}
 	}
 
 	return nil

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -1588,6 +1588,10 @@ func TestSkipSystemCollections(t *testing.T) {
 // entries are skipped when restoring the oplog.
 func TestSkipStartAndAbortIndexBuild(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 	ctx := t.Context()
 
 	sessionProvider, _, err := testutil.GetBareSessionProvider(t)

--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -485,7 +485,10 @@ func (restore *MongoRestore) ApplyOp(session *mongo.Client, op db.Oplog) error {
 		},
 	)
 	if err := singleRes.Err(); err != nil {
-		return fmt.Errorf("applyOps: %v", err)
+		return fmt.Errorf(
+			"applyOps (note that --oplogReplay and --preserveUUID are not supported with sharded or disaggregated storage clusters): %v",
+			err,
+		)
 	}
 	res := bson.M{}
 	if err := singleRes.Decode(&res); err != nil {

--- a/mongorestore/oplog_edges_test.go
+++ b/mongorestore/oplog_edges_test.go
@@ -25,6 +25,10 @@ import (
 // applies no data rather than silently choosing one of the two.
 func TestOplogReplayConflict(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+	testutil.SkipForDisaggregatedStorage(
+		t,
+		"it replays an oplog, and DSC does not support the applyOps command",
+	)
 
 	client, err := testutil.GetBareSession(t)
 	require.NoError(t, err)


### PR DESCRIPTION
Sharded and DSC clusters do not support the `applyOps` command, which these features require.

Checking if a cluster if DSC requires the `collStat` permission, which `mongorestore` typically doesn't have. To deal with this, I've changed the error we return when `applyOps` fails to call out that `--applyOplog` and `--preserveUUID` are not supported for sharded or disagg clusters.