### PR TITLE
TOOLS-4122 Add a new `TOOLS_TESTING_MONGOD2` env var and helpers for cross-cluster integration tests

### DIFF
--- a/common/testopts/testopts.go
+++ b/common/testopts/testopts.go
@@ -20,24 +20,38 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
-// DefaultTestPort is the port the test suites expect a mongod on unless the environment overrides it
-// through URIEnvVar.
-const DefaultTestPort = "33333"
+const (
+	// DefaultTestPort is the port the test suites expect a mongod on unless the environment
+	// overrides it through URIEnvVar.
+	DefaultTestPort = "33333"
 
-// URIEnvVar names the env var that points the test suites at the server under test, overriding
-// localhost:DefaultTestPort.
-const URIEnvVar = "TOOLS_TESTING_MONGOD"
+	// URIEnvVar names the env var that points the test suites at the server under test, overriding
+	// localhost:DefaultTestPort.
+	URIEnvVar = "TOOLS_TESTING_MONGOD"
+
+	// URIEnvVar2 names the env var that points the test suites at a second, distinct server under
+	// test.
+	//
+	// Tests that need a second cluster (e.g. a dump on one cluster restored into another) use this
+	// URL for a second, distinct cluster.
+	URIEnvVar2 = "TOOLS_TESTING_MONGOD2"
+)
 
 func GetToolOptions() (*options.ToolOptions, error) {
+	return GetToolOptionsForURI(os.Getenv(URIEnvVar))
+}
+
+// GetToolOptionsForURI builds ToolOptions pointing at the given URI, or at the default
+// localhost:DefaultTestPort when uri is empty.
+func GetToolOptionsForURI(uri string) (*options.ToolOptions, error) {
 	var toolOptions *options.ToolOptions
 	// get ToolOptions from URI or defaults
-	if uri := os.Getenv(URIEnvVar); uri != "" {
+	if uri != "" {
 		parse, err := connstring.ParseAndValidate(uri)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"%#q from the %#q env var is not a valid connection string: %w",
+				"%#q is not a valid connection string: %w",
 				uri,
-				URIEnvVar,
 				err,
 			)
 		}
@@ -49,9 +63,8 @@ func GetToolOptions() (*options.ToolOptions, error) {
 		_, err = toolOptions.ParseArgs(fakeArgs)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"could not create toolOptions with %#q from the %#q env var: %w",
+				"could not create toolOptions with %#q: %w",
 				uri,
-				URIEnvVar,
 				err,
 			)
 		}
