### PR TITLE
TOOLS-4122 Add URI-accepting helpers to the dumprestore suite

### DIFF
--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -235,8 +235,15 @@ func (s *DumpRestoreSuite) testDumpAndRestoreAllDBsIgnoresSomeConfigCollections(
 }
 
 func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, error) {
+	return getRestoreWithArgsForURI(os.Getenv(testopts.URIEnvVar), additionalArgs...)
+}
+
+func getRestoreWithArgsForURI(
+	uri string,
+	additionalArgs ...string,
+) (*mongorestore.MongoRestore, error) {
 	opts, err := mongorestore.ParseOptions(
-		append(testopts.GetBareArgs(), additionalArgs...),
+		append(testopts.GetBareArgsForURI(uri), additionalArgs...),
 		"",
 		"",
 	)
@@ -253,7 +260,15 @@ func getRestoreWithArgs(additionalArgs ...string) (*mongorestore.MongoRestore, e
 }
 
 func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoDump, error) {
-	provider, toolOpts, err := testutil.GetBareSessionProvider(t)
+	return getArchiveMongoDumpForURI(t, os.Getenv(testopts.URIEnvVar), output)
+}
+
+func getArchiveMongoDumpForURI(
+	t *testing.T,
+	uri string,
+	output io.WriteCloser,
+) (*mongodump.MongoDump, error) {
+	provider, toolOpts, err := testutil.GetBareSessionProviderForURI(t, uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for dump")
 	}
@@ -278,7 +293,15 @@ func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoD
 }
 
 func getArchiveMongoRestore(t *testing.T, input io.ReadCloser) (*mongorestore.MongoRestore, error) {
-	_, toolOpts, err := testutil.GetBareSessionProvider(t)
+	return getArchiveMongoRestoreForURI(t, os.Getenv(testopts.URIEnvVar), input)
+}
+
+func getArchiveMongoRestoreForURI(
+	t *testing.T,
+	uri string,
+	input io.ReadCloser,
+) (*mongorestore.MongoRestore, error) {
+	_, toolOpts, err := testutil.GetBareSessionProviderForURI(t, uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "get session provider for restore")
 	}

--- a/integration/dumprestore/suite_test.go
+++ b/integration/dumprestore/suite_test.go
@@ -31,18 +31,30 @@ func TestDumpRestore(t *testing.T) {
 }
 
 func (s *DumpRestoreSuite) withBSONMongodump(testCase func(string), args ...string) {
+	s.withBSONMongodumpForURI(os.Getenv(testopts.URIEnvVar), testCase, args...)
+}
+
+func (s *DumpRestoreSuite) withBSONMongodumpForURI(
+	uri string,
+	testCase func(string),
+	args ...string,
+) {
 	dir, cleanup := testutil.MakeTempDir(s.T())
 	defer cleanup()
 	dirArgs := []string{
 		"--out", dir,
 	}
-	s.runMongodumpWithArgs(append(dirArgs, args...)...)
+	s.runMongodumpWithArgsForURI(uri, append(dirArgs, args...)...)
 	testCase(dir)
 }
 
 func (s *DumpRestoreSuite) runMongodumpWithArgs(args ...string) {
+	s.runMongodumpWithArgsForURI(os.Getenv(testopts.URIEnvVar), args...)
+}
+
+func (s *DumpRestoreSuite) runMongodumpWithArgsForURI(uri string, args ...string) {
 	cmd := []string{"go", "run", filepath.Join("..", "..", "mongodump", "main")}
-	cmd = append(cmd, testopts.GetBareArgs()...)
+	cmd = append(cmd, testopts.GetBareArgsForURI(uri)...)
 	cmd = append(cmd, args...)
 	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 	cmdStr := strings.Join(cmd, " ")
@@ -124,15 +136,24 @@ func (s *DumpRestoreSuite) runBSONMongodumpForCollection(
 }
 
 func (s *DumpRestoreSuite) withArchiveMongodump(testCase func(string), dumpArgs ...string) {
+	s.withArchiveMongodumpForURI(os.Getenv(testopts.URIEnvVar), testCase, dumpArgs...)
+}
+
+func (s *DumpRestoreSuite) withArchiveMongodumpForURI(
+	uri string,
+	testCase func(string),
+	dumpArgs ...string,
+) {
 	dir, cleanup := testutil.MakeTempDir(s.T())
 	defer cleanup()
 	file := filepath.Join(dir, "archive")
-	s.runArchiveMongodump(file, dumpArgs...)
+	s.runArchiveMongodumpForURI(uri, file, dumpArgs...)
 	testCase(file)
 }
 
-func (s *DumpRestoreSuite) runArchiveMongodump(file string, dumpArgs ...string) {
-	s.runMongodumpWithArgs(
+func (s *DumpRestoreSuite) runArchiveMongodumpForURI(uri, file string, dumpArgs ...string) {
+	s.runMongodumpWithArgsForURI(
+		uri,
 		append(
 			[]string{mongorestore.ArchiveOption + "=" + file},
 			dumpArgs...,
@@ -226,6 +247,30 @@ func (s *DumpRestoreSuite) database(name string) *mongo.Database {
 	s.Require().NoError(err, "can connect to the server")
 
 	return session.Database("dumprestore_" + name)
+}
+
+// targetSession returns a session to the cluster a restore writes to and that a restore's data is
+// verified on. That is the second cluster when one is configured via TOOLS_TESTING_MONGOD2, else
+// the source cluster, so single-cluster runs behave exactly as before.
+//
+//nolint:unused // the cross-cluster routing (a follow-up PR) is the only caller
+func (s *DumpRestoreSuite) targetSession() *mongo.Client {
+	uri := testopts.SecondURI()
+	if uri == "" {
+		uri = os.Getenv(testopts.URIEnvVar)
+	}
+
+	session, err := testutil.GetBareSessionForURI(s.T(), uri)
+	s.Require().NoError(err, "can connect to the target cluster")
+
+	return session
+}
+
+// targetDatabase returns a handle to a named database on the target cluster.
+//
+//nolint:unused // the cross-cluster routing (a follow-up PR) is the only caller
+func (s *DumpRestoreSuite) targetDatabase(name string) *mongo.Database {
+	return s.targetSession().Database("dumprestore_" + name)
 }
 
 func (s *DumpRestoreSuite) createCollection(


### PR DESCRIPTION
This adds helpers which take a URI to the dump and restore helpers. This will allow us to have two different URIs, one for dump and for restore.

The existing single-URI helpers are now thin wrappers that pass TOOLS_TESTING_MONGOD, so nothing changes for single-cluster runs.

The target* helpers have a temporary `//nolint:unused`. This will go away in the follow-up PR once we start using these helpers.