### PR TITLE
TOOLS-4122 Wrap dump/restore tests with a new cross-cluster integration test wrapper

### DIFF
--- a/integration/dumprestore/roundtrip_test.go
+++ b/integration/dumprestore/roundtrip_test.go
@@ -36,107 +36,103 @@ func uniqueDBName() string {
 }
 
 func (s *DumpRestoreSuite) TestPipedDumpRestore() {
-	s.T().Logf("start %#q", s.T().Name())
-	ctx := s.Context()
+	s.withCrossCluster(func(cc crossCluster) {
+		s.T().Logf("start %#q", s.T().Name())
+		ctx := s.Context()
 
-	provider, _, err := testutil.GetBareSessionProvider(s.T())
-	s.Require().NoError(err, "should get session provider")
+		srcCollNames := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
 
-	s.T().Logf("getting session")
-	sess, err := provider.GetSession()
-	s.Require().NoError(err, "should get session")
+		const docsPerColl = 10_000
 
-	srcCollNames := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+		db := cc.source.Database(uniqueDBName())
 
-	const docsPerColl = 10_000
+		s.T().Logf("creating collections")
 
-	db := sess.Database(uniqueDBName())
-
-	s.T().Logf("creating collections")
-
-	for _, collName := range srcCollNames {
-		docs := lo.RepeatBy(
-			docsPerColl,
-			func(_ int) bson.D {
-				return bson.D{
-					{"someNum", rand.Float64()},
-				}
-			},
-		)
-
-		_, err := db.Collection(collName).InsertMany(
-			ctx,
-			lo.ToAnySlice(docs),
-		)
-
-		s.Require().NoError(err, "should insert docs into %#q", collName)
-	}
-
-	s.T().Log("Finished creating documents.")
-
-	reader, writer := io.Pipe()
-
-	eg, _ := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		defer writer.Close()
-
-		dump, err := getArchiveMongoDump(s.T(), writer)
-		if err != nil {
-			return errors.Wrap(err, "create mongodump")
-		}
-
-		dump.ToolOptions.DB = db.Name()
-
-		s.Assert().NoError(dump.Dump(), "dump should work")
-
-		return nil
-	})
-
-	eg.Go(func() error {
-		defer reader.Close()
-
-		restore, err := getArchiveMongoRestore(s.T(), reader)
-		if err != nil {
-			return errors.Wrap(err, "create mongorestore")
-		}
-
-		restore.NSOptions = &mongorestore.NSOptions{
-			NSFrom: lo.Map(
-				srcCollNames,
-				func(cn string, _ int) string {
-					return db.Name() + "." + cn
+		for _, collName := range srcCollNames {
+			docs := lo.RepeatBy(
+				docsPerColl,
+				func(_ int) bson.D {
+					return bson.D{
+						{"someNum", rand.Float64()},
+					}
 				},
-			),
-			NSTo: lo.Map(
-				srcCollNames,
-				func(cn string, _ int) string {
-					return db.Name() + ".dst-" + cn
-				},
-			),
+			)
+
+			_, err := db.Collection(collName).InsertMany(
+				ctx,
+				lo.ToAnySlice(docs),
+			)
+
+			s.Require().NoError(err, "should insert docs into %#q", collName)
 		}
 
-		s.Assert().NoError(restore.Restore().Err, "restore should work")
+		s.T().Log("Finished creating documents.")
 
-		return nil
+		reader, writer := io.Pipe()
+
+		eg, _ := errgroup.WithContext(ctx)
+		eg.Go(func() error {
+			defer writer.Close()
+
+			dump, err := getArchiveMongoDumpForURI(s.T(), cc.sourceURI, writer)
+			if err != nil {
+				return errors.Wrap(err, "create mongodump")
+			}
+
+			dump.ToolOptions.DB = db.Name()
+
+			s.Assert().NoError(dump.Dump(), "dump should work")
+
+			return nil
+		})
+
+		eg.Go(func() error {
+			defer reader.Close()
+
+			restore, err := getArchiveMongoRestoreForURI(s.T(), cc.targetURI, reader)
+			if err != nil {
+				return errors.Wrap(err, "create mongorestore")
+			}
+
+			restore.NSOptions = &mongorestore.NSOptions{
+				NSFrom: lo.Map(
+					srcCollNames,
+					func(cn string, _ int) string {
+						return db.Name() + "." + cn
+					},
+				),
+				NSTo: lo.Map(
+					srcCollNames,
+					func(cn string, _ int) string {
+						return db.Name() + ".dst-" + cn
+					},
+				),
+			}
+
+			s.Assert().NoError(restore.Restore().Err, "restore should work")
+
+			return nil
+		})
+
+		s.Require().NoError(eg.Wait())
+
+		// Without this the test only proves the pipe did not error: a namespace dropped or misrouted
+		// by the archive demultiplexer would go unnoticed.
+		for _, collName := range srcCollNames {
+			dstName := "dst-" + collName
+
+			count, err := cc.target.Database(db.Name()).Collection(dstName).
+				CountDocuments(ctx, bson.D{})
+			s.Require().NoError(err, "should count docs in %#q", dstName)
+			s.Assert().EqualValues(
+				docsPerColl,
+				count,
+				"%#q should hold every document piped from %#q",
+				dstName,
+				collName,
+			)
+		}
 	})
-
-	s.Require().NoError(eg.Wait())
-
-	// Without this the test only proves the pipe did not error: a namespace dropped or misrouted by
-	// the archive demultiplexer would go unnoticed.
-	for _, collName := range srcCollNames {
-		dstName := "dst-" + collName
-
-		count, err := db.Collection(dstName).CountDocuments(ctx, bson.D{})
-		s.Require().NoError(err, "should count docs in %#q", dstName)
-		s.Assert().EqualValues(
-			docsPerColl,
-			count,
-			"%#q should hold every document piped from %#q",
-			dstName,
-			collName,
-		)
-	}
 }
 
 func (s *DumpRestoreSuite) TestDumpAndRestoreConfigDB() {
@@ -279,10 +275,6 @@ func getRestoreWithArgsForURI(
 	return restore, nil
 }
 
-func getArchiveMongoDump(t *testing.T, output io.WriteCloser) (*mongodump.MongoDump, error) {
-	return getArchiveMongoDumpForURI(t, os.Getenv(testopts.URIEnvVar), output)
-}
-
 func getArchiveMongoDumpForURI(
 	t *testing.T,
 	uri string,
@@ -310,10 +302,6 @@ func getArchiveMongoDumpForURI(
 	}
 
 	return dump, nil
-}
-
-func getArchiveMongoRestore(t *testing.T, input io.ReadCloser) (*mongorestore.MongoRestore, error) {
-	return getArchiveMongoRestoreForURI(t, os.Getenv(testopts.URIEnvVar), input)
 }
 
 func getArchiveMongoRestoreForURI(

--- a/integration/dumprestore/suite_test.go
+++ b/integration/dumprestore/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
 type DumpRestoreSuite struct {
@@ -346,6 +348,107 @@ func (s *DumpRestoreSuite) database(name string) *mongo.Database {
 	s.Require().NoError(err, "can connect to the server")
 
 	return session.Database("dumprestore_" + name)
+}
+
+// crossCluster names the two clusters a round-trip test runs between and which
+// side each role maps to. Setup and dump use the source; restore and the
+// post-restore assertions use the target.
+type crossCluster struct {
+	source, target       *mongo.Client
+	sourceURI, targetURI string
+}
+
+// systemDatabaseNames are the databases mongod manages itself, which a test must
+// never drop.
+var systemDatabaseNames = []string{"admin", "config", "local"}
+
+// skipForCrossCluster skips the test when a second cluster is configured, because the
+// test assumes source and target are the same cluster. reason says what that assumption is.
+//
+//nolint:unused // the cross-cluster routing (a follow-up PR) is the only caller
+func (s *DumpRestoreSuite) skipForCrossCluster(reason string) {
+	if os.Getenv(testopts.URIEnvVar2) != "" {
+		s.T().Skip(reason)
+	}
+}
+
+// withCrossCluster runs a round-trip test body once per source/target
+// orientation. In single-cluster mode it runs once, with source and target both
+// the primary cluster. In cross-cluster mode it runs twice, once with each
+// cluster as the source, so a test exercises the boundary in both directions.
+func (s *DumpRestoreSuite) withCrossCluster(body func(crossCluster)) {
+	primaryURI := os.Getenv(testopts.URIEnvVar)
+	secondURI := os.Getenv(testopts.URIEnvVar2)
+
+	if secondURI == "" {
+		session, err := testutil.GetBareSession(s.T())
+		s.Require().NoError(err, "can connect to the server")
+		s.dropUserDatabases(session)
+		body(crossCluster{
+			source:    session,
+			target:    session,
+			sourceURI: primaryURI,
+			targetURI: primaryURI,
+		})
+		return
+	}
+
+	for _, orientation := range []struct {
+		source, target string
+	}{
+		{primaryURI, secondURI},
+		{secondURI, primaryURI},
+	} {
+		s.Run(
+			fmt.Sprintf(
+				"dump from %s restore into %s",
+				uriLabel(orientation.source),
+				uriLabel(orientation.target),
+			),
+			func() {
+				source, err := testutil.GetBareSessionForURI(s.T(), orientation.source)
+				s.Require().NoError(err, "can connect to the source cluster")
+				target, err := testutil.GetBareSessionForURI(s.T(), orientation.target)
+				s.Require().NoError(err, "can connect to the target cluster")
+
+				s.dropUserDatabases(source)
+				s.dropUserDatabases(target)
+
+				body(crossCluster{
+					source:    source,
+					target:    target,
+					sourceURI: orientation.source,
+					targetURI: orientation.target,
+				})
+			},
+		)
+	}
+}
+
+// dropUserDatabases drops every user (non-system) database on cluster so a test
+// body starts from a clean slate. The two cluster orientations share clusters,
+// so this keeps a later orientation from tripping over what an earlier one left
+// behind.
+func (s *DumpRestoreSuite) dropUserDatabases(cluster *mongo.Client) {
+	names, err := cluster.ListDatabaseNames(s.Context(), bson.D{})
+	s.Require().NoError(err, "can list the databases")
+
+	for _, name := range names {
+		if slices.Contains(systemDatabaseNames, name) {
+			continue
+		}
+		s.Require().NoError(cluster.Database(name).Drop(s.Context()), "can drop database %#q", name)
+	}
+}
+
+// uriLabel returns a short human-readable name for a cluster URI, for use in
+// test subtest names.
+func uriLabel(uri string) string {
+	cs, err := connstring.ParseAndValidate(uri)
+	if err != nil {
+		return uri
+	}
+	return strings.Join(cs.Hosts, ",")
 }
 
 func (s *DumpRestoreSuite) createCollection(


### PR DESCRIPTION
This adds a new wrapper for all integration tests that do a round-trip dump and restore called `withCrossCluster`.

This wrapper will run the same integration test multiple times when both there are two clusters to test against. It will run them three ways:

- cluster 0 dump -> cluster 0 restore
- cluster 0 dump -> cluster 1 restore
- cluster 1 dump -> cluster 0 restore

The wrapper also drops all collections on both clusters before it runs the tests, which lets us remove various `t.Cleanup` calls and other ad-hoc pre-emptive drop calls in these tests.

This exists primarily for testing ASC <-> DSC inter-operability, but is also generally a good thing to test between two clusters with the same version and storage layer. We want to make sure that dump/restore work properly when restoring to a totally new cluster (like after a cluster becomes unavailable), not that it just works when restoring to the _same_ cluster as the dump came from.

This PR wraps the tests in `integration/dumprestore/roundtrip_test.go`. Future PRs will add this to more round trip tests, and the final PR adds a new CI task for doing a ASC <-> DSC cross-cluster test.