@@ -98,11 +111,17 @@ func MustGetToolOptions(t *testing.T) options.ToolOptions {
 }
 
 func GetBareArgs() []string {
+	return GetBareArgsForURI(os.Getenv(URIEnvVar))
+}
+
+// GetBareArgsForURI returns the command-line args that point a tool at the given URI, or at the
+// default localhost:DefaultTestPort when uri is empty.
+func GetBareArgsForURI(uri string) []string {
 	args := []string{}
 
 	args = append(args, GetSSLArgs()...)
 	args = append(args, GetAuthArgs()...)
-	if uri := os.Getenv(URIEnvVar); uri != "" {
+	if uri != "" {
 		args = append(args, "--uri", uri)
 	} else {
 		args = append(args, "--host", "localhost", "--port", DefaultTestPort)

--- a/common/testutil/testutil.go
+++ b/common/testutil/testutil.go
@@ -30,9 +30,14 @@ import (
 // and port. The underlying session provider is closed when the test ends, so
 // the returned client must not be used after that.
 func GetBareSession(t *testing.T) (*mongo.Client, error) {
+	return GetBareSessionForURI(t, os.Getenv(testopts.URIEnvVar))
+}
+
+// GetBareSessionForURI is GetBareSession for a specific connection string.
+func GetBareSessionForURI(t *testing.T, uri string) (*mongo.Client, error) {
 	t.Helper()
 
-	sessionProvider, _, err := GetBareSessionProvider(t)
+	sessionProvider, _, err := GetBareSessionProviderForURI(t, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +60,17 @@ func GetBareSessionProvider(
 ) (*db.SessionProvider, *options.ToolOptions, error) {
 	t.Helper()
 
-	toolOptions, err := testopts.GetToolOptions()
+	return GetBareSessionProviderForURI(t, os.Getenv(testopts.URIEnvVar))
+}
+
+// GetBareSessionProviderForURI is GetBareSessionProvider for a specific connection string.
+func GetBareSessionProviderForURI(
+	t *testing.T,
+	uri string,
+) (*db.SessionProvider, *options.ToolOptions, error) {
+	t.Helper()
+
+	toolOptions, err := testopts.GetToolOptionsForURI(uri)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"error getting tool options to create a bare session provider: %w",

--- a/integration/dumprestore/dump_flags_test.go
+++ b/integration/dumprestore/dump_flags_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mongodb/mongo-tools/common/testopts"
 	"github.com/mongodb/mongo-tools/common/testutil"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -247,6 +248,7 @@ func (s *DumpRestoreSuite) TestDumpToStdout() {
 
 	s.runMongodumpToWriter(
 		bsonFile,
+		os.Getenv(testopts.URIEnvVar),
 		"--out", "-",
 		"--db", testDB.Name(),
 		"--collection", collName,

--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -255,8 +255,15 @@ func (s *DumpRestoreSuite) testDumpAndRestoreAllDBsIgnoresSomeConfigCollections(
 }
 
 func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, error) {
+	return getRestoreWithArgsForURI(os.Getenv(testopts.URIEnvVar), additionalArgs...)
+}
+
+func getRestoreWithArgsForURI(
+	uri string,
+	additionalArgs ...string,
+) (*mongorestore.MongoRestore, error) {
 	opts, err := mongorestore.ParseOptions(
-		append(testopts.GetBareArgs(), additionalArgs...),
+		append(testopts.GetBareArgsForURI(uri), additionalArgs...),
 		"",
 		"",
 	)
@@ -273,7 +280,15 @@ func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, e
 }
 
 func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoDump, error) {
-	provider, toolOpts, err := testutil.GetBareSessionProvider(t)
+	return getArchiveMongoDumpForURI(t, os.Getenv(testopts.URIEnvVar), output)
+}
+
+func getArchiveMongoDumpForURI(
+	t *testing.T,
+	uri string,
+	output io.WriteCloser,
+) (*mongodump.MongoDump, error) {
+	provider, toolOpts, err := testutil.GetBareSessionProviderForURI(t, uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for dump")
 	}
@@ -298,7 +313,15 @@ func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoD
 }
 
 func getArchiveMongoRestore(t *testing.T, input io.ReadCloser) (*mongorestore.MongoRestore, error) {
-	_, toolOpts, err := testutil.GetBareSessionProvider(t)
+	return getArchiveMongoRestoreForURI(t, os.Getenv(testopts.URIEnvVar), input)
+}
+
+func getArchiveMongoRestoreForURI(
+	t *testing.T,
+	uri string,
+	input io.ReadCloser,
+) (*mongorestore.MongoRestore, error) {
+	_, toolOpts, err := testutil.GetBareSessionProviderForURI(t, uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for restore")
 	}

--- a/integration/dumprestore/suite_test.go
+++ b/integration/dumprestore/suite_test.go
@@ -32,32 +32,40 @@ func TestDumpRestore(t *testing.T) {
 }
 
 func (s *DumpRestoreSuite) withBSONMongodump(testCase func(string), args ...string) {
+	s.withBSONMongodumpForURI(os.Getenv(testopts.URIEnvVar), testCase, args...)
+}
+
+func (s *DumpRestoreSuite) withBSONMongodumpForURI(
+	uri string,
+	testCase func(string),
+	args ...string,
+) {
 	dir, cleanup := testutil.MakeTempDir(s.T())
 	defer cleanup()
 	dirArgs := []string{
 		"--out", dir,
 	}
-	s.runMongodumpWithArgs(append(dirArgs, args...)...)
+	s.runMongodumpWithArgsForURI(nil, uri, append(dirArgs, args...)...)
 	testCase(dir)
 }
 
 func (s *DumpRestoreSuite) runMongodumpWithArgs(args ...string) {
-	s.runMongodump(nil, args...)
+	s.runMongodumpWithArgsForURI(nil, os.Getenv(testopts.URIEnvVar), args...)
 }
 
-// runMongodumpToWriter runs mongodump with its standard output redirected to
-// stdout, for the dumps that write their data there rather than to a directory.
-func (s *DumpRestoreSuite) runMongodumpToWriter(stdout io.Writer, args ...string) {
-	s.runMongodump(stdout, args...)
+// runMongodumpToWriter runs mongodump with its standard output redirected to stdout, for the dumps
+// that write their data there rather than to a directory.
+func (s *DumpRestoreSuite) runMongodumpToWriter(stdout io.Writer, uri string, args ...string) {
+	s.runMongodumpWithArgsForURI(stdout, uri, args...)
 }
 
-// runMongodump runs mongodump and requires it to succeed without reporting a
-// missing namespace. A nil stdout leaves mongodump's own standard output to be
-// captured alongside its diagnostics; otherwise standard output carries the
-// dump itself and only the diagnostics are captured.
-func (s *DumpRestoreSuite) runMongodump(stdout io.Writer, args ...string) {
+func (s *DumpRestoreSuite) runMongodumpWithArgsForURI(
+	stdout io.Writer,
+	uri string,
+	args ...string,
+) {
 	cmd := []string{"go", "run", filepath.Join("..", "..", "mongodump", "main")}
-	cmd = append(cmd, testopts.GetBareArgs()...)
+	cmd = append(cmd, testopts.GetBareArgsForURI(uri)...)
 	cmd = append(cmd, args...)
 	cmdStr := strings.Join(cmd, " ")
 
@@ -151,15 +159,25 @@ func (s *DumpRestoreSuite) runBSONMongodumpForCollection(
 }
 
 func (s *DumpRestoreSuite) withArchiveMongodump(testCase func(string), dumpArgs ...string) {
+	s.withArchiveMongodumpForURI(os.Getenv(testopts.URIEnvVar), testCase, dumpArgs...)
+}
+
+func (s *DumpRestoreSuite) withArchiveMongodumpForURI(
+	uri string,
+	testCase func(string),
+	dumpArgs ...string,
+) {
 	dir, cleanup := testutil.MakeTempDir(s.T())
 	defer cleanup()
 	file := filepath.Join(dir, "archive")
-	s.runArchiveMongodump(file, dumpArgs...)
+	s.runArchiveMongodumpForURI(uri, file, dumpArgs...)
 	testCase(file)
 }
 
-func (s *DumpRestoreSuite) runArchiveMongodump(file string, dumpArgs ...string) {
-	s.runMongodumpWithArgs(
+func (s *DumpRestoreSuite) runArchiveMongodumpForURI(uri, file string, dumpArgs ...string) {
+	s.runMongodumpWithArgsForURI(
+		nil,
+		uri,
 		append(
 			[]string{mongorestore.ArchiveOption + "=" + file},
 			dumpArgs...,


### PR DESCRIPTION
The integration test helpers currently read a single connection string from `TOOLS_TESTING_MONGOD`. We want to be able to run dump/restore tests across two clusters (e.g. a dump on one cluster restored into another).

This is some prep work towards making that possible. It adds scaffolding for a new `TOOLS_TESTING_MONGOD2` env var, which will be populated for cross-cluster tests and empty for others. It also changes the helpers that connect to a cluster so that there is a version that uses the default URI and a version which takes an explicit URI.

Right now, this is just the initial plumbing. Nothing actually _sets_ this new env var and none of the tests actually make use of it.