### PR TITLE
TOOLS-4368 passthrough config: bump mongosync pin

### DIFF
--- a/mongodump_passthrough/functions.yml
+++ b/mongodump_passthrough/functions.yml
@@ -27,7 +27,7 @@ variables:
   # And when you change the _mongosync_pin, you also need to update other pins
   # which get passed as environment variables to scripts in mongosync/evergreen/scripts.
   #
-  _mongosync_pin: &_mongosync_pin "1f8541766d415c9de12aee6760926ba93ece45ae"
+  _mongosync_pin: &_mongosync_pin "260ecf7c3beece0c732627b82630bd54b0169610"
 
   f_expansions_write: &f_expansions_write
     command: expansions.write


### PR DESCRIPTION
This includes some changes from a few months ago that never made it into this pin (oops), and gets the tests running on 8.3, along with some other cleanups. We're going to start working on this code more seriously, so this commit is just bringing it up to the current state before that work starts in earnest